### PR TITLE
Support HTML in tooltips

### DIFF
--- a/skins/neowx-material/almanac.html.tmpl
+++ b/skins/neowx-material/almanac.html.tmpl
@@ -47,7 +47,7 @@
                                 <h6 class="$Extras.color-text"><i class="wi wi-sunrise"></i>
                                     $gettext("rise")</h6>
                                 $almanac.sun.rise
-                                <span class="d-block text-muted" data-toggle="tooltip"
+                                <span class="d-block text-muted" data-toggle="tooltip" data-html="true"
                                       title="$gettext("start_civil_twilight")">$almanac(horizon=-6).sun(use_center=1).rise</span>
                             </div>
                             <div class="col-4">
@@ -59,7 +59,7 @@
                                 <h6 class="$Extras.color-text"><i class="wi wi-sunset"></i>
                                     $gettext("set")</h6>
                                 $almanac.sun.set
-                                <span class="d-block text-muted" data-toggle="tooltip"
+                                <span class="d-block text-muted" data-toggle="tooltip" data-html="true"
                                       title="$gettext("end_civil_twilight")">$almanac(horizon=-6).sun(use_center=1).set</span>
                             </div>
                         </div>

--- a/skins/neowx-material/header.inc
+++ b/skins/neowx-material/header.inc
@@ -160,7 +160,7 @@
                     <i class="wi wi-moonset mr-1" style="opacity: .75"></i> $almanac.moon.set
                 </li>
                 <li class="nav-item mr-4 text-white text-center" style="line-height: 1.75" >
-                    <span title="$almanac.moon_phase" data-toggle="tooltip">
+                    <span title="$almanac.moon_phase" data-toggle="tooltip" data-html="true">
                         #if $almanac.moon_phase == $almanac.moon_phases[0]
                         <i class="wi wi-moon-new mr-1" style="opacity: .75"></i>
                         #else if $almanac.moon_phase == $almanac.moon_phases[1]

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -21,21 +21,21 @@
             #if $getVar('trend.' + name + '.raw') > 0.1
             <i class="wi wi-direction-up-right"
                title="$gettext("trend"): $getVar('trend.' + name) ($trend.time_delta.hour)"
-               data-toggle="tooltip"></i>
+               data-toggle="tooltip" data-html="true"></i>
             #else if $getVar('trend.' + name + '.raw') < 0.1
             <i class="wi wi-direction-down-right"
                title="$gettext("trend"): $getVar('trend.' + name) ($trend.time_delta.hour)"
-               data-toggle="tooltip"></i>
+               data-toggle="tooltip" data-html="true"></i>
             #else
               <i class="wi wi-direction-right"
                  title="$gettext("trend"): 0 ($trend.time_delta.hour)"
-                 data-toggle="tooltip"></i>
+                 data-toggle="tooltip" data-html="true"></i>
             #end if
 
           #else if $name == 'windSpeed'
 
             <i class="wi wi-wind from-$current.windDir.formatted-deg"
-               title="$current.windDir.formatted°" data-toggle="tooltip"></i>
+               title="$current.windDir.formatted°" data-toggle="tooltip" data-html="true"></i>
 
           #end if
         </h3>
@@ -55,7 +55,7 @@
           <div class="col-3 text-muted font-small hi-text">
             $day.wind.max $day.wind.gustdir.ordinal_compass <br>
             <i class="wi wi-wind from-$day.wind.gustdir.formatted-deg mr-2"
-               title="$day.wind.gustdir.formatted°" data-toggle="tooltip"></i>
+               title="$day.wind.gustdir.formatted°" data-toggle="tooltip" data-html="true"></i>
             ($day.wind.maxtime.format($Extras.Formatting.datetime_today))
           </div>
         </div>

--- a/skins/neowx-material/month-%Y-%m.html.tmpl
+++ b/skins/neowx-material/month-%Y-%m.html.tmpl
@@ -19,7 +19,7 @@
           #if $name == 'windSpeed'
 
             <i class="wi wi-wind from-$month.windDir.avg.formatted-deg"
-               title="$month.windDir.avg.formatted°" data-toggle="tooltip"></i>
+               title="$month.windDir.avg.formatted°" data-toggle="tooltip" data-html="true"></i>
 
           #end if
         </h3>
