### PR TITLE
feat: Add Online indicator and show offline state only on current page

### DIFF
--- a/bin/user/onlinecheck.py
+++ b/bin/user/onlinecheck.py
@@ -1,0 +1,150 @@
+#
+# Copyright (c) 2025 OnlineCheck Extension for NeoWX Material
+#
+# Distributed under the terms of the GNU GENERAL PUBLIC LICENSE
+#
+
+"""Provides a simple online/offline check for weewx skins.
+
+To use, add the following to the [CheetahGenerator] section of skin.conf:
+
+[CheetahGenerator]
+    search_list_extensions = user.onlinecheck.OnlineCheck
+
+Then, in your template, you can get the status like this:
+
+#set $online_check = $onlinecheck.get_status()
+#if $online_check.offline
+    ... we are offline ...
+#end if
+
+Configuration options can be placed in an [[OnlineCheck]] section:
+
+[[OnlineCheck]]
+    # URL to check for connectivity. Default: http://www.google.com
+    check_url = http://www.google.com
+
+    # Timeout for the check in seconds. Default: 10
+    timeout = 10
+
+    # Interval for the check in minutes. Default: 3
+    interval = 3
+
+    # Always show online status icon. Default: false
+    always_show_status = false
+"""
+
+import time
+import urllib.request
+import urllib.error
+import logging
+
+try:
+    # weewx-specific imports
+    from weewx.cheetahgenerator import SearchList
+except ImportError:
+    # Fallback for running outside of weewx
+    SearchList = object
+
+VERSION = "1.0.7"
+
+log = logging.getLogger(__name__)
+
+# Global cache for online status
+_online_cache = {
+    "last_check": 0,
+    "data": None,
+}
+
+class OnlineCheck(SearchList):
+    """
+    SearchList extension that provides an online status check.
+    """
+    def __init__(self, generator):
+        self.skin_dict = generator.skin_dict
+        self.generator = generator
+
+        # Get config from skin.conf, with defaults
+        self.config = self.skin_dict.get('Extras', {}).get('OnlineCheck', {})
+        self.check_url = self.config.get('check_url', 'http://www.google.com')
+        self.timeout = int(self.config.get('timeout', 10))
+        self.cache_duration = int(self.config.get('interval', 5)) * 60  # in seconds
+
+        # Determine if an online check is needed
+        self.perform_check = self._is_check_required()
+
+        log.info("OnlineCheck version %s", VERSION)
+        if self.perform_check:
+            log.info("Initialized OnlineCheck: URL='%s', Timeout=%ds, Interval=%dmin",
+                     self.check_url, self.timeout, self.cache_duration / 60)
+        else:
+            log.info("OnlineCheck: No online features enabled, check is disabled.")
+
+    def get_extension_list(self, timespan, db_lookup):
+        """
+        Returns a search list extension with the online check object.
+        """
+        return [{'onlinecheck': self}]
+
+    def finalize(self):
+        """
+        Called at the end of the generation process.
+        """
+        pass
+
+    def _is_check_required(self):
+        """
+        Checks if either update check or forecast is enabled.
+        """
+        # Check for update check setting
+        update_check_mode = self.skin_dict.get('Extras', {}).get('Footer', {}).get('update_check', 'off')
+        if update_check_mode != 'off':
+            return True
+
+        # Check if forecast is in search_list_extensions
+        search_list = self.generator.config_dict.get('CheetahGenerator', {}).get('search_list_extensions', '')
+        if 'user.openmeteo.Forecast' in search_list:
+            return True
+
+        return False
+
+    def get_status(self):
+        """
+        Performs the online check and returns a dictionary with the status.
+        Caches the result to avoid frequent checks.
+        """
+        global _online_cache
+
+        # If no online features are enabled, return a default online status
+        if not self.perform_check:
+            return {'offline': False}
+
+        current_time = time.time()
+
+        # Check cache first
+        if (current_time - _online_cache["last_check"]) < self.cache_duration and _online_cache["data"] is not None:
+            log.debug("OnlineCheck: Using cached online status.")
+            return _online_cache["data"]
+
+        # If cache is stale, perform the check
+        offline_status = False
+        try:
+            log.debug("OnlineCheck: Performing online check using URL: %s", self.check_url)
+            # A HEAD request is more lightweight than GET
+            request = urllib.request.Request(self.check_url, method='HEAD')
+            with urllib.request.urlopen(request, timeout=self.timeout):
+                # Any successful response means we are online
+                pass
+            log.debug("OnlineCheck: Check successful.")
+        except (urllib.error.URLError, OSError) as e:
+            log.info("OnlineCheck: Check failed, assuming offline. Error: %s", e)
+            offline_status = True
+
+        result = {'offline': offline_status}
+
+        # Update cache
+        _online_cache["last_check"] = current_time
+        _online_cache["data"] = result
+
+        log.debug("OnlineCheck: result: %s", result)
+        return result

