### PR TITLE
Implementation of Update check and version increment

### DIFF
--- a/bin/user/updatecheck.py
+++ b/bin/user/updatecheck.py
@@ -1,0 +1,203 @@
+#
+# Copyright (c) 2025 UpdateCheck Extension for NeoWX Material
+#
+# Distributed under the terms of the GNU GENERAL PUBLIC LICENSE
+#
+
+"""Extends the Cheetah generator search list to check for updates from GitHub
+
+[CheetahGenerator]
+    search_list_extensions = user.updatecheck.UpdateCheck
+
+# Update Check behavior
+# -------------------------------------------------------------------------
+# Here you can configure update check behavior
+#
+[[UpdateCheck]]
+    # Update check modes:
+    # off - No update checking performed
+    # minor - Only show notifications for minor version updates (e.g., 1.50.x -> 1.51.x)
+    # patch - Show notifications for all version updates including patches (e.g., 1.51.1 -> 1.51.2)
+    update_check = patch
+
+    # Update check interval in minutes (default: 1440 minutes = 24 hours = 1 day)
+    update_interval = 1440
+
+    # URL to check for the latest version (default points to the skin.conf in the GitHub repository)
+    update_check_url = https://raw.githubusercontent.com/seehase/neowx-material/master/skins/neowx-material/skin.conf
+
+"""
+
+import time
+import urllib.request
+import urllib.parse
+import urllib.error
+import logging
+import re
+
+try:
+    from packaging import version
+    HAVE_PACKAGING = True
+except ImportError:
+    # Fallback for systems without packaging library
+    from distutils.version import LooseVersion
+    HAVE_PACKAGING = False
+
+try:
+    from weewx.cheetahgenerator import SearchList
+except ImportError:
+    # This will be available when running in weewx context
+    SearchList = object
+
+VERSION = "1.0.0"
+
+log = logging.getLogger(__name__)
+
+# Global cache variable - check only every 4 hours
+_update_cache = {
+    "last_check": 0,
+    "data": None,
+}
+
+CACHE_DURATION = 4 * 60 * 60  # 4 hours in seconds
+TIMEOUT = 15  # seconds
+RETRIES = 3
+DELAY = 5  # seconds between retries
+
+
+class UpdateCheck(SearchList):
+
+    def __init__(self, generator):
+        SearchList.__init__(self, generator)
+        log.info("version: %s" % VERSION)
+
+        self.generator = generator
+        self.footer_dict = generator.skin_dict.get("Extras", {}).get("Footer", {})
+        self.current_version = generator.skin_dict.get("Extras", {}).get("version", "0.0.0")
+
+        # Configuration
+        self.update_check_mode = self.footer_dict.get("update_check", "off")
+        self.update_interval = int(self.footer_dict.get("update_interval", "240"))  # minutes
+        self.update_check_url = self.footer_dict.get("update_check_url", "https://raw.githubusercontent.com/seehase/neowx-material/master/skins/neowx-material/skin.conf")
+
+        # Convert interval from minutes to seconds
+        self.cache_duration = self.update_interval * 60
+
+    def update_check(self):
+        """Main function that returns update information"""
+
+        if self.update_check_mode == "off":
+            log.debug("Update check is disabled")
+            return None
+
+        if not self.current_version:
+            log.debug("No current version found in skin.conf")
+            return None
+
+        try:
+            latest_version = self._get_latest_version()
+            if not latest_version:
+                return None
+
+            return self._compare_versions(self.current_version, latest_version)
+
+        except Exception as e:
+            log.debug("Error during update check: %s", e)
+            return None
+
+    def _get_latest_version(self):
+        """Get the latest version from GitHub with caching"""
+        global _update_cache
+
+        current_time = time.time()
+
+        # Check if we have cached data that's still valid
+        if (current_time - _update_cache["last_check"]) < self.cache_duration and _update_cache["data"]:
+            log.debug("Using cached version data (interval: %d minutes)", self.update_interval)
+            return _update_cache["data"]
+
+        # Fetch new version from the configured URL
+        github_url = self.update_check_url
+
+        for attempt in range(1, RETRIES + 1):
+            try:
+                log.debug("Fetching version from: %s (attempt %d)", github_url, attempt)
+
+                with urllib.request.urlopen(github_url, timeout=TIMEOUT) as response:
+                    if response.status != 200:
+                        raise Exception(f"HTTP error: {response.status}")
+
+                    content = response.read().decode('utf-8')
+                    version_match = re.search(r'version\s*=\s*([0-9]+\.[0-9]+\.[0-9]+)', content)
+
+                    if version_match:
+                        latest_version = version_match.group(1)
+                        log.debug("Found latest version: %s", latest_version)
+
+                        # Update cache
+                        _update_cache["last_check"] = current_time
+                        _update_cache["data"] = latest_version
+
+                        return latest_version
+                    else:
+                        raise Exception("Version not found in remote skin.conf")
+
+            except (urllib.error.URLError, urllib.error.HTTPError, Exception) as e:
+                if attempt < RETRIES:
+                    log.debug("Retry in %d seconds... (%s)", DELAY, str(e))
+                    time.sleep(DELAY)
+                else:
+                    log.info("Failed to fetch latest version from GitHub after %d attempts", RETRIES)
+                    log.debug("Last error: %s", e)
+                    return None
+
+        return None
+
+    def _compare_versions(self, current_ver, latest_ver):
+        """Compare versions and return update information based on check mode"""
+        try:
+            if HAVE_PACKAGING:
+                current = version.parse(current_ver)
+                latest = version.parse(latest_ver)
+            else:
+                current = LooseVersion(current_ver)
+                latest = LooseVersion(latest_ver)
+
+            if latest <= current:
+                log.debug("Current version %s is up to date (latest: %s)", current_ver, latest_ver)
+                return None
+
+            log.debug("Current version %s latest version: %s)", current_ver, latest_ver)
+
+            # Determine if we should show this update based on the check mode
+            if self.update_check_mode == "minor":
+                # Only show if major or minor version changed
+                if HAVE_PACKAGING:
+                    if current.major != latest.major or current.minor != latest.minor:
+                        return self._create_update_info(current_ver, latest_ver, "minor")
+                else:
+                    # Fallback: parse version manually for major.minor comparison
+                    current_parts = current_ver.split('.')
+                    latest_parts = latest_ver.split('.')
+                    if (len(current_parts) >= 2 and len(latest_parts) >= 2 and
+                        (current_parts[0] != latest_parts[0] or current_parts[1] != latest_parts[1])):
+                        return self._create_update_info(current_ver, latest_ver, "minor")
+            elif self.update_check_mode == "patch":
+                # Show all updates including patches
+                return self._create_update_info(current_ver, latest_ver, "patch")
+
+            return None
+
+        except Exception as e:
+            log.debug("Error comparing versions %s vs %s: %s", current_ver, latest_ver, e)
+            return None
+
+    def _create_update_info(self, current_ver, latest_ver, update_type):
+        """Create update information dictionary"""
+        return {
+            "available": True,
+            "current_version": current_ver,
+            "latest_version": latest_ver,
+            "update_type": update_type,
+            "github_url": "https://github.com/seehase/neowx-material"
+        }