@@ -39,7 +39,7 @@
           <div class="col-3 text-muted font-small hi-text">
             $month.wind.max $month.wind.gustdir.ordinal_compass <br>
             <i class="wi wi-wind from-$month.wind.gustdir.formatted-deg mr-2"
-               title="$month.wind.gustdir.formatted°" data-toggle="tooltip"></i>
+               title="$month.wind.gustdir.formatted°" data-toggle="tooltip" data-html="true"></i>
             ($month.wind.maxtime.format($Extras.Formatting.datetime))
           </div>
         </div>

--- a/skins/neowx-material/month.html.tmpl
+++ b/skins/neowx-material/month.html.tmpl
@@ -19,7 +19,7 @@
           #if $name == 'windSpeed'
 
             <i class="wi wi-wind from-$month.windDir.avg.formatted-deg"
-               title="$month.windDir.avg.formatted°" data-toggle="tooltip"></i>
+               title="$month.windDir.avg.formatted°" data-toggle="tooltip" data-html="true"></i>
 
           #end if
         </h3>
@@ -39,7 +39,7 @@
           <div class="col-3 text-muted font-small hi-text">
             $month.wind.max $month.wind.gustdir.ordinal_compass <br>
             <i class="wi wi-wind from-$month.wind.gustdir.formatted-deg mr-2"
-               title="$month.wind.gustdir.formatted°" data-toggle="tooltip"></i>
+               title="$month.wind.gustdir.formatted°" data-toggle="tooltip" data-html="true"></i>
             ($month.wind.maxtime.format($Extras.Formatting.datetime))
           </div>
         </div>

