### PR TITLE
Apexcharts toolbar: enable pan as default

### DIFF
--- a/skins/neowx-material/js.inc
+++ b/skins/neowx-material/js.inc
@@ -85,7 +85,7 @@
                 allowMouseWheelZoom: $allowMouseWheelZoom,
             },
             toolbar: {
-                autoSelected: 'zoom',
+                autoSelected: 'pan',
                 export: {
                     csv: {
                         headerCategory: 'DateTime',


### PR DESCRIPTION
The default zoom setting is problematic when scrolling on mobile devices.