### PR TITLE
Add support for Google Tag Manager

### DIFF
--- a/skins/neowx-material/head.inc
+++ b/skins/neowx-material/head.inc
@@ -29,17 +29,28 @@
 <meta http-equiv="refresh" content="$Extras.Header.auto_refresh_seconds">
 #end if
 
-## Google Analytics
-#if $Extras.Header.google_analytics_enable == "yes"
-<!-- Google tag (gtag.js) -->
+## Google Tag Manager or Google Analytics but not both at the same time
+
+#if $Extras.Header.google_tagmanager_enable == "yes"
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','$Extras.Header.google_tagmanager_id');
+</script>
+<!-- End Google Tag Manager -->
+#else if $Extras.Header.google_analytics_enable == "yes"
+<!-- Google analytics tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=$Extras.Header.google_analytics_id"></script>
 <script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
 
-  gtag('config', '$Extras.Header.google_analytics_id');
+    gtag('config', '$Extras.Header.google_analytics_id');
 </script>
+<!-- End Google analytics tag -->
 #end if
 
 ## Favicons / mobile icons

--- a/skins/neowx-material/header.inc
+++ b/skins/neowx-material/header.inc
@@ -2,6 +2,15 @@
 ## +-------------------------------------------------------------------------+
 ## |    header.inc                 Header section (nav) for all templates    |
 ## +-------------------------------------------------------------------------+
+
+## Add google tag manager if enabled
+#if $Extras.Header.google_tagmanager_enable == "yes"
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=$Extras.Header.google_tagmanager_id"
+                  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+#end if
+
 <header>
 
     <nav class="navbar navbar-expand-lg navbar-dark $Extras.color">

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -40,7 +40,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
     #
-    version = 1.38.0
+    version = 1.39.0
 
     # Language
     # -------------------------------------------------------------------------
@@ -110,7 +110,11 @@
         # If you don't like the logo you can specify the URL to your own
         custom_logo_url =
 
-        # Enable Google Analytics
+        # Enable Google Tag Manager support, use either GA or GTM not both at the same time
+        google_tagmanager_enable = no
+        google_tagmanager_id =
+
+        # Enable Google Analytics support, use either GA or GTM not both at the same time
         google_analytics_enable = no
         google_analytics_id =
 


### PR DESCRIPTION
Added support for Google Tag Manager

You can now choose between Google Tag Manager (GTM) or Google Analytic (GA).
Only one system can be active at the same time, if both are enabled GTM wins
By default both options are disabled, enable you preferred solution

To enable and configure, change settings in skin.conf
e.g.

```
        # Enable Google Tag Manager support, use either GA or GTM not both at the same time
        google_tagmanager_enable = yes
        google_tagmanager_id = GTM-AB12XYZ1

        # Enable Google Analytics support, use either GA or GTM not both at the same time
        google_analytics_enable = no
        google_analytics_id =
```