--- a/skins/neowx-material/package.json
+++ b/skins/neowx-material/package.json
@@ -7,7 +7,7 @@
   "author": "Neoground GmbH",
   "license": "MIT",
   "dependencies": {
-    "sass": "^1.86.0"
+    "sass": "^1.87.0"
   },
   "scripts": {
     "build-css": "sass --load-path scss scss/style.scss css/style.css",

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -40,7 +40,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
     #
-    version = 1.40.0
+    version = 1.41.0
 
     # Language
     # -------------------------------------------------------------------------

--- a/skins/neowx-material/week.html.tmpl
+++ b/skins/neowx-material/week.html.tmpl
@@ -19,7 +19,7 @@
           #if $name == 'windSpeed'
 
             <i class="wi wi-wind from-$week.windDir.avg.formatted-deg"
-               title="$week.windDir.avg.formatted°" data-toggle="tooltip"></i>
+               title="$week.windDir.avg.formatted°" data-toggle="tooltip" data-html="true"></i>
 
           #end if
         </h3>
@@ -39,7 +39,7 @@
           <div class="col-3 text-muted font-small hi-text">
             $week.wind.max $week.wind.gustdir.ordinal_compass <br>
             <i class="wi wi-wind from-$week.wind.gustdir.formatted-deg mr-2"
-               title="$week.wind.gustdir.formatted°" data-toggle="tooltip"></i>
+               title="$week.wind.gustdir.formatted°" data-toggle="tooltip" data-html="true"></i>
             ($week.wind.maxtime.format($Extras.Formatting.datetime))
           </div>
         </div>

--- a/skins/neowx-material/yarn.lock
+++ b/skins/neowx-material/yarn.lock
@@ -162,10 +162,10 @@ readdirp@^4.0.1:
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.1.1.tgz#bd115327129672dc47f87408f05df9bd9ca3ef55"
   integrity sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==
 
-sass@^1.86.0:
-  version "1.86.0"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.86.0.tgz#f49464fb6237a903a93f4e8760ef6e37a5030114"
-  integrity sha512-zV8vGUld/+mP4KbMLJMX7TyGCuUp7hnkOScgCMsWuHtns8CWBoz+vmEhoGMXsaJrbUP8gj+F1dLvVe79sK8UdA==
+sass@^1.87.0:
+  version "1.87.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.87.0.tgz#8cceb36fa63fb48a8d5d7f2f4c13b49c524b723e"
+  integrity sha512-d0NoFH4v6SjEK7BoX810Jsrhj7IQSYHAHLi/iSpgqKc7LaIDshFRlSg5LOymf9FqQhxEHs2W5ZQXlvy0KD45Uw==
   dependencies:
     chokidar "^4.0.0"
     immutable "^5.0.2"

--- a/skins/neowx-material/year-%Y.html.tmpl
+++ b/skins/neowx-material/year-%Y.html.tmpl
@@ -19,7 +19,7 @@
           #if $name == 'windSpeed'
 
             <i class="wi wi-wind from-$year.windDir.avg.formatted-deg"
-               title="$year.windDir.avg.formatted°" data-toggle="tooltip"></i>
+               title="$year.windDir.avg.formatted°" data-toggle="tooltip" data-html="true"></i>
 
           #end if
         </h3>
@@ -39,7 +39,7 @@
           <div class="col-3 text-muted font-small hi-text">
             $year.wind.max $year.wind.gustdir.ordinal_compass <br>
             <i class="wi wi-wind from-$year.wind.gustdir.formatted-deg mr-2"
-               title="$year.wind.gustdir.formatted°" data-toggle="tooltip"></i>
+               title="$year.wind.gustdir.formatted°" data-toggle="tooltip" data-html="true"></i>
             ($year.wind.maxtime.format($Extras.Formatting.datetime_archive))
           </div>
         </div>
@@ -149,7 +149,7 @@
                   $month.wind.max<br>
                   $month.windDir.avg.ordinal_compass
                   <i class="wi wi-wind from-$month.windDir.avg.formatted-deg mr-2"
-                     title="$month.windDir.avg.formatted°" data-toggle="tooltip"></i>
+                     title="$month.windDir.avg.formatted°" data-toggle="tooltip" data-html="true"></i>
                 </div>
                 <div class="col-4">
                   <i class="wi wi-showers h5-responsive"></i><br>

--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -19,7 +19,7 @@
           #if $name == 'windSpeed'
 
             <i class="wi wi-wind from-$year.windDir.avg.formatted-deg"
-               title="$year.windDir.avg.formatted°" data-toggle="tooltip"></i>
+               title="$year.windDir.avg.formatted°" data-toggle="tooltip" data-html="true"></i>
 
           #end if
         </h3>
@@ -39,7 +39,7 @@
           <div class="col-3 text-muted font-small hi-text">
             $year.wind.max $year.wind.gustdir.ordinal_compass <br>
             <i class="wi wi-wind from-$year.wind.gustdir.formatted-deg mr-2"
-               title="$year.wind.gustdir.formatted°" data-toggle="tooltip"></i>
+               title="$year.wind.gustdir.formatted°" data-toggle="tooltip" data-html="true"></i>
             ($year.wind.maxtime.format($Extras.Formatting.datetime_archive))
           </div>
         </div>

--- a/skins/neowx-material/yesterday.html.tmpl
+++ b/skins/neowx-material/yesterday.html.tmpl
@@ -17,7 +17,7 @@
           #if $name == 'windSpeed'
 
             <i class="wi wi-wind from-$yesterday.windDir.avg.formatted-deg"
-               title="$yesterday.windDir.avg.formatted°" data-toggle="tooltip"></i>
+               title="$yesterday.windDir.avg.formatted°" data-toggle="tooltip" data-html="true"></i>
 
           #end if
         </h3>
@@ -37,7 +37,7 @@
           <div class="col-3 text-muted font-small hi-text">
             $yesterday.wind.max $yesterday.wind.gustdir.ordinal_compass <br>
             <i class="wi wi-wind from-$yesterday.wind.gustdir.formatted-deg mr-2"
-               title="$yesterday.wind.gustdir.formatted°" data-toggle="tooltip"></i>
+               title="$yesterday.wind.gustdir.formatted°" data-toggle="tooltip" data-html="true"></i>
             ($yesterday.wind.maxtime.format($Extras.Formatting.datetime_today))
           </div>
         </div>


### PR DESCRIPTION
You can now use HTML tags in tooltips
e.g.


define or change your language conf
```
[Units]
[[Labels]]
    meter	      = " m", " m"
    day               = " day",    "<sup>d</sup>"
    hour              = " hour",   "<sup>h</sup>"
    minute            = " minute", "<sup>m</sup>"
    second            = " second", "<sup>s</sup>"
```
and tooltips are formatted correctly
![image](https://github.com/user-attachments/assets/1bcdecee-f124-46f1-8322-df6bd1b89399)

This solves https://github.com/seehase/neowx-material/issues/67

@stalkerGH
please check and confirm
