### PR TITLE
Use ordinal direction names for labels in my custom WindDir Charts

### DIFF
--- a/src/graph_line_archive_config.inc
+++ b/src/graph_line_archive_config.inc
@@ -63,7 +63,7 @@ grid: {
     position: 'back',
     xaxis: {
         lines: {
-            show: true
+            show: false
         }
     },
     yaxis: {

--- a/src/graph_line_config.inc
+++ b/src/graph_line_config.inc
@@ -63,7 +63,7 @@ grid: {
     position: 'back',
     xaxis: {
         lines: {
-            show: true
+            show: false
         }
     },
     yaxis: {

--- a/src/index.html.tmpl
+++ b/src/index.html.tmpl
@@ -229,18 +229,45 @@
 
 new ApexCharts(document.querySelector('#$id'), {
   ...graph_${type}_config,
-  yaxis: {
-    #if $name == "windDir"
+  #if $name == "windDir"
+    yaxis: {
         max: 360,
         min: 0,
+        type: 'datetime',
         tickAmount: 8,
-    #end if
+        trim: false,
         labels: {
-            formatter: function (val) {
-                return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)"; 
+            tickAmount: 8,
+            rotateAlways: false,
+            hideOverlappingLabels: true,
+            showDuplicates: false,
+            trim: false,
+            formatter: function(val, timestamp) {
+                var degrees = Number(val);
+                var direction = getOrdinalDirection(degrees);
+                return direction;
             }
         },
-  },
+    },
+    tooltip: {
+        enabled: true,
+        y: {
+            formatter: function (val) {
+              var degrees = Number(val);
+              var direction = getOrdinalDirection(degrees);
+              return direction + ' (' + degrees.toFixed(0) + '°)';
+            }
+         },
+    },
+  #else
+    yaxis: {
+      labels: {
+          formatter: function (val) {
+              return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
+          }
+      },
+    },
+  #end if
   series: [
     {
       name: "$getVar('obs.label.' + series1)",

--- a/src/js.inc
+++ b/src/js.inc
@@ -76,4 +76,11 @@
             },
         },
     }
+
+## Ordinals conversion for W0CHP's custom WindDir Charts:
+function getOrdinalDirection(degrees) {
+    var sectors = ['North', 'NE', 'East', 'SE', 'South', 'SW', 'West', 'NW'];
+    var index = Math.round(degrees / (360 / sectors.length));
+    return sectors[index % sectors.length];
+}
 </script>

--- a/src/month-%Y-%m.html.tmpl
+++ b/src/month-%Y-%m.html.tmpl
@@ -258,18 +258,45 @@ new ApexCharts(document.querySelector('#$id'), {
 
 new ApexCharts(document.querySelector('#$id'), {
   ...graph_${type}_config,
-  yaxis: {
-    #if $name == "windDir"
+  #if $name == "windDir"
+    yaxis: {
         max: 360,
         min: 0,
+        type: 'datetime',
         tickAmount: 8,
-    #end if
+        trim: false,
         labels: {
-            formatter: function (val) {
-                return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
+            tickAmount: 8,
+            rotateAlways: false,
+            hideOverlappingLabels: true,
+            showDuplicates: false,
+            trim: false,
+            formatter: function(val, timestamp) {
+                var degrees = Number(val);
+                var direction = getOrdinalDirection(degrees);
+                return direction;
             }
         },
-  },
+    },
+    tooltip: {
+        enabled: true,
+        y: {
+            formatter: function (val) {
+              var degrees = Number(val);
+              var direction = getOrdinalDirection(degrees);
+              return direction + ' (' + degrees.toFixed(0) + '°)';
+            }
+         },
+    },
+  #else
+    yaxis: {
+      labels: {
+          formatter: function (val) {
+              return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
+          }
+      },
+    },
+  #end if
   series: [
     {
       name: "$getVar('obs.label.' + series1)",

--- a/src/month.html.tmpl
+++ b/src/month.html.tmpl
@@ -211,18 +211,45 @@
 
 new ApexCharts(document.querySelector('#$id'), {
   ...graph_${type}_config,
-  yaxis: {
-    #if $name == "windDir"
+  #if $name == "windDir"
+    yaxis: {
         max: 360,
         min: 0,
+        type: 'datetime',
         tickAmount: 8,
-    #end if
+        trim: false,
         labels: {
-            formatter: function (val) {
-                return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
+            tickAmount: 8,
+            rotateAlways: false,
+            hideOverlappingLabels: true,
+            showDuplicates: false,
+            trim: false,
+            formatter: function(val, timestamp) {
+                var degrees = Number(val);
+                var direction = getOrdinalDirection(degrees);
+                return direction;
             }
         },
-  },
+    },
+    tooltip: {
+        enabled: true,
+        y: {
+            formatter: function (val) {
+              var degrees = Number(val);
+              var direction = getOrdinalDirection(degrees);
+              return direction + ' (' + degrees.toFixed(0) + '°)';
+            }
+         },
+    },
+  #else
+    yaxis: {
+      labels: {
+          formatter: function (val) {
+              return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
+          }
+      },
+    },
+  #end if
   series: [
     {
       name: "$getVar('obs.label.' + series1)",

--- a/src/week.html.tmpl
+++ b/src/week.html.tmpl
@@ -211,18 +211,45 @@
 
 new ApexCharts(document.querySelector('#$id'), {
   ...graph_${type}_config,
-  yaxis: {
-    #if $name == "windDir"
+  #if $name == "windDir"
+    yaxis: {
         max: 360,
         min: 0,
+        type: 'datetime',
         tickAmount: 8,
-    #end if
+        trim: false,
         labels: {
-            formatter: function (val) {
-                return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)"; 
+            tickAmount: 8,
+            rotateAlways: false,
+            hideOverlappingLabels: true,
+            showDuplicates: false,
+            trim: false,
+            formatter: function(val, timestamp) {
+                var degrees = Number(val);
+                var direction = getOrdinalDirection(degrees);
+                return direction;
             }
         },
-  },
+    },
+    tooltip: {
+        enabled: true,
+        y: {
+            formatter: function (val) {
+              var degrees = Number(val);
+              var direction = getOrdinalDirection(degrees);
+              return direction + ' (' + degrees.toFixed(0) + '°)';
+            }
+         },
+    },
+  #else
+    yaxis: {
+      labels: {
+          formatter: function (val) {
+              return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
+          }
+      },
+    },
+  #end if
   series: [
     {
       name: "$getVar('obs.label.' + series1)",

--- a/src/year-%Y.html.tmpl
+++ b/src/year-%Y.html.tmpl
@@ -304,18 +304,45 @@ new ApexCharts(document.querySelector('#$id'), {
 
 new ApexCharts(document.querySelector('#$id'), {
   ...graph_${type}_config,
-  yaxis: {
-    #if $name == "windDir"
+  #if $name == "windDir"
+    yaxis: {
         max: 360,
         min: 0,
+        type: 'datetime',
         tickAmount: 8,
-    #end if
+        trim: false,
         labels: {
-            formatter: function (val) {
-                return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
+            tickAmount: 8,
+            rotateAlways: false,
+            hideOverlappingLabels: true,
+            showDuplicates: false,
+            trim: false,
+            formatter: function(val, timestamp) {
+                var degrees = Number(val);
+                var direction = getOrdinalDirection(degrees);
+                return direction;
             }
         },
-  },
+    },
+    tooltip: {
+        enabled: true,
+        y: {
+            formatter: function (val) {
+              var degrees = Number(val);
+              var direction = getOrdinalDirection(degrees);
+              return direction + ' (' + degrees.toFixed(0) + '°)';
+            }
+         },
+    },
+  #else
+    yaxis: {
+      labels: {
+          formatter: function (val) {
+              return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
+          }
+      },
+    },
+  #end if
   series: [
     {
       name: "$getVar('obs.label.' + series1)",

--- a/src/year.html.tmpl
+++ b/src/year.html.tmpl
@@ -256,18 +256,45 @@ new ApexCharts(document.querySelector('#$id'), {
 
 new ApexCharts(document.querySelector('#$id'), {
   ...graph_${type}_config,
-  yaxis: {
-    #if $name == "windDir"
+  #if $name == "windDir"
+    yaxis: {
         max: 360,
         min: 0,
+        type: 'datetime',
         tickAmount: 8,
-    #end if
+        trim: false,
         labels: {
-            formatter: function (val) {
-                return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
+            tickAmount: 8,
+            rotateAlways: false,
+            hideOverlappingLabels: true,
+            showDuplicates: false,
+            trim: false,
+            formatter: function(val, timestamp) {
+                var degrees = Number(val);
+                var direction = getOrdinalDirection(degrees);
+                return direction;
             }
         },
-  },
+    },
+    tooltip: {
+        enabled: true,
+        y: {
+            formatter: function (val) {
+              var degrees = Number(val);
+              var direction = getOrdinalDirection(degrees);
+              return direction + ' (' + degrees.toFixed(0) + '°)';
+            }
+         },
+    },
+  #else
+    yaxis: {
+      labels: {
+          formatter: function (val) {
+              return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
+          }
+      },
+    },
+  #end if
   series: [
     {
       name: "$getVar('obs.label.' + series1)",

--- a/src/yesterday.html.tmpl
+++ b/src/yesterday.html.tmpl
@@ -230,18 +230,45 @@ half_length4 = Math.ceil(series4data.length / 2);
 
 new ApexCharts(document.querySelector('#$id'), {
   ...graph_${type}_config,
-  yaxis: {
-    #if $name == "windDir"
+  #if $name == "windDir"
+    yaxis: {
         max: 360,
         min: 0,
+        type: 'datetime',
         tickAmount: 8,
-    #end if
+        trim: false,
         labels: {
-            formatter: function (val) {
-                return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)"; 
+            tickAmount: 8,
+            rotateAlways: false,
+            hideOverlappingLabels: true,
+            showDuplicates: false,
+            trim: false,
+            formatter: function(val, timestamp) {
+                var degrees = Number(val);
+                var direction = getOrdinalDirection(degrees);
+                return direction;
             }
         },
-  },
+    },
+    tooltip: {
+        enabled: true,
+        y: {
+            formatter: function (val) {
+              var degrees = Number(val);
+              var direction = getOrdinalDirection(degrees);
+              return direction + ' (' + degrees.toFixed(0) + '°)';
+            }
+         },
+    },
+  #else
+    yaxis: {
+      labels: {
+          formatter: function (val) {
+              return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
+          }
+      },
+    },
+  #end if
   series: [
     {
       name: "$getVar('obs.label.' + series1)",


### PR DESCRIPTION
The direction degree value is still visible in the hover tooltip. I also cleaned up the chart grid to be more consistent with the others. Demo here: https://winona.city/