### PR TITLE
New option for auto-refresh

### DIFF
--- a/skins/neowx-material/head.inc
+++ b/skins/neowx-material/head.inc
@@ -24,6 +24,11 @@
 ## Tap highlighting
 <meta name="msapplication-tap-highlight" content="no">
 
+## Auto refresh
+#if $Extras.Header.auto_refresh_enable == "yes"
+<meta http-equiv="refresh" content="$Extras.Header.auto_refresh_seconds">
+#end if
+
 ## Google Analytics
 #if $Extras.Header.google_analytics_enable == "yes"
 <!-- Google tag (gtag.js) -->

--- a/skins/neowx-material/month.html.tmpl
+++ b/skins/neowx-material/month.html.tmpl
@@ -116,7 +116,7 @@
 <html lang="$lang">
 <head>
   <title>
-    $gettext("$active_nav") | $station.location
+    $gettext($active_nav) | $station.location
   </title>
   #include "head.inc"
 </head>

--- a/skins/neowx-material/package.json
+++ b/skins/neowx-material/package.json
@@ -7,7 +7,7 @@
   "author": "Neoground GmbH",
   "license": "MIT",
   "dependencies": {
-    "sass": "^1.83.4"
+    "sass": "^1.84.0"
   },
   "scripts": {
     "build-css": "sass --load-path scss scss/style.scss css/style.css",

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -40,7 +40,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
     #
-    version = 1.36.1
+    version = 1.37.0
 
     # Language
     # -------------------------------------------------------------------------
@@ -114,6 +114,9 @@
         google_analytics_enable = no
         google_analytics_id =
 
+        # enable or disable auto refresh and define number seconds after page will be reloaded
+        auto_refresh_enable = yes
+        auto_refresh_seconds = 300
 
 
     # Footer

--- a/skins/neowx-material/week.html.tmpl
+++ b/skins/neowx-material/week.html.tmpl
@@ -116,7 +116,7 @@
 <html lang="$lang">
 <head>
   <title>
-    $gettext("$active_nav") | $station.location
+     $gettext($active_nav) | $station.location
   </title>
   #include "head.inc"
 </head>

--- a/skins/neowx-material/yarn.lock
+++ b/skins/neowx-material/yarn.lock
@@ -162,10 +162,10 @@ readdirp@^4.0.1:
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.1.1.tgz#bd115327129672dc47f87408f05df9bd9ca3ef55"
   integrity sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==
 
-sass@^1.83.4:
-  version "1.83.4"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.83.4.tgz#5ccf60f43eb61eeec300b780b8dcb85f16eec6d1"
-  integrity sha512-B1bozCeNQiOgDcLd33e2Cs2U60wZwjUUXzh900ZyQF5qUasvMdDZYbQ566LJu7cqR+sAHlAfO6RMkaID5s6qpA==
+sass@^1.84.0:
+  version "1.84.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.84.0.tgz#da9154cbccb2d2eac7a9486091b6d9ba93ef5bad"
+  integrity sha512-XDAbhEPJRxi7H0SxrnOpiXFQoUJHwkR2u3Zc4el+fK/Tt5Hpzw5kkQ59qVDfvdaUq6gCrEZIbySFBM2T9DNKHg==
   dependencies:
     chokidar "^4.0.0"
     immutable "^5.0.2"

--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -116,7 +116,7 @@
 <html lang="$lang">
 <head>
   <title>
-    $gettext("$active_nav") | $station.location
+    $gettext($active_nav) | $station.location
   </title>
   #include "head.inc"
 </head>


### PR DESCRIPTION
Added option to configure auto-refresh in skin.conf

To enable auto refresh every 5min use this configuration

```
 # enable or disable auto refresh and define the seconds after page will be reloaded
        auto_refresh_enable = yes
        auto_refresh_seconds = 300

```