### PR TITLE
Yearly history report: empty month fix

### DIFF
--- a/src/year-%Y.html.tmpl
+++ b/src/year-%Y.html.tmpl
@@ -134,6 +134,7 @@
       </div>
 
       #for $month in $year.months
+        #if $month.outTemp.has_data
         <div class="col-12 col-lg-6 mb-4 text-center">
           <div class="card">
             <div class="card-body">
@@ -172,7 +173,8 @@
             </div>
           </div>
         </div>
-        #end for
+        #end if
+      #end for
 
     </div>
 


### PR DESCRIPTION
Adds logic to yearly history report, to exlude month "cards" which contain no/null data, thusly, preventing 404/non-existent pages and null month "card" data.

## Without Logic:
![Before_Logic](https://user-images.githubusercontent.com/226376/200694945-0033e071-04f9-48a6-8ffa-490e8fdd2f7b.png)

## With Logic:
![After_Logic](https://user-images.githubusercontent.com/226376/200695020-642abfbb-6806-4dae-80e7-cf97e6b8e486.png)

Note, I used "outTemp" as the basic data test, as I could not get `$SummaryByMonth` to work. 🤷‍♂️ 

Also, submitting this PR to @seehase since the original @neoground repo has no activity for over one year (and we all have outstanding PR's that haven't moved 😆 ).