### PR TITLE
Fix skin_conf_patch.sh to be able to patch tree level entries like Extras.Embedded.iFrame1.title = xxx

### DIFF
--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -40,7 +40,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
 
-    version = 1.51.0
+    version = 1.51.1
 
     # Language
     # -------------------------------------------------------------------------

--- a/skins/neowx-material/skin_conf_patches.txt.sample
+++ b/skins/neowx-material/skin_conf_patches.txt.sample
@@ -18,3 +18,5 @@ Extras.Header.custom1_url =
 Extras.Header.custom2_label =
 Extras.Footer.about =
 CopyGenerator.copy_once =
+Extras.Appearance.values_order = outTemp, outHumidity,
+Extras.Embedded.image2.title = My Imagae Title


### PR DESCRIPTION

This pull request enhances the patching functionality for the `skin.conf` file in the `neowx-material` skin by adding support for a third-level section hierarchy (subsubsections). This allows for more granular configuration updates and better organization of configuration keys. The version number is also incremented to reflect these improvements.

Use the script `skin_conf_patch.sh` together with your settings stored in `skin_conf_patches.txt` to easily upgrade to newer versions of neo-weewx without always changing the skin.conf file by hand

Example see `skin_conf_patches.txt.sample`