### PR TITLE
Fix config_patcher to add root level blocks

### DIFF
--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class BasicInstaller(ExtensionInstaller):
     def __init__(self):
         super(BasicInstaller, self).__init__(
-            version="1.52.21",
+            version="1.52.23",
             name="neowx-material",
             description="The most versatile and modern weewx skin",
             author="Neoground GmbH",

--- a/skins/neowx-material/package-lock.json
+++ b/skins/neowx-material/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neowx-material",
-  "version": "1.52.21",
+  "version": "1.52.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neowx-material",
-      "version": "1.52.21",
+      "version": "1.52.23",
       "license": "MIT",
       "dependencies": {
         "sass": "^1.94.2"

--- a/skins/neowx-material/package.json
+++ b/skins/neowx-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neowx-material",
-  "version": "1.52.21",
+  "version": "1.52.23",
   "description": "The most versatile and modern weewx skin",
   "main": "index.js",
   "repository": "https://github.com/neoground/neowx-material",

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -39,7 +39,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
 
-    version = 1.52.22
+    version = 1.52.23
 
     # Language
     # -------------------------------------------------------------------------


### PR DESCRIPTION
In your patchflie you can now add new root blocks like

```
[Labels]
    [[Generic]]
        extraTemp1 = Wintergarden Temperature
        extraHumid1 = Wintergarden Humidity
        extraTemp2 = Outdoor2 Temperature
        extraHumid2 = Outdoor2 Humidity
        extraTemp3 = Cellar Temperature
        extraHumid3 = Cellar Humidity
```

so after patch is applied the new block will appear in your skin.conf