### PR TITLE
#141 allows display zero values in telemetry

### DIFF
--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class BasicInstaller(ExtensionInstaller):
     def __init__(self):
         super(BasicInstaller, self).__init__(
-            version="1.50.6",
+            version="1.50.7",
             name="neowx-material",
             description="The most versatile and modern weewx skin",
             author="Neoground GmbH",

--- a/skins/neowx-material/package-lock.json
+++ b/skins/neowx-material/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neowx-material",
-  "version": "1.50.6",
+  "version": "1.50.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neowx-material",
-      "version": "1.50.6",
+      "version": "1.50.7",
       "license": "MIT",
       "dependencies": {
         "sass": "^1.93.2"

--- a/skins/neowx-material/package.json
+++ b/skins/neowx-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neowx-material",
-  "version": "1.50.6",
+  "version": "1.50.7",
   "description": "The most versatile and modern weewx skin",
   "main": "index.js",
   "repository": "https://github.com/neoground/neowx-material",

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -40,7 +40,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
 
-    version = 1.50.6
+    version = 1.50.7
 
     # Language
     # -------------------------------------------------------------------------
@@ -312,6 +312,14 @@
 
         # Show words "Today" and "Tomorrow" instead of weekday names yes/no
         show_today_tomorrow = no
+
+    # Telemetry behavior
+    # -------------------------------------------------------------------------
+    # Here you can change telemetry behavior
+    #
+    [[Telemetry]]
+        # This will allow to display telemetry plots and cards if value is zero, it is required as some stations report 1 or 0 only.  yes/no
+        allow_zero_values = no
 
     # Charts
     # -------------------------------------------------------------------------

--- a/skins/neowx-material/telemetry.html.tmpl
+++ b/skins/neowx-material/telemetry.html.tmpl
@@ -8,7 +8,7 @@
 ## +-------------------------------------------------------------------------+
 
 #def valuesCard($name)
-#if $getVar('day.' + name + '.has_data') and $getVar('day.' + name + '.max.raw') > 0
+#if $getVar('day.' + name + '.has_data') and ($getVar('day.' + name + '.max.raw') > 0 or $Extras.Telemetry.allow_zero_values == "yes")
 <div class="col-12 col-lg-6 mb-4">
   <div class="card">
     <div class="card-body text-center">
@@ -110,7 +110,7 @@
 
 #def getChartJsCode($name, $series, $column = "avg")
 
-#if $getVar('day.' + name + '.has_data') and $getVar('day.' + name + '.max.raw') > 0
+#if $getVar('day.' + name + '.has_data') and ($getVar('day.' + name + '.max.raw') > 0 or $Extras.Telemetry.allow_zero_values == "yes")
 
 new ApexCharts(document.querySelector('#$name-chart'), {
   ...graph_area_config,


### PR DESCRIPTION
This should solve #141 by adding option in skin.conf

```
    [[Telemetry]]
        # This will allow to display telemetry plots and cards if value is zero, it is required as some stations report 1 or 0 only.  yes/no
        allow_zero_values = no
```

default is "no" so it doesn't change anything for general public, but it someone need to display zero values, changing this to "yes" will bypass check " > 0 " in telemetry.html.tmpl