### PR TITLE
FIx for #78 Wind averaging charts

### DIFF
--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -345,7 +345,7 @@ new ApexCharts(document.querySelector('#$id'), {
 
   // Wind
   $getChartJsCode("windSpeed", "windSpeedchart", "area", "windSpeed", "windGust", "max")
-  $getChartJsCode("windDir", "windDirchart", "line", "windDir")
+  $getChartJsCode("windDir", "windDirchart", "line", "windDir", "", "vecdir")
 
   // outHumidity
   $getChartJsCode("outHumidity", "outHumiditychart", "area", "outHumidity")

--- a/skins/neowx-material/month.html.tmpl
+++ b/skins/neowx-material/month.html.tmpl
@@ -326,7 +326,7 @@ new ApexCharts(document.querySelector('#$id'), {
 
   // Wind
   $getChartJsCode("windSpeed", "windSpeedchart", "area", "windSpeed", "windGust", "max")
-  $getChartJsCode("windDir", "windDirchart", "line", "windDir")
+  $getChartJsCode("windDir", "windDirchart", "line", "windDir", "", "vecdir")
 
   // outHumidity
   $getChartJsCode("outHumidity", "outHumiditychart", "area", "outHumidity")

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -41,7 +41,7 @@
     # You can check for updates on the project page.
     #
 
-    version = 1.44.1
+    version = 1.44.2
 
     # Language
     # -------------------------------------------------------------------------

--- a/skins/neowx-material/week.html.tmpl
+++ b/skins/neowx-material/week.html.tmpl
@@ -326,7 +326,7 @@ new ApexCharts(document.querySelector('#$id'), {
 
   // Wind
   $getChartJsCode("windSpeed", "windSpeedchart", "area", "windSpeed", "windGust", "max")
-  $getChartJsCode("windDir", "windDirchart", "line", "windDir")
+  $getChartJsCode("windDir", "windDirchart", "line", "windDir", "", "vecdir")
 
   // outHumidity
   $getChartJsCode("outHumidity", "outHumiditychart", "area", "outHumidity")

--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -373,7 +373,7 @@ new ApexCharts(document.querySelector('#$id'), {
 
   // Wind
   $getChartJsCode("windSpeed", "windSpeedchart", "area", "windSpeed", "windGust", "max")
-  $getChartJsCode("windDir", "windDirchart", "line", "windDir")
+  $getChartJsCode("windDir", "windDirchart", "line", "windDir", "", "vecdir")
 
   // outHumidity
   $getChartJsCode("outHumidity", "outHumiditychart", "area", "outHumidity")

--- a/skins/neowx-material/yesterday.html.tmpl
+++ b/skins/neowx-material/yesterday.html.tmpl
@@ -349,7 +349,7 @@ new ApexCharts(document.querySelector('#$id'), {
 
   // Wind
   $getChartJsCode("windSpeed", "windSpeedchart", "area", "windSpeed", "windGust", "max")
-  $getChartJsCode("windDir", "windDirchart", "line", "windDir")
+  $getChartJsCode("windDir", "windDirchart", "line", "windDir", "", "vecdir")
 
   // outHumidity
   $getChartJsCode("outHumidity", "outHumiditychart", "area", "outHumidity")


### PR DESCRIPTION
I have changed wind direction charts to use "vecdir" instead of "avg". The reason for this is described in #77 and #78