--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class BasicInstaller(ExtensionInstaller):
     def __init__(self):
         super(BasicInstaller, self).__init__(
-            version="1.53.28",
+            version="1.54.0",
             name="neowx-material",
             description="The most versatile and modern weewx skin",
             author="Neoweewx",
@@ -396,6 +396,6 @@ class BasicInstaller(ExtensionInstaller):
                         "skins/neowx-material/config_patcher.py",
                     ],
                 ),
-                ("bin/user", ["bin/user/historygenerator.py", "bin/user/openmeteo.py", "bin/user/updatecheck.py"]),
+                ("bin/user", ["bin/user/historygenerator.py", "bin/user/openmeteo.py", "bin/user/updatecheck.py", "bin/user/onlinecheck.py"]),
             ],
         )

--- a/skins/neowx-material/footer.inc
+++ b/skins/neowx-material/footer.inc
@@ -146,7 +146,7 @@
         ## Update notification
         #if $update_check and $update_check.available
             <div class="alert alert-info alert-dismissible fade show mx-3 my-2" role="alert">
-                <i class="fas fa-info-circle"></i>
+                <span class="mdi mdi-information-outline"></span>
                 $gettext("update_available")
                 <strong>v$update_check.latest_version</strong>
                 ($gettext("current"): v$update_check.current_version)

--- a/skins/neowx-material/head.inc
+++ b/skins/neowx-material/head.inc
@@ -79,8 +79,8 @@
 <link rel="stylesheet" href="weather-icons/css/weather-icons.min.css">
 <link rel="stylesheet" href="weather-icons/css/weather-icons-wind.min.css">
 
-## Font Awesome
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+## Material Design Icons
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@7.4.47/css/materialdesignicons.min.css">
 
 ## ApexChart stylesheet
 <link rel="stylesheet" href="js/vendor/apexcharts/apexcharts.css">

--- a/skins/neowx-material/header.inc
+++ b/skins/neowx-material/header.inc
@@ -33,7 +33,23 @@
                         <span class="font-small datetime-header" id="current-datetime" data-timestamp="$current.dateTime.raw">$current.dateTime.format($datetime_format)</span>
                         #if ($Extras.MQTT.enabled == "true" or $Extras.MQTT.enabled == True) and $active_nav == 'current'
                             <span id="mqtt-status" class="font-small datetime-header" style="margin-left: 1px; display: inline-block;">
-                                <i id="mqtt-indicator" class="fas fa-share-nodes" data-toggle="tooltip" data-placement="bottom" style="vertical-align: middle;" title=""></i>
+                                <span id="mqtt-indicator" class="mdi mdi-resistor-nodes" data-toggle="tooltip" data-placement="bottom" style="vertical-align: middle;" title=""></span>
+                            </span>
+                        #end if
+                        #if $varExists('onlinecheck')
+                            #set $online_check = $onlinecheck.get_status()
+                        #else
+                            #set $online_check = {'offline': False}
+                        #end if
+                        #if $online_check.offline
+                            <!-- Show wifi slash icon if online check is offline -->
+                            <span id="online-status" class="font-small datetime-header" style="margin-left: 1px; display: inline-block;">
+                                <span class="mdi mdi-wifi-strength-alert-outline" data-toggle="tooltip" data-placement="bottom" style="vertical-align: middle;" title="$gettext('System is offline')"></span>
+                            </span>
+                        #elif $Extras.OnlineCheck.get('always_show_status', False)
+                            <!-- Show online status if enabled -->
+                            <span id="online-status" class="font-small datetime-header" style="margin-left: 1px; display: inline-block;">
+                                <span class="mdi mdi-wifi" data-toggle="tooltip" data-placement="bottom" style="vertical-align: middle;" title="$gettext('System is online')"></span>
                             </span>
                         #end if
                     #end if

--- a/skins/neowx-material/js.inc
+++ b/skins/neowx-material/js.inc
@@ -23,11 +23,11 @@
 
 <script type="text/javascript">
     // Show/update status label only if configured threshold > 0 in skin.conf
