### PR TITLE
Disable allowMouseWheelZoom in charts

### DIFF
--- a/skins/neowx-material/graph_line_archive_config.inc
+++ b/skins/neowx-material/graph_line_archive_config.inc
@@ -3,12 +3,19 @@
 ## |    graph_line_archive_config.inc             JS config for default line charts    |
 ## +-----------------------------------------------------------------------------------+
 
+#set $allowMouseWheelZoom = "false"
+#if $Extras.Appearance.allowMouseWheelZoom == "true"
+#set $allowMouseWheelZoom = "true"
+#end if
+
+
 chart: {
     type: 'line',
     zoom: {
         enabled: false,
         type: 'x',  
         autoScaleYaxis: false,
+        allowMouseWheelZoom: $allowMouseWheelZoom,
     },
 },
 

--- a/skins/neowx-material/js.inc
+++ b/skins/neowx-material/js.inc
@@ -43,6 +43,11 @@
     }
 </script>
 
+#set $allowMouseWheelZoom = "false"
+#if $Extras.Appearance.allowMouseWheelZoom == "true"
+#set $allowMouseWheelZoom = "true"
+#end if
+
 ## Global apexcharts config
 <script type="text/javascript">
     var config_mode = '${Extras.Appearance.mode}';
@@ -76,7 +81,8 @@
             zoom: {
                 type: 'x',
                 enabled: true,
-                autoScaleYaxis: true
+                autoScaleYaxis: true,
+                allowMouseWheelZoom: $allowMouseWheelZoom,
             },
             toolbar: {
                 autoSelected: 'zoom',

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -40,7 +40,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
 
-    version = 1.50.7
+    version = 1.50.8
 
     # Language
     # -------------------------------------------------------------------------
@@ -275,6 +275,9 @@
         # hi_value_color = "f44336"
         lo_value_color =
         hi_value_color =
+
+        # allowMouseWheelZoom in charts true/false, default is no if enabled, it can have impact during scrolling the page
+        allowMouseWheelZoom = false
 
     # Forecast behavior
     # -------------------------------------------------------------------------


### PR DESCRIPTION
Option to enable or disable allowMouseWheelZoom in charts, because it prevents scrolliing if mouse is over a chart
Zoom is still possible with drag&drop

use 
```
[Extras]
    [[Appearance]]
        # allowMouseWheelZoom in charts true/false, default is no if enabled, it can have impact during scrolling the page
        allowMouseWheelZoom = false
```
to configure, default is "false"