### PR TITLE
Fixed  issue with hi/lo_value_color

### DIFF
--- a/skins/neowx-material/head.inc
+++ b/skins/neowx-material/head.inc
@@ -68,7 +68,7 @@
 #if $Extras.Appearance.lo_value_color != ""
 <style>
     .lo-text {
-        color: $Extras.Appearance.lo_value_color !important;
+        color: #$Extras.Appearance.lo_value_color !important;
     }
 </style>
 #end if
@@ -76,7 +76,7 @@
 #if $Extras.Appearance.hi_value_color != ""
 <style>
     .hi-text {
-        color: $Extras.Appearance.hi_value_color !important;
+        color: #$Extras.Appearance.hi_value_color !important;
     }
 </style>
 #end if

--- a/skins/neowx-material/package.json
+++ b/skins/neowx-material/package.json
@@ -1,13 +1,13 @@
 {
   "name": "neowx-material",
-  "version": "1.35.4",
+  "version": "1.36.0",
   "description": "The most versatile and modern weewx skin",
   "main": "index.js",
   "repository": "https://github.com/neoground/neowx-material",
   "author": "Neoground GmbH",
   "license": "MIT",
   "dependencies": {
-    "sass": "^1.83.1"
+    "sass": "^1.83.4"
   },
   "scripts": {
     "build-css": "sass --load-path scss scss/style.scss css/style.css",

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -40,7 +40,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
     #
-    version = 1.35.4
+    version = 1.36.0
 
     # Language
     # -------------------------------------------------------------------------
@@ -221,9 +221,9 @@
         mode = auto
 
         # Here you can set a hex code for the text color of low / high values
-        # on all cards. By default they are grey. (quotes are needed on values)
-        # lo_value_color = "#03a9f4"
-        # hi_value_color = "#f44336"
+        # on all cards. By default they are grey. (quotes are needed on values but no #)
+        # lo_value_color = "03a9f4"
+        # hi_value_color = "f44336"
         lo_value_color =
         hi_value_color =
 

--- a/skins/neowx-material/yarn.lock
+++ b/skins/neowx-material/yarn.lock
@@ -162,10 +162,10 @@ readdirp@^4.0.1:
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.1.1.tgz#bd115327129672dc47f87408f05df9bd9ca3ef55"
   integrity sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==
 
-sass@^1.83.1:
-  version "1.83.1"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.83.1.tgz#dee1ab94b47a6f9993d3195d36f556bcbda64846"
-  integrity sha512-EVJbDaEs4Rr3F0glJzFSOvtg2/oy2V/YrGFPqPY24UqcLDWcI9ZY5sN+qyO3c/QCZwzgfirvhXvINiJCE/OLcA==
+sass@^1.83.4:
+  version "1.83.4"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.83.4.tgz#5ccf60f43eb61eeec300b780b8dcb85f16eec6d1"
+  integrity sha512-B1bozCeNQiOgDcLd33e2Cs2U60wZwjUUXzh900ZyQF5qUasvMdDZYbQ566LJu7cqR+sAHlAfO6RMkaID5s6qpA==
   dependencies:
     chokidar "^4.0.0"
     immutable "^5.0.2"


### PR DESCRIPTION
fixes https://github.com/seehase/neowx-material/issues/41

so define values without # but in quotes
e.g.

```
lo_value_color = "03a9f4"
hi_value_color = "f44336"
```
to get colored labels
![image](https://github.com/user-attachments/assets/504a8e26-04f6-4f7d-9c07-d9fee2871fe0)

update dependabot dependencies