--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class BasicInstaller(ExtensionInstaller):
     def __init__(self):
         super(BasicInstaller, self).__init__(
-            version="1.51.3",
+            version="1.52.0",
             name="neowx-material",
             description="The most versatile and modern weewx skin",
             author="Neoground GmbH",

--- a/skins/neowx-material/footer.inc
+++ b/skins/neowx-material/footer.inc
@@ -142,6 +142,18 @@
 		  Weather forecast data provided by&nbsp;<a href="https://open-meteo.com/">Open-Meteo.com</a> under (<a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>) license. Data may be modified (e.g., unit conversion, aggregation).
 		</div>
 		#end if
+
+        ## Update notification
+        #if $update_check and $update_check.available
+        <div class="alert alert-info alert-dismissible fade show mx-3 my-2" role="alert">
+            <i class="fas fa-info-circle"></i>
+            <strong>Update Available!</strong>
+            $gettext("update_available")
+            <strong>v$update_check.latest_version</strong>
+            ($gettext("current"): v$update_check.current_version)
+            <a href="$update_check.github_url" target="_blank" class="alert-link">$gettext("view_on_github")</a>
+        </div>
+        #end if
     </div>
     ## Copyright
 

--- a/skins/neowx-material/lang/ca.conf
+++ b/skins/neowx-material/lang/ca.conf
@@ -77,6 +77,8 @@
     uranus               = Urà
     sky_altitude         = Altitud
     celestial_bodies     = Cossos celestes
+    update_available     = Actualització disponible Una nova versió de la pell NeoWX Material està disponible.
+    view_on_github       = Veure a GitHub
 
     [[Forecast]]
         evapotranspiration = Evapotranspiració

--- a/skins/neowx-material/lang/de.conf
+++ b/skins/neowx-material/lang/de.conf
@@ -192,10 +192,12 @@
     trend                = Trend
     tropical_days        = Tropische Tage
     tropical_nights      = Tropische Nächte
+    update_available     = Eine neue Version von NeoWX Material ist verfügbar
     uranus               = Uranus
     uv_max               = Maximum UV Index
     venus                = Venus
     vernal_equinox       = Frühlingstagundnachtgleiche
+    view_on_github       = Auf GitHub ansehen
     weather              = Wetter
     weather_statistics   = Wetter Statistiken
     week                 = Woche

--- a/skins/neowx-material/lang/en.conf
+++ b/skins/neowx-material/lang/en.conf
@@ -84,10 +84,12 @@
     trend                = Trend
     tropical_days        = Tropical days
     tropical_nights      = Tropical nights
+    update_available     = Update Available A new version of the NeoWX Material skin is available.
     uranus               = Uranus
     uv_max               = Maximum UV Index
     venus                = Venus
     vernal_equinox       = Vernal Equinox
+    view_on_github       = View on GitHub
     weather              = Weather
     weather_statistics   = Weather Statistics
     week                 = Week

--- a/skins/neowx-material/lang/es.conf
+++ b/skins/neowx-material/lang/es.conf
@@ -201,6 +201,8 @@
     azimuth              = Azimut
     sky_altitude         = Altitud
     celestial_bodies     = Cuerpos celestes
+    update_available     = Actualización disponible Una nueva versión de la skin NeoWX Material está disponible.
+    view_on_github       = Ver en GitHub
 
     [[Forecast]]
         evapotranspiration = Evapotranspiración

--- a/skins/neowx-material/lang/fi.conf
+++ b/skins/neowx-material/lang/fi.conf
@@ -204,6 +204,8 @@
     azimuth              = Atsimuutti
     sky_altitude         = Korkeus
     celestial_bodies     = Taivaankappaleet
+    update_available     = Päivitys saatavilla Uusi versio NeoWX Material -teemasta on saatavilla.
+    view_on_github       = Näytä GitHubissa
 
     [[Forecast]]
         evapotranspiration = Haihdunta

--- a/skins/neowx-material/lang/fr.conf
+++ b/skins/neowx-material/lang/fr.conf
@@ -201,6 +201,8 @@
     azimuth              = Azimut
     sky_altitude         = Hauteur
     celestial_bodies     = Corps célestes
+    update_available     = Mise à jour disponible Une nouvelle version du thème NeoWX Material est disponible.
+    view_on_github       = Voir sur GitHub
 
     [[Forecast]]
         evapotranspiration = Evapotranspiration

--- a/skins/neowx-material/lang/it.conf
+++ b/skins/neowx-material/lang/it.conf
@@ -201,6 +201,8 @@
     azimuth              = Azimut
     sky_altitude         = Altezza
     celestial_bodies     = Corpi celesti
+    update_available     = Aggiornamento disponibile Una nuova versione del tema NeoWX Material è disponibile.
+    view_on_github       = Visualizza su GitHub
 
     [[Forecast]]
         evapotranspiration = ET

--- a/skins/neowx-material/lang/nl.conf
+++ b/skins/neowx-material/lang/nl.conf
@@ -200,6 +200,8 @@
     azimuth              = Azimut
     sky_altitude         = Hoogte
     celestial_bodies     = Hemellichamen
+    update_available     = Update beschikbaar Een nieuwe versie van de NeoWX Material skin is beschikbaar.
+    view_on_github       = Bekijk op GitHub
 
     [[Forecast]]
         evapotranspiration = Verdamping

--- a/skins/neowx-material/lang/pl.conf
+++ b/skins/neowx-material/lang/pl.conf
@@ -170,6 +170,8 @@
     azimuth              = Azymut
     sky_altitude         = Wysokość
     celestial_bodies     = Ciała niebieskie
+    update_available     = Aktualizacja dostępna Nowa wersja skórki NeoWX Material jest dostępna.
+    view_on_github       = Zobacz na GitHub
 
     [[Forecast]]
         evapotranspiration = Parowanie (ET)

--- a/skins/neowx-material/lang/se.conf
+++ b/skins/neowx-material/lang/se.conf
@@ -205,6 +205,8 @@
     azimuth              = Azimut
     sky_altitude         = Höjd
     celestial_bodies     = Himlakro
+    update_available     = Uppdatering tillgänglig En ny version av NeoWX Material-skalet är tillgänglig.
+    view_on_github       = Visa på GitHub
 
     [[Forecast]]
         evapotranspiration = Evapotranspiration

--- a/skins/neowx-material/lang/sk.conf
+++ b/skins/neowx-material/lang/sk.conf
@@ -265,6 +265,8 @@
     year                 = Rok
     year_records         = Tohtoročné záznamy
     yesterday            = Včera
+    update_available     = Aktualizácia dostupná Nová verzia skinu NeoWX Material je dostupná.
+    view_on_github       = Zobraziť na GitHub
 
     [[Forecast]]
         evapotranspiration = Výpar vody

--- a/skins/neowx-material/package-lock.json
+++ b/skins/neowx-material/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neowx-material",
-  "version": "1.51.3",
+  "version": "1.52.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neowx-material",
-      "version": "1.51.3",
+      "version": "1.52.0",
       "license": "MIT",
       "dependencies": {
         "sass": "^1.93.2"

--- a/skins/neowx-material/package.json
+++ b/skins/neowx-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neowx-material",
-  "version": "1.51.3",
+  "version": "1.52.0",
   "description": "The most versatile and modern weewx skin",
   "main": "index.js",
   "repository": "https://github.com/neoground/neowx-material",

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -40,7 +40,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
 
-    version = 1.51.3
+    version = 1.52.0
 
     # Language
     # -------------------------------------------------------------------------
@@ -218,7 +218,20 @@
         # We thank you for your support.
         support_weewx = yes
         support_skin = yes
-        show_version = yes
+        show_version = 1.52.0
+
+        # Update check modes:
+        # Internet connection is requiered for this feature
+        # off - No update checking performed
+        # minor - Only show notifications for minor version updates (e.g., 1.50.x -> 1.51.x)
+        # patch - Show notifications for all version updates including patches (e.g., 1.51.1 -> 1.51.2)
+        update_check = minor
+
+        # Update check interval in minutes (default: 1440 minutes = 24 hours = 1 day)
+        update_interval = 1440
+
+        # URL to check for the latest version (usually no need to change this)
+        update_check_url = https://raw.githubusercontent.com/seehase/neowx-material/master/skins/neowx-material/skin.conf
 
 
     # Date and time formatting
@@ -561,7 +574,7 @@
 # This section describes all templates and their generated files
 #
 [CheetahGenerator]
-    search_list_extensions = user.historygenerator.MyXSearch, user.openmeteo.Forecast
+    search_list_extensions = user.historygenerator.MyXSearch, user.openmeteo.Forecast, user.updatecheck.UpdateCheck
 
     # Possible encodings are 'html_entities', 'utf8', or 'strict_ascii'
     encoding = utf8

--- a/update_version.sh
+++ b/update_version.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+
+# update_version.sh - Updates version in multiple files and builds the project
+# Usage: ./update_version.sh [--patch-version|--minor-version|--version x.x.x|--help|-h]
+
+# Function to show help
+show_help() {
+    echo "update_version.sh - Updates version in multiple files and builds the project"
+    echo ""
+    echo "Usage:"
+    echo "  ./update_version.sh [OPTION]"
+    echo ""
+    echo "Options:"
+    echo "  --patch-version     Increment patch version by 1 (x.x.X)"
+    echo "  --minor-version     Increment minor version by 1 and set patch to 0 (x.X.0)"
+    echo "  --version x.x.x     Set specific version"
+    echo "  --help, -h          Show this help message"
+    echo ""
+    echo "If no option is provided, --patch-version is used by default."
+    echo ""
+    echo "Examples:"
+    echo "  ./update_version.sh                    # Increment patch version"
+    echo "  ./update_version.sh --patch-version    # Increment patch version"
+    echo "  ./update_version.sh --minor-version    # Increment minor version"
+    echo "  ./update_version.sh --version 2.0.0    # Set to specific version"
+    echo ""
+    echo "The script updates version in:"
+    echo "  - skins/neowx-material/skin.conf"
+    echo "  - install.py"
+    echo "  - skins/neowx-material/package.json"
+    echo ""
+    echo "And then runs: npm install && yarn run build"
+}
+
+# Function to get current version from skin.conf
+get_current_version() {
+    if [ -f "skins/neowx-material/skin.conf" ]; then
+        grep "^[[:space:]]*version = " skins/neowx-material/skin.conf | head -1 | sed 's/.*version = //' | tr -d '\r'
+    else
+        echo "Error: skins/neowx-material/skin.conf not found"
+        exit 1
+    fi
+}
+
+# Function to increment patch version
+increment_patch() {
+    local version="$1"
+    local major=$(echo "$version" | cut -d. -f1)
+    local minor=$(echo "$version" | cut -d. -f2)
+    local patch=$(echo "$version" | cut -d. -f3)
+    echo "$major.$minor.$((patch + 1))"
+}
+
+# Function to increment minor version
+increment_minor() {
+    local version="$1"
+    local major=$(echo "$version" | cut -d. -f1)
+    local minor=$(echo "$version" | cut -d. -f2)
+    echo "$major.$((minor + 1)).0"
+}
+
+# Check for help flags
+if [[ "$1" == "--help" || "$1" == "-h" ]]; then
+    show_help
+    exit 0
+fi
+
+# Check for multiple parameters (only one should be provided)
+if [ $# -gt 2 ]; then
+    echo "Error: Too many parameters provided"
+    echo "Only one option is allowed at a time"
+    echo "Use --help for usage information"
+    exit 1
+fi
+
+# Check for conflicting parameters
+if [ $# -eq 2 ] && [[ "$1" != "--version" ]]; then
+    echo "Error: Invalid parameter combination"
+    echo "Only --version accepts an additional argument"
+    echo "Use --help for usage information"
+    exit 1
+fi
+
+# Determine the version to use
+if [ $# -eq 0 ]; then
+    # Default: increment patch version
+    CURRENT_VERSION=$(get_current_version)
+    VERSION=$(increment_patch "$CURRENT_VERSION")
+    echo "No parameter provided, incrementing patch version from $CURRENT_VERSION to $VERSION"
+elif [[ "$1" == "--patch-version" ]]; then
+    CURRENT_VERSION=$(get_current_version)
+    VERSION=$(increment_patch "$CURRENT_VERSION")
+    echo "Incrementing patch version from $CURRENT_VERSION to $VERSION"
+elif [[ "$1" == "--minor-version" ]]; then
+    CURRENT_VERSION=$(get_current_version)
+    VERSION=$(increment_minor "$CURRENT_VERSION")
+    echo "Incrementing minor version from $CURRENT_VERSION to $VERSION"
+elif [[ "$1" == "--version" ]]; then
+    if [ $# -ne 2 ]; then
+        echo "Error: --version requires a version number"
+        echo "Example: ./update_version.sh --version 1.53.0"
+        exit 1
+    fi
+    VERSION="$2"
+    echo "Setting version to: $VERSION"
+else
+    echo "Error: Unknown parameter '$1'"
+    echo "Use --help for usage information"
+    exit 1
+fi
+
+# Validate version format (basic check for semantic versioning)
+if [[ ! $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: Version '$VERSION' doesn't follow semantic versioning (x.y.z)"
+    exit 1
+fi
+
+echo "Updating version to: $VERSION"
+
+# Update skin.conf
+echo "Updating skins/neowx-material/skin.conf..."
+if [ -f "skins/neowx-material/skin.conf" ]; then
+    sed -i '' "s/version = .*/version = $VERSION/" skins/neowx-material/skin.conf
+    echo "✓ Updated skin.conf"
+else
+    echo "✗ Error: skins/neowx-material/skin.conf not found"
+    exit 1
+fi
+
+# Update install.py
+echo "Updating install.py..."
+if [ -f "install.py" ]; then
+    sed -i '' "s/version=\"[^\"]*\"/version=\"$VERSION\"/" install.py
+    echo "✓ Updated install.py"
+else
+    echo "✗ Error: install.py not found"
+    exit 1
+fi
+
+# Update package.json
+echo "Updating skins/neowx-material/package.json..."
+if [ -f "skins/neowx-material/package.json" ]; then
+    sed -i '' "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" skins/neowx-material/package.json
+    echo "✓ Updated package.json"
+else
+    echo "✗ Error: skins/neowx-material/package.json not found"
+    exit 1
+fi
+
+# Change to the skins/neowx-material directory for running commands
+cd skins/neowx-material || {
+    echo "✗ Error: Could not change to skins/neowx-material directory"
+    exit 1
+}
+
+# Run npm install
+echo "Running npm install..."
+if npm install; then
+    echo "✓ npm install completed successfully"
+else
+    echo "✗ Error: npm install failed"
+    exit 1
+fi
+
+# Run yarn run build
+echo "Running yarn run build..."
+if yarn run build; then
+    echo "✓ yarn run build completed successfully"
+else
+    echo "✗ Error: yarn run build failed"
+    exit 1
+fi
+
+echo ""
+echo "🎉 Version update completed successfully!"
+if [[ -n "$CURRENT_VERSION" ]]; then
+    echo "Previous version: $CURRENT_VERSION"
+fi
+echo "New version: $VERSION"
+echo "Updated files:"
+echo "  - skins/neowx-material/skin.conf"
+echo "  - install.py"
+echo "  - skins/neowx-material/package.json"
+echo ""
+echo "Build commands executed:"
+echo "  - npm install"
+echo "  - yarn run build"


### PR DESCRIPTION
This pull request introduces a new automatic update notification feature to the NeoWX Material skin, allowing users to be informed when a new version is available. It also adds configuration options for update checking, updates the skin version, and integrates the update check logic into the template engine.

<img width="974" height="124" alt="image" src="https://github.com/user-attachments/assets/cd44372b-c313-4280-bc04-fb08cf851f05" />

To perform update check a internet connection is required, if you installation do not have internet connection
please disable the features

Configuration:
in skin.conf footer section
```
    [[Footer]]
        # Update check modes:
        # Internet connection is requiered for this feature
        # off - No update checking performed
        # minor - Only show notifications for minor version updates (e.g., 1.50.x -> 1.51.x)
        # patch - Show notifications for all version updates including patches (e.g., 1.51.1 -> 1.51.2)
        update_check = minor

        # Update check interval in minutes (default 1440 = 24 hours = 1 day)
        update_interval = 1440

        # URL to check for the latest version (usually no need to change this)
        update_check_url = https://raw.githubusercontent.com/seehase/neowx-material/master/skins/neowx-material/skin.conf
```
