### PR TITLE
Improved setting theme color to manifest by picking right color based on 'Extras.color'

### DIFF
--- a/skins/neowx-material/manifest.json.tmpl
+++ b/skins/neowx-material/manifest.json.tmpl
@@ -50,6 +50,6 @@
   "scope": "/",
   "orientation": "any",
   "display": "standalone",
-  "theme_color": "${Extras.theme_color}",
-  "background_color": "${Extras.background_color}"
+  "theme_color": "${Extras.Manifest[$Extras.color]}",
+  "background_color": "${Extras.Manifest.background_color}"
 }

--- a/skins/neowx-material/package-lock.json
+++ b/skins/neowx-material/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neowx-material",
-  "version": "1.48.0",
+  "version": "1.48.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neowx-material",
-      "version": "1.48.0",
+      "version": "1.48.1",
       "license": "MIT",
       "dependencies": {
         "sass": "^1.90.0"

--- a/skins/neowx-material/package.json
+++ b/skins/neowx-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neowx-material",
-  "version": "1.48.0",
+  "version": "1.48.1",
   "description": "The most versatile and modern weewx skin",
   "main": "index.js",
   "repository": "https://github.com/neoground/neowx-material",

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -41,7 +41,7 @@
     # You can check for updates on the project page.
     #
 
-    version = 1.48.0
+    version = 1.48.1
 
     # Language
     # -------------------------------------------------------------------------
@@ -68,9 +68,32 @@
     #
     color = indigo
 
-    # Theme color and background color for the manifest.json
-    theme_color = "#3f51b5"
-    background_color = "#f5f5f5"
+    # Theme colors for manifest file and background color for the manifest.json
+    # -------------------------------------------------------------------------
+    # This is list of all available theme colors
+    # Based on color set above the correct hex code will be set automatically into manifest.json
+    #
+    [[Manifest]]
+        background_color = "#f5f5f5" # light theme background color is same for all themes in manifest.json
+        red = "#f44336"
+        pink = "#e91e63"
+        purple = "#9c27b0"
+        deep-purple = "#673ab7"
+        indigo = "#3f51b5"
+        blue = "#2196f3"
+        light-blue = "#03a9f4"
+        cyan = "#00bcd4"
+        teal = "#009688"
+        green = "#4caf50"
+        light-green = "#8bc34a"
+        lime = "#cddc39"
+        yellow = "#ffeb3b"
+        amber = "#ffc107"
+        orange = "#ff9800"
+        deep-orange = "#ff5722"
+        brown = "#795548"
+        grey = "#9e9e9e"
+        blue-grey = "#607d8b"
 
     # Header
     # -------------------------------------------------------------------------


### PR DESCRIPTION
Reworked setting theme color into manifest file based on color set in skin.conf. This way user doesn't need to handle hash colors by himself, but there is already predefined list for every supported color (matches base color from scss file). And for manifest it will pick correct one using: "theme_color": "${Extras.Manifest[$Extras.color]}"