-    const isArchivePage = "$active_nav" === "archive"; // do not show status on archive page
-    if (!isArchivePage && $Extras.Header.offline_threshold_minutes > 0) {
+    const showOfflineLabel = "$active_nav" === "current"; // Show offline-state only on current page
+    if (showOfflineLabel && $Extras.Header.offline_threshold_minutes > 0) {
         let lastUpdateTimestampString = '$current.dateTime.raw';
         if (lastUpdateTimestampString === "" ) {
-            lastUpdateTimestampString = "4891363200"; // Fallback to 2125 if not available
+            lastUpdateTimestampString = "4891363200"; // Fallback to 01.01.2125 if not available
         }
         const lastUpdateTimestamp =  Number(lastUpdateTimestampString) ;  // in seconds
         const nowTimestamp = new Date() / 1000;             // now in seconds

--- a/skins/neowx-material/package-lock.json
+++ b/skins/neowx-material/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neowx-material",
-  "version": "1.53.28",
+  "version": "1.54.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neowx-material",
-      "version": "1.53.28",
+      "version": "1.54.0",
       "license": "MIT",
       "dependencies": {
         "sass": "1.99.0"

--- a/skins/neowx-material/package.json
+++ b/skins/neowx-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neowx-material",
-  "version": "1.53.28",
+  "version": "1.54.0",
   "description": "The most versatile and modern weewx skin",
   "main": "index.js",
   "repository": "https://github.com/neoground/neowx-material",

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -18,7 +18,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
 
-    version = 1.53.28
+    version = 1.54.0
 
     # Language
     # -------------------------------------------------------------------------
@@ -207,11 +207,26 @@
         # URL to check for the latest version (usually no need to change this)
         update_check_url = https://raw.githubusercontent.com/seehase/neowx-material/master/skins/neowx-material/skin.conf
 
+    # OnlineCheck
+    # -------------------------------------------------------------------------
+    #
+    [[OnlineCheck]]
+        # URL to check for connectivity. Default: http://www.google.com
+        check_url = http://www.google.com
+
+        # Timeout for the check in seconds. Default: 10
+        timeout = 10
+
+        # Interval for the check in minutes. Default: 3
+        interval = 3
+
+        # Always show online status icon. Default: false
+        always_show_status = false
+
     # Date and time formatting
     # -------------------------------------------------------------------------
     #
     [[Formatting]]
-
         # Datetime format (strftime) for $current.dateTime
         # This format is used for:
         #   1. Static page rendering in header.inc
@@ -430,24 +445,6 @@
         # Height of charts in px
         height = 300
 
-        # Custom chart titles
-        # Here you can override the default title of a chart.
-        # By default it's the label name of the first data of a chart.
-        # Key is always the name of the chart.
-        # Just uncomment this and add charts to this list.
-        #
-        #[[[Titles]]]
-        #    outTemp = "Outside Temperatures"
-        #    windchill = "Apparent Temperatures"
-        # Translations
-        # Feel free to add your own or adjust the values.
-        # We robots sometimes no good at translating. Beep Boop.
-        #
-        # Do your translation in the corresponing .conf file in the /lang directory
-        #    [[Translations]]
-        #
-        #        [[[<country>]]]
-
         # Stroke settings
         # ---------------------------------------------------------------------
         #
@@ -501,6 +498,25 @@
         year_rain_timespan = 604800
         year_ET_timespan = 86400
         year_windrun_timespan = 86400
+
+        # Custom chart titles
+        # Here you can override the default title of a chart.
+        # By default it's the label name of the first data of a chart.
+        # Key is always the name of the chart.
+        # Just uncomment this and add charts to this list.
+        #
+        #   [[[Titles]]]
+        #       outTemp = "Outside Temperatures"
+        #       windchill = "Apparent Temperatures"
+        #
+        # Translations
+        # Feel free to add your own or adjust the values.
+        # We robots sometimes no good at translating. Beep Boop.
+        #
+        # Do your translation in the corresponing .conf file in the /lang directory
+        #    [[Translations]]
+        #
+        #        [[[<country>]]]
 
     [[MQTT]]
         # Enable/Disable MQTT functionality (default: false)
@@ -602,7 +618,7 @@
 # -------------------------------------------------------------------------
 #
 [CheetahGenerator]
-    search_list_extensions = user.historygenerator.MyXSearch, user.openmeteo.Forecast, user.updatecheck.UpdateCheck
+    search_list_extensions = user.historygenerator.MyXSearch, user.openmeteo.Forecast, user.updatecheck.UpdateCheck, user.onlinecheck.OnlineCheck
 
     # Possible encodings are 'html_entities', 'utf8', or 'strict_ascii'
     encoding = utf8


### PR DESCRIPTION
Show online/offline indicator on current page, if weewx is configured to use internet connection e.g. update-check or forcast

by default it only shows if weewx service is running without internet connection but it can be configured to show online and offline internet status

<img width="273" height="73" alt="image" src="https://github.com/user-attachments/assets/db5ca459-047d-4148-801d-ab7a0d3c3734" />


```
    # OnlineCheck
    # -------------------------------------------------------------------------
    #
    [[OnlineCheck]]
        # URL to check for connectivity. Default: http://www.google.com
        check_url = http://www.google.com

        # Timeout for the check in seconds. Default: 10
        timeout = 10

        # Interval for the check in minutes. Default: 3
        interval = 3

        # Always show online status icon. Default: false
        always_show_status = false
```
Also improved offline status (when html pages are not updated
<img width="1035" height="86" alt="image" src="https://github.com/user-attachments/assets/5d4b4558-5276-42ad-94e1-db012bbb8af3" />

This status is now only shown on the "current" page, because other pages could be updated only once per day 

so this PR solves
https://github.com/seehase/neowx-material/issues/290
https://github.com/seehase/neowx-material/issues/299
https://github.com/seehase/neowx-material/issues/300

I also switched from 
Font Awesome (https://fontawesome.com/)
to 
Material Design Icons (https://pictogrammers.com/library/mdi/)
due to missing icons and needed pro version
https://pictogrammers.com/library/mdi/ is open source