### PR TITLE
Added option to separate forecast from measured values by horizontal …

### DIFF
--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class BasicInstaller(ExtensionInstaller):
     def __init__(self):
         super(BasicInstaller, self).__init__(
-            version="1.50.0",
+            version="1.50.2",
             name="neowx-material",
             description="The most versatile and modern weewx skin",
             author="Neoground GmbH",

--- a/skins/neowx-material/forecast.inc
+++ b/skins/neowx-material/forecast.inc
@@ -40,12 +40,21 @@
 #end if
 
 #if $forecast is not None
-  #for $x in $forecast.daily
+  #if $Extras.Forecast.forecast_separator == "yes" and $Extras.Appearance.values_order[0] != "forecast"
+  <hr class="col-12 m-0 mb-4 p-0" />
+  #end if 
+  #for $i, $x in $enumerate($forecast.daily)
     <div class="col-12 col-md-6 col-xl-4 mb-4">
       <div class="card">
         <div class="card-body text-center pb-1">
           <h3 class="h5-responsive $Extras.color-text">
-            $pgettext("Forecast","daily") - $x[0].format("%A")
+            #if $Extras.Forecast.show_today_tomorrow == "yes" and $i == 0
+              $pgettext("Forecast","forecast") - $pgettext("Forecast","today")
+            #else if $Extras.Forecast.show_today_tomorrow == "yes" and $i == 1
+              $pgettext("Forecast","forecast") - $pgettext("Forecast","tomorrow")
+            #else
+              $pgettext("Forecast","forecast") - $x[0].format("%A")
+            #end if
           </h3>
           <div class="row flex-fill font-small">
             #if $Extras.Forecast.show_description == "yes"
@@ -137,4 +146,7 @@
       </div>
     </div>
   #end for
+  #if $Extras.Forecast.forecast_separator == "yes" and $Extras.Appearance.values_order[-1] != "forecast"
+  <hr class="col-12 m-0 mb-4 p-0" />
+  #end if 
 #end if

--- a/skins/neowx-material/lang/ca.conf
+++ b/skins/neowx-material/lang/ca.conf
@@ -74,7 +74,9 @@
     tropical_nights      = Nits tropicals
 
     [[Forecast]]
-        daily            = Predicció diària
+        forecast         = Predicció
+        today            = Avui
+        tomorrow         = Demà
         precipitation    = Precipitació
         probability      = Probabilitat
         min_temp         = Temp. mínima

--- a/skins/neowx-material/lang/de.conf
+++ b/skins/neowx-material/lang/de.conf
@@ -198,7 +198,9 @@
     yesterday            = Gestern
 
     [[Forecast]]
-        daily            = Vorhersage
+        forecast         = Vorhersage
+        today            = Heute
+        tomorrow         = Morgen
         precipitation    = Niederschlag
         probability      = Wahrscheinlichkeit
         min_temp         = Min. Temperatur

--- a/skins/neowx-material/lang/en.conf
+++ b/skins/neowx-material/lang/en.conf
@@ -90,7 +90,9 @@
     yesterday            = Yesterday
 
     [[Forecast]]
-        daily            = Daily forecast
+        forecast         = Forecast
+        today            = Today
+        tomorrow         = Tomorrow
         precipitation    = Precipitation
         probability      = Probability
         min_temp         = Min. temperature

--- a/skins/neowx-material/lang/es.conf
+++ b/skins/neowx-material/lang/es.conf
@@ -197,7 +197,9 @@
     tropical_nights      = Noches tropicales
 
     [[Forecast]]
-        daily            = Pronóstico diario
+        forecast         = Pronóstico
+        today            = Hoy
+        tomorrow         = Mañana
         precipitation    = Precipitación
         probability      = Probabilidad
         min_temp         = Temp. mínima

--- a/skins/neowx-material/lang/fi.conf
+++ b/skins/neowx-material/lang/fi.conf
@@ -200,7 +200,9 @@
     tropical_nights      = Trooppiset yöt
 
     [[Forecast]]
-        daily            = Päivittäinen ennuste
+        forecast         = Ennuste
+        today            = Tänään
+        tomorrow         = Huomenna
         precipitation    = Sademäärä
         probability      = Todennäköisyys
         min_temp         = Alin lämpötila

--- a/skins/neowx-material/lang/fr.conf
+++ b/skins/neowx-material/lang/fr.conf
@@ -197,7 +197,9 @@
     tropical_nights      = Nuits tropicales
 
     [[Forecast]]
-        daily            = Prévisions quotidiennes
+        forecast         = Prévisions
+        today            = "Aujourd'hui"
+        tomorrow         = Demain
         precipitation    = Précipitations
         probability      = Probabilité
         min_temp         = Température min.

--- a/skins/neowx-material/lang/it.conf
+++ b/skins/neowx-material/lang/it.conf
@@ -197,7 +197,9 @@
     tropical_nights      = Notti tropicali
 
     [[Forecast]]
-        daily            = Previsioni giornaliere
+        forecast         = Previsioni
+        today            = Oggi
+        tomorrow         = Domani
         precipitation    = Precipitazioni
         probability      = Probabilità
         min_temp         = Temp. minima

--- a/skins/neowx-material/lang/nl.conf
+++ b/skins/neowx-material/lang/nl.conf
@@ -196,7 +196,9 @@
     yesterday            = Gisteren
 
     [[Forecast]]
-        daily            = Dagelijks weerbericht
+        forecast         = Weerbericht
+        today            = Vandaag
+        tomorrow         = Morgen
         precipitation    = Neerslag
         probability      = Kans
         min_temp         = Min. temperatuur

--- a/skins/neowx-material/lang/pl.conf
+++ b/skins/neowx-material/lang/pl.conf
@@ -166,7 +166,9 @@
     tropical_nights      = Tropikalne noce
 
     [[Forecast]]
-        daily            = Prognoza dzienna
+        forecast         = Prognoza
+        today            = Dzisiaj
+        tomorrow         = Jutro
         precipitation    = Opady
         probability      = Prawdopodobieństwo
         min_temp         = Min. temperatura

--- a/skins/neowx-material/lang/se.conf
+++ b/skins/neowx-material/lang/se.conf
@@ -201,7 +201,9 @@
     tropical_nights      = Tropiska nätter
 
     [[Forecast]]
-        daily            = Daglig prognos
+        forecast         = Prognos
+        today            = Idag
+        tomorrow         = Imorgon
         precipitation    = Nederbörd
         probability      = Sannolikhet
         min_temp         = Min. temperatur

--- a/skins/neowx-material/lang/sk.conf
+++ b/skins/neowx-material/lang/sk.conf
@@ -260,7 +260,9 @@
     yesterday            = Včera
 
     [[Forecast]]
-        daily            = Denná predpoveď
+        forecast         = Predpoveď
+        today            = Dnes
+        tomorrow         = Zajtra
         precipitation    = Zrážky
         probability      = Pravdepodobnosť
         min_temp         = Minimálna teplota

--- a/skins/neowx-material/package-lock.json
+++ b/skins/neowx-material/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neowx-material",
-  "version": "1.50.0",
+  "version": "1.50.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neowx-material",
-      "version": "1.50.0",
+      "version": "1.50.2",
       "license": "MIT",
       "dependencies": {
         "sass": "^1.93.2"

--- a/skins/neowx-material/package.json
+++ b/skins/neowx-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neowx-material",
-  "version": "1.50.0",
+  "version": "1.50.2",
   "description": "The most versatile and modern weewx skin",
   "main": "index.js",
   "repository": "https://github.com/neoground/neowx-material",

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -40,7 +40,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
 
-    version = 1.50.1
+    version = 1.50.2
 
     # Language
     # -------------------------------------------------------------------------
@@ -301,6 +301,10 @@
         days = 3
         # Model to use, by default "best_match" is used. For more options see https://open-meteo.com/en/docs only one model can be used at a time.
         model = best_match
+        # Render separator between current weather and forecast yes/no
+        forecast_separator = no
+        # Show words "Today" and "Tomorrow" instead of weekday names yes/no
+        show_today_tomorrow = no
 
     # Charts
     # -------------------------------------------------------------------------


### PR DESCRIPTION
Three improvements:

1) Shortened text from Daily forecast to just "Forecast"
2) Option to separate forecast with horizontal ruler, in case forecast is in middle than horizontal ruler is added to top and bottom of forecast, and if forecast is as last, than horizontal ruler is added only to top.
3) Option to change label of current and next day forecast from day name to "Today"/"Tomorrow".

Example with ruler on bottom:
<img width="1173" height="638" alt="image" src="https://github.com/user-attachments/assets/a6ba8185-dfb3-46af-aa12-10520897f185" />
