### PR TITLE
Option to show if HTLM pages are not updated for more than x minutes

### DIFF
--- a/skins/neowx-material/header.inc
+++ b/skins/neowx-material/header.inc
@@ -31,6 +31,7 @@
                 #else 
                 <span class="font-small">$current.dateTime</span>
                 #end if
+                <span id="status-label" class="font-small red"><strong></strong></span>
             </span>
         </span>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"

--- a/skins/neowx-material/js.inc
+++ b/skins/neowx-material/js.inc
@@ -21,6 +21,23 @@
 ## NeoWX Material App
 <script type="text/javascript" src="js/app.js"></script>
 
+<script type="text/javascript">
+    // Show/update status label only if configured threshold > 0 in skin.conf
+    if ($Extras.Header.offline_threshold_minutes > 0) {
+        const lastUpdateTimestamp = $current.dateTime.raw;  // in seconds
+        const nowTimestamp = new Date() / 1000;             // now in seconds
+        const diffMinutes = (nowTimestamp - lastUpdateTimestamp) / 60; // Difference in minutes
+
+        const statusLabel = document.getElementById("status-label");
+        if (statusLabel && diffMinutes > $Extras.Header.offline_threshold_minutes) {
+            statusLabel.textContent = "$gettext('OFFLINE')";
+        } else {
+            // enable if you want to show also ONLINE (which should always be the excepted state)
+            // statusLabel.textContent = "$gettext('ONLINE')";
+        }
+    }
+</script>
+
 ## Global apexcharts config
 <script type="text/javascript">
     var config_mode = '${Extras.Appearance.mode}';

--- a/skins/neowx-material/lang/de.conf
+++ b/skins/neowx-material/lang/de.conf
@@ -191,3 +191,5 @@
     lowest               = Niedrigs
     longest              = Niedrigst
     most                 = Meistens
+    OFFLINE              = OFFLINE
+    ONLINE               = ONLINE

--- a/skins/neowx-material/lang/en.conf
+++ b/skins/neowx-material/lang/en.conf
@@ -78,3 +78,5 @@
     lowest               = Lowest
     longest              = Longest
     most                 = Most
+    OFFLINE              = OFFLINE
+    ONLINE               = ONLINE

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -40,7 +40,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
     #
-    version = 1.39.1
+    version = 1.40.0
 
     # Language
     # -------------------------------------------------------------------------
@@ -121,6 +121,10 @@
         # enable or disable auto refresh and define number seconds after page will be reloaded
         auto_refresh_enable = yes
         auto_refresh_seconds = 300
+
+        # Show online/offline state if last update datetime > x minutes
+        # set offline_threshold_minutes to 0 to disable feature
+        offline_threshold_minutes = 15
 
 
     # Footer


### PR DESCRIPTION
Feature to show state "OFFLINE", when HTML pages are not updated for more than x minutes
e.g.
![image](https://github.com/user-attachments/assets/e8973949-e607-491f-bf22-ea97a3d6214d)

It can be configured in skin.conf, set value to 0 to disable feature, default is 15min

```
        # Show online/offline state if last update datetime > x minutes
        # set offline_threshold_minutes to 0 to disable feature
        offline_threshold_minutes = 15
```
The text "OFFLINE" can be translated in language files, I did it for EN and DE
