### PR TITLE
Potential fix for code scanning alert no. 25: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/merge-label.yml
+++ b/.github/workflows/merge-label.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/.github/workflows/pr-version-check.yml
+++ b/.github/workflows/pr-version-check.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     name: Check Version
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -39,9 +39,9 @@
     #
     # This is the current version of this skin.
     # You can check for updates on the project page.
-    #
 
-    version = 1.49.12
+
+    version = 1.49.13
 
     # Language
     # -------------------------------------------------------------------------


### PR DESCRIPTION
Potential fix for [https://github.com/seehase/neowx-material/security/code-scanning/25](https://github.com/seehase/neowx-material/security/code-scanning/25)

To address this issue, you should add a `permissions` block to the job (`release`) or at the workflow root. Since the job performs a checkout and creates git tags (via the GitHub API), the minimal required permissions are `contents: write`. Other permissions (like `pull-requests`, `issues`, etc.) are not referenced in this job and should remain at defaults (none). The change involves inserting a `permissions` block at the workflow or job level (best is at job level for scoping) as follows:

- In `.github/workflows/merge-label.yml`, add under `jobs.release:`  
  `permissions:`  
  `  contents: write`  
  (insert between line 8 and line 9, before `runs-on:`)

No other code or imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
