### PR TITLE
feat: Support for additional soil sensors (up to 8 sensors)

### DIFF
--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class BasicInstaller(ExtensionInstaller):
     def __init__(self):
         super(BasicInstaller, self).__init__(
-            version="1.54.0",
+            version="1.55.0",
             name="neowx-material",
             description="The most versatile and modern weewx skin",
             author="Neoweewx",

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -476,9 +476,13 @@
         ## | string  $column   the column of the display value  (e.g. min, max, avg) |
         ## | string  $series3  opt. field name for 3rd series   (e.g. outTemp or "") |
         ## | string  $series4  opt. field name for 4th series   (e.g. outTemp or "") |
+        ## | string  $series5  opt. field name for 5th series   (e.g. outTemp or "") |
+        ## | string  $series6  opt. field name for 6th series   (e.g. outTemp or "") |
+        ## | string  $series7  opt. field name for 7th series   (e.g. outTemp or "") |
+        ## | string  $series8  opt. field name for 8th series   (e.g. outTemp or "") |
         ## +-------------------------------------------------------------------------+
 
-        #def getChartJsCode($name, $id, $type, $series1, $series2 = "", $column = "avg", $series3 = "", $series4 = "")
+        #def getChartJsCode($name, $id, $type, $series1, $series2 = "", $column = "avg", $series3 = "", $series4 = "", $series5 = "", $series6 = "", $series7 = "", $series8 = "")
 
             ## Only add JS chart code if in array
             #if $name in $Extras.Appearance.charts_order
@@ -547,6 +551,30 @@
                                 ,{
                                     name: "$getVar('obs.label.' + series4)",
                                     data: [ $getChartData(series4, column) ]
+                                }
+                            #end if
+                            #if $series5 != "" and $getVar('day.' + series5 + '.has_data')
+                                ,{
+                                    name: "$getVar('obs.label.' + series5)",
+                                    data: [ $getChartData(series5, column) ]
+                                }
+                            #end if
+                            #if $series6 != "" and $getVar('day.' + series6 + '.has_data')
+                                ,{
+                                    name: "$getVar('obs.label.' + series6)",
+                                    data: [ $getChartData(series6, column) ]
+                                }
+                            #end if
+                            #if $series7 != "" and $getVar('day.' + series7 + '.has_data')
+                                ,{
+                                    name: "$getVar('obs.label.' + series7)",
+                                    data: [ $getChartData(series7, column) ]
+                                }
+                            #end if
+                            #if $series8 != "" and $getVar('day.' + series8 + '.has_data')
+                                ,{
+                                    name: "$getVar('obs.label.' + series8)",
+                                    data: [ $getChartData(series8, column) ]
                                 }
                             #end if
                         ]
@@ -650,12 +678,12 @@
                 $getChartJsCode("leafTemp1", "leafTempchart", "area", "leafTemp1", "leafTemp2", "avg")
             #end if
 
-            #if $day.soilTemp1.has_data or $day.soilTemp2.has_data or $day.soilTemp3.has_data or $day.soilTemp4.has_data
-                $getChartJsCode("soilTemp1", "soilTemp1chart", "area", "soilTemp1", "soilTemp2", "avg", "soilTemp3", "soilTemp4")
+            #if $day.soilTemp1.has_data or $day.soilTemp2.has_data or $day.soilTemp3.has_data or $day.soilTemp4.has_data or $day.soilTemp5.has_data or $day.soilTemp6.has_data or $day.soilTemp7.has_data or $day.soilTemp8.has_data
+                $getChartJsCode("soilTemp1", "soilTemp1chart", "area", "soilTemp1", "soilTemp2", "avg", "soilTemp3", "soilTemp4", "soilTemp5", "soilTemp6", "soilTemp7", "soilTemp8")
             #end if
 
-            #if $day.soilMoist1.has_data or $day.soilMoist2.has_data or $day.soilMoist3.has_data or $day.soilMoist4.has_data
-                $getChartJsCode("soilMoist1", "soilMoist1chart", "area", "soilMoist1", "soilMoist2", "avg", "soilMoist3", "soilMoist4")
+            #if $day.soilMoist1.has_data or $day.soilMoist2.has_data or $day.soilMoist3.has_data or $day.soilMoist4.has_data or $day.soilMoist5.has_data or $day.soilMoist6.has_data or $day.soilMoist7.has_data or $day.soilMoist8.has_data
+                $getChartJsCode("soilMoist1", "soilMoist1chart", "area", "soilMoist1", "soilMoist2", "avg", "soilMoist3", "soilMoist4", "soilMoist5", "soilMoist6", "soilMoist7", "soilMoist8")
             #end if
 
             #if $day.cloudbase.has_data

--- a/skins/neowx-material/month-%Y-%m.html.tmpl
+++ b/skins/neowx-material/month-%Y-%m.html.tmpl
@@ -320,9 +320,13 @@
         ## | string  $column   the column of the display value  (e.g. min, max, avg) |
         ## | string  $series3  opt. field name for 3rd series   (e.g. outTemp or "") |
         ## | string  $series4  opt. field name for 4th series   (e.g. outTemp or "") |
+        ## | string  $series5  opt. field name for 5th series   (e.g. outTemp or "") |
+        ## | string  $series6  opt. field name for 6th series   (e.g. outTemp or "") |
+        ## | string  $series7  opt. field name for 7th series   (e.g. outTemp or "") |
+        ## | string  $series8  opt. field name for 8th series   (e.g. outTemp or "") |
         ## +-------------------------------------------------------------------------+
 
-        #def getChartJsCode($name, $id, $type, $series1, $series2 = "", $column = "avg", $series3 = "", $series4 = "")
+        #def getChartJsCode($name, $id, $type, $series1, $series2 = "", $column = "avg", $series3 = "", $series4 = "", $series5 = "", $series6 = "", $series7 = "", $series8 = "")
 
             ## Only add JS chart code if in array
             #if $name in $Extras.Appearance.charts_order
@@ -367,6 +371,30 @@
                                     ,{
                                         name: "$getVar('obs.label.' + series4)",
                                         data: [ $getChartData(series4, column) ]
+                                    }
+                                #end if
+                                #if $series5 != "" and $getVar('day.' + series5 + '.has_data')
+                                    ,{
+                                        name: "$getVar('obs.label.' + series5)",
+                                        data: [ $getChartData(series5, column) ]
+                                    }
+                                #end if
+                                #if $series6 != "" and $getVar('day.' + series6 + '.has_data')
+                                    ,{
+                                        name: "$getVar('obs.label.' + series6)",
+                                        data: [ $getChartData(series6, column) ]
+                                    }
+                                #end if
+                                #if $series7 != "" and $getVar('day.' + series7 + '.has_data')
+                                    ,{
+                                        name: "$getVar('obs.label.' + series7)",
+                                        data: [ $getChartData(series7, column) ]
+                                    }
+                                #end if
+                                #if $series8 != "" and $getVar('day.' + series8 + '.has_data')
+                                    ,{
+                                        name: "$getVar('obs.label.' + series8)",
+                                        data: [ $getChartData(series8, column) ]
                                     }
                                 #end if
                             ]
@@ -547,12 +575,12 @@
                 $getChartJsCode("leafTemp1", "leafTemp1chart", "area", "leafTemp1", "leafTemp2", "avg")
             #end if
 
-            #if $month.soilTemp1.has_data or $month.soilTemp2.has_data or $month.soilTemp3.has_data or $month.soilTemp4.has_data
-                $getChartJsCode("soilTemp1", "soilTemp1chart", "area", "soilTemp1", "soilTemp2", "avg", "soilTemp3", "soilTemp4")
+            #if $day.soilTemp1.has_data or $day.soilTemp2.has_data or $day.soilTemp3.has_data or $day.soilTemp4.has_data or $day.soilTemp5.has_data or $day.soilTemp6.has_data or $day.soilTemp7.has_data or $day.soilTemp8.has_data
+                $getChartJsCode("soilTemp1", "soilTemp1chart", "area", "soilTemp1", "soilTemp2", "avg", "soilTemp3", "soilTemp4", "soilTemp5", "soilTemp6", "soilTemp7", "soilTemp8")
             #end if
 
-            #if $month.soilMoist1.has_data or $month.soilMoist2.has_data or $month.soilMoist3.has_data or $month.soilMoist4.has_data
-                $getChartJsCode("soilMoist1", "soilMoist1chart", "area", "soilMoist1", "soilMoist2", "avg", "soilMoist3", "soilMoist4")
+            #if $day.soilMoist1.has_data or $day.soilMoist2.has_data or $day.soilMoist3.has_data or $day.soilMoist4.has_data or $day.soilMoist5.has_data or $day.soilMoist6.has_data or $day.soilMoist7.has_data or $day.soilMoist8.has_data
+                $getChartJsCode("soilMoist1", "soilMoist1chart", "area", "soilMoist1", "soilMoist2", "avg", "soilMoist3", "soilMoist4", "soilMoist5", "soilMoist6", "soilMoist7", "soilMoist8")
             #end if
 
             #if $month.cloudbase.has_data

--- a/skins/neowx-material/month.html.tmpl
+++ b/skins/neowx-material/month.html.tmpl
@@ -327,9 +327,13 @@
         ## | string  $column   the column of the display value  (e.g. min, max, avg) |
         ## | string  $series3  opt. field name for 3rd series   (e.g. outTemp or "") |
         ## | string  $series4  opt. field name for 4th series   (e.g. outTemp or "") |
+        ## | string  $series5  opt. field name for 5th series   (e.g. outTemp or "") |
+        ## | string  $series6  opt. field name for 6th series   (e.g. outTemp or "") |
+        ## | string  $series7  opt. field name for 7th series   (e.g. outTemp or "") |
+        ## | string  $series8  opt. field name for 8th series   (e.g. outTemp or "") |
         ## +-------------------------------------------------------------------------+
 
-        #def getChartJsCode($name, $id, $type, $series1, $series2 = "", $column = "avg", $series3 = "", $series4 = "")
+        #def getChartJsCode($name, $id, $type, $series1, $series2 = "", $column = "avg", $series3 = "", $series4 = "", $series5 = "", $series6 = "", $series7 = "", $series8 = "")
 
             ## Only add JS chart code if in array
             #if $name in $Extras.Appearance.charts_order
@@ -398,6 +402,30 @@
                                 ,{
                                     name: "$getVar('obs.label.' + series4)",
                                     data: [ $getChartData(series4, column) ]
+                                }
+                            #end if
+                            #if $series5 != "" and $getVar('day.' + series5 + '.has_data')
+                                ,{
+                                    name: "$getVar('obs.label.' + series5)",
+                                    data: [ $getChartData(series5, column) ]
+                                }
+                            #end if
+                            #if $series6 != "" and $getVar('day.' + series6 + '.has_data')
+                                ,{
+                                    name: "$getVar('obs.label.' + series6)",
+                                    data: [ $getChartData(series6, column) ]
+                                }
+                            #end if
+                            #if $series7 != "" and $getVar('day.' + series7 + '.has_data')
+                                ,{
+                                    name: "$getVar('obs.label.' + series7)",
+                                    data: [ $getChartData(series7, column) ]
+                                }
+                            #end if
+                            #if $series8 != "" and $getVar('day.' + series8 + '.has_data')
+                                ,{
+                                    name: "$getVar('obs.label.' + series8)",
+                                    data: [ $getChartData(series8, column) ]
                                 }
                             #end if
                         ]
@@ -504,12 +532,12 @@
                 $getChartJsCode("leafTemp1", "leafTemp1chart", "area", "leafTemp1", "leafTemp2", "avg")
             #end if
 
-            #if $month.soilTemp1.has_data or $month.soilTemp2.has_data or $month.soilTemp3.has_data or $month.soilTemp4.has_data
-                $getChartJsCode("soilTemp1", "soilTemp1chart", "area", "soilTemp1", "soilTemp2", "avg", "soilTemp3", "soilTemp4")
+            #if $day.soilTemp1.has_data or $day.soilTemp2.has_data or $day.soilTemp3.has_data or $day.soilTemp4.has_data or $day.soilTemp5.has_data or $day.soilTemp6.has_data or $day.soilTemp7.has_data or $day.soilTemp8.has_data
+                $getChartJsCode("soilTemp1", "soilTemp1chart", "area", "soilTemp1", "soilTemp2", "avg", "soilTemp3", "soilTemp4", "soilTemp5", "soilTemp6", "soilTemp7", "soilTemp8")
             #end if
 
-            #if $month.soilMoist1.has_data or $month.soilMoist2.has_data or $month.soilMoist3.has_data or $month.soilMoist4.has_data
-                $getChartJsCode("soilMoist1", "soilMoist1chart", "area", "soilMoist1", "soilMoist2", "avg", "soilMoist3", "soilMoist4")
+            #if $day.soilMoist1.has_data or $day.soilMoist2.has_data or $day.soilMoist3.has_data or $day.soilMoist4.has_data or $day.soilMoist5.has_data or $day.soilMoist6.has_data or $day.soilMoist7.has_data or $day.soilMoist8.has_data
+                $getChartJsCode("soilMoist1", "soilMoist1chart", "area", "soilMoist1", "soilMoist2", "avg", "soilMoist3", "soilMoist4", "soilMoist5", "soilMoist6", "soilMoist7", "soilMoist8")
             #end if
 
             #if $month.cloudbase.has_data

--- a/skins/neowx-material/package-lock.json
+++ b/skins/neowx-material/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neowx-material",
-  "version": "1.54.0",
+  "version": "1.55.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neowx-material",
-      "version": "1.54.0",
+      "version": "1.55.0",
       "license": "MIT",
       "dependencies": {
         "sass": "1.99.0"

--- a/skins/neowx-material/package.json
+++ b/skins/neowx-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neowx-material",
-  "version": "1.54.0",
+  "version": "1.55.0",
   "description": "The most versatile and modern weewx skin",
   "main": "index.js",
   "repository": "https://github.com/neoground/neowx-material",

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -18,7 +18,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
 
-    version = 1.54.0
+    version = 1.55.0
 
     # Language
     # -------------------------------------------------------------------------
@@ -255,10 +255,10 @@
 
         # The order of values cards (left column)
         # For enabling forecast, add "forecast" without quotes to the list
-        values_order = outTemp, outHumidity, barometer, altimeter, pressure, windSpeed, windrun, rain, snowDepth, dewpoint, windchill, heatindex, inTemp, inHumidity, UV, ET, radiation, appTemp, cloudbase, extraTemp1, extraHumid1, extraTemp2, extraHumid2, extraTemp3, extraHumid3, extraTemp4, extraHumid4, extraTemp5, extraHumid5, extraTemp6, extraHumid6, extraTemp7, extraHumid7, extraTemp8, extraHumid8, lightning_strike_count, lightning_noise_count, lightning_disturber_count, lightning_distance, lightning_energy, pm2_5, co2, temperatureThresholdDays
+        values_order = soilMoist1, soilMoist2, soilMoist3, soilMoist4,soilMoist5, soilMoist6, outTemp, outHumidity, barometer, altimeter, pressure, windSpeed, windrun, rain, snowDepth, dewpoint, windchill, heatindex, inTemp, inHumidity, UV, ET, radiation, appTemp, cloudbase, extraTemp1, extraHumid1, extraTemp2, extraHumid2, extraTemp3, extraHumid3, extraTemp4, extraHumid4, extraTemp5, extraHumid5, extraTemp6, extraHumid6, extraTemp7, extraHumid7, extraTemp8, extraHumid8, soilMoist1, soilMoist2, soilMoist3, soilMoist4, soilMoist5, soilMoist6, soilMoist7, soilMoist8, soilTemp1, soilTemp2, soilTemp3, soilTemp4, soilTemp5, soilTemp6, soilTemp7, soilTemp8, lightning_strike_count, lightning_noise_count, lightning_disturber_count, lightning_distance, lightning_energy, pm2_5, co2, temperatureThresholdDays
 
         # The order of chart cards (right column)
-        charts_order = outTemp, windchill, barometer, altimeter, pressure, rain, snowDepth, windSpeed, windrun, windDir, windvec, UV, ET, radiation, outHumidity, inTemp, inHumidity, appTemp, cloudbase, extraTemp1, extraHumid1, extraTemp2, extraHumid2, extraTemp3, extraHumid3, extraTemp4, extraHumid4, extraTemp5, extraHumid5, extraTemp6, extraHumid6, extraTemp7, extraHumid7, extraTemp8, extraHumid8, lightning_strike_count, lightning_noise_count, lightning_disturber_count, lightning_distance, lightning_energy, pm2_5, co2
+        charts_order = outTemp, windchill, barometer, altimeter, pressure, rain, snowDepth, windSpeed, windrun, windDir, windvec, UV, ET, radiation, outHumidity, inTemp, inHumidity, appTemp, cloudbase, extraTemp1, extraHumid1, extraTemp2, extraHumid2, extraTemp3, extraHumid3, extraTemp4, extraHumid4, extraTemp5, extraHumid5, extraTemp6, extraHumid6, extraTemp7, extraHumid7, extraTemp8, extraHumid8, soilMoist1, soilTemp1, lightning_strike_count, lightning_noise_count, lightning_disturber_count, lightning_distance, lightning_energy, pm2_5, co2
 
         # For enabling embedded iframes or images add their names to the list below
         # The names must match the ones defined in the [[Embedded]] section below
@@ -614,9 +614,11 @@
             inDewpoint = "inDewpoint_C", "°C", 1
             humidex = "humidex_C", "°C", 1
 
+
 # Cheetah templating engine configuration
 # -------------------------------------------------------------------------
 #
+
 [CheetahGenerator]
     search_list_extensions = user.historygenerator.MyXSearch, user.openmeteo.Forecast, user.updatecheck.UpdateCheck, user.onlinecheck.OnlineCheck
 
@@ -635,6 +637,7 @@
     [[SummaryByYear]]
         # Reports which summarize by year
         [[[year_summary]]]
+            stale_age = 86400
             template = year-%Y.html.tmpl
 
         [[[year_NOAA]]]
@@ -656,6 +659,7 @@
             template = month.html.tmpl
 
         [[[year]]]
+            stale_age = 86400
             template = year.html.tmpl
 
         [[[archive]]]
@@ -813,3 +817,11 @@
 #
 [Generators]
     generator_list = weewx.cheetahgenerator.CheetahGenerator, weewx.reportengine.CopyGenerator
+
+
+[Labels]
+    [[Generic]]
+        # Here you can override any label in the skin by defining it here with the same name as in the template files.
+        # For example, to change the label of the outside temperature card, you can add:
+        # outTemp = "Outside Temperature"
+        unused = unused

--- a/skins/neowx-material/week.html.tmpl
+++ b/skins/neowx-material/week.html.tmpl
@@ -245,9 +245,13 @@
         ## | string  $column   the column of the display value  (e.g. min, max, avg) |
         ## | string  $series3  opt. field name for 3rd series   (e.g. outTemp or "") |
         ## | string  $series4  opt. field name for 4th series   (e.g. outTemp or "") |
+        ## | string  $series5  opt. field name for 5th series   (e.g. outTemp or "") |
+        ## | string  $series6  opt. field name for 6th series   (e.g. outTemp or "") |
+        ## | string  $series7  opt. field name for 7th series   (e.g. outTemp or "") |
+        ## | string  $series8  opt. field name for 8th series   (e.g. outTemp or "") |
         ## +-------------------------------------------------------------------------+
 
-        #def getChartJsCode($name, $id, $type, $series1, $series2 = "", $column = "avg", $series3 = "", $series4 = "")
+        #def getChartJsCode($name, $id, $type, $series1, $series2 = "", $column = "avg", $series3 = "", $series4 = "", $series5 = "", $series6 = "", $series7 = "", $series8 = "")
 
             ## Only add JS chart code if in array
             #if $name in $Extras.Appearance.charts_order
@@ -316,6 +320,30 @@
                                 ,{
                                     name: "$getVar('obs.label.' + series4)",
                                     data: [ $getChartData(series4, column) ]
+                                }
+                            #end if
+                            #if $series5 != "" and $getVar('day.' + series5 + '.has_data')
+                                ,{
+                                    name: "$getVar('obs.label.' + series5)",
+                                    data: [ $getChartData(series5, column) ]
+                                }
+                            #end if
+                            #if $series6 != "" and $getVar('day.' + series6 + '.has_data')
+                                ,{
+                                    name: "$getVar('obs.label.' + series6)",
+                                    data: [ $getChartData(series6, column) ]
+                                }
+                            #end if
+                            #if $series7 != "" and $getVar('day.' + series7 + '.has_data')
+                                ,{
+                                    name: "$getVar('obs.label.' + series7)",
+                                    data: [ $getChartData(series7, column) ]
+                                }
+                            #end if
+                            #if $series8 != "" and $getVar('day.' + series8 + '.has_data')
+                                ,{
+                                    name: "$getVar('obs.label.' + series8)",
+                                    data: [ $getChartData(series8, column) ]
                                 }
                             #end if
                         ]
@@ -422,12 +450,12 @@
                 $getChartJsCode("leafTemp", "leafTemp1chart", "area", "leafTemp1", "leafTemp2", "avg")
             #end if
 
-            #if $week.soilTemp1.has_data or $week.soilTemp2.has_data or $week.soilTemp3.has_data or $week.soilTemp4.has_data
-                $getChartJsCode("soilTemp1", "soilTemp1chart", "area", "soilTemp1", "soilTemp2", "avg", "soilTemp3", "soilTemp4")
+            #if $day.soilTemp1.has_data or $day.soilTemp2.has_data or $day.soilTemp3.has_data or $day.soilTemp4.has_data or $day.soilTemp5.has_data or $day.soilTemp6.has_data or $day.soilTemp7.has_data or $day.soilTemp8.has_data
+                $getChartJsCode("soilTemp1", "soilTemp1chart", "area", "soilTemp1", "soilTemp2", "avg", "soilTemp3", "soilTemp4", "soilTemp5", "soilTemp6", "soilTemp7", "soilTemp8")
             #end if
 
-            #if $week.soilMoist1.has_data or $week.soilMoist2.has_data or $week.soilMoist3.has_data or $week.soilMoist4.has_data
-                $getChartJsCode("soilMoist1", "soilMoist1chart", "area", "soilMoist1", "soilMoist2", "avg", "soilMoist3", "soilMoist4")
+            #if $day.soilMoist1.has_data or $day.soilMoist2.has_data or $day.soilMoist3.has_data or $day.soilMoist4.has_data or $day.soilMoist5.has_data or $day.soilMoist6.has_data or $day.soilMoist7.has_data or $day.soilMoist8.has_data
+                $getChartJsCode("soilMoist1", "soilMoist1chart", "area", "soilMoist1", "soilMoist2", "avg", "soilMoist3", "soilMoist4", "soilMoist5", "soilMoist6", "soilMoist7", "soilMoist8")
             #end if
 
             #if $week.cloudbase.has_data

--- a/skins/neowx-material/year-%Y.html.tmpl
+++ b/skins/neowx-material/year-%Y.html.tmpl
@@ -366,9 +366,13 @@
 ## | string  $column   the column of the display value  (e.g. min, max, avg) |
 ## | string  $series3  opt. field name for 3rd series   (e.g. outTemp or "") |
 ## | string  $series4  opt. field name for 4th series   (e.g. outTemp or "") |
+## | string  $series5  opt. field name for 5th series   (e.g. outTemp or "") |
+## | string  $series6  opt. field name for 6th series   (e.g. outTemp or "") |
+## | string  $series7  opt. field name for 7th series   (e.g. outTemp or "") |
+## | string  $series8  opt. field name for 8th series   (e.g. outTemp or "") |
 ## +-------------------------------------------------------------------------+
 
-#def getChartJsCode($name, $id, $type, $series1, $series2 = "", $column = "avg", $series3 = "", $series4 = "")
+#def getChartJsCode($name, $id, $type, $series1, $series2 = "", $column = "avg", $series3 = "", $series4 = "", $series5 = "", $series6 = "", $series7 = "", $series8 = "")
 
     ## Only add JS chart code if in array
     #if $name in $Extras.Appearance.charts_order
@@ -413,6 +417,30 @@
                             ,{
                                 name: "$getVar('obs.label.' + series4)",
                                 data: [ $getChartData(series4, column) ]
+                            }
+                        #end if
+                        #if $series5 != "" and $getVar('day.' + series5 + '.has_data')
+                            ,{
+                                name: "$getVar('obs.label.' + series5)",
+                                data: [ $getChartData(series5, column) ]
+                            }
+                        #end if
+                        #if $series6 != "" and $getVar('day.' + series6 + '.has_data')
+                            ,{
+                                name: "$getVar('obs.label.' + series6)",
+                                data: [ $getChartData(series6, column) ]
+                            }
+                        #end if
+                        #if $series7 != "" and $getVar('day.' + series7 + '.has_data')
+                            ,{
+                                name: "$getVar('obs.label.' + series7)",
+                                data: [ $getChartData(series7, column) ]
+                            }
+                        #end if
+                        #if $series8 != "" and $getVar('day.' + series8 + '.has_data')
+                            ,{
+                                name: "$getVar('obs.label.' + series8)",
+                                data: [ $getChartData(series8, column) ]
                             }
                         #end if
                     ]
@@ -588,12 +616,12 @@
         $getChartJsCode("leafTemp1", "leafTemp1chart", "area", "leafTemp1", "leafTemp2", "avg")
     #end if
 
-    #if $year.soilTemp1.has_data or $year.soilTemp2.has_data or $year.soilTemp3.has_data or $year.soilTemp4.has_data
-        $getChartJsCode("soilTemp1", "soilTemp1chart", "area", "soilTemp1", "soilTemp2", "avg", "soilTemp3", "soilTemp4")
+    #if $day.soilTemp1.has_data or $day.soilTemp2.has_data or $day.soilTemp3.has_data or $day.soilTemp4.has_data or $day.soilTemp5.has_data or $day.soilTemp6.has_data or $day.soilTemp7.has_data or $day.soilTemp8.has_data
+        $getChartJsCode("soilTemp1", "soilTemp1chart", "area", "soilTemp1", "soilTemp2", "avg", "soilTemp3", "soilTemp4", "soilTemp5", "soilTemp6", "soilTemp7", "soilTemp8")
     #end if
 
-    #if $year.soilMoist1.has_data or $year.soilMoist2.has_data or $year.soilMoist3.has_data or $year.soilMoist4.has_data
-        $getChartJsCode("soilMoist1", "soilMoist1chart", "area", "soilMoist1", "soilMoist2", "avg", "soilMoist3", "soilMoist4")
+    #if $day.soilMoist1.has_data or $day.soilMoist2.has_data or $day.soilMoist3.has_data or $day.soilMoist4.has_data or $day.soilMoist5.has_data or $day.soilMoist6.has_data or $day.soilMoist7.has_data or $day.soilMoist8.has_data
+        $getChartJsCode("soilMoist1", "soilMoist1chart", "area", "soilMoist1", "soilMoist2", "avg", "soilMoist3", "soilMoist4", "soilMoist5", "soilMoist6", "soilMoist7", "soilMoist8")
     #end if
 
     #if $year.cloudbase.has_data

--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -326,9 +326,13 @@
         ## | string  $column   the column of the display value  (e.g. min, max, avg) |
         ## | string  $series3  opt. field name for 3rd series   (e.g. outTemp or "") |
         ## | string  $series4  opt. field name for 4th series   (e.g. outTemp or "") |
+        ## | string  $series5  opt. field name for 5th series   (e.g. outTemp or "") |
+        ## | string  $series6  opt. field name for 6th series   (e.g. outTemp or "") |
+        ## | string  $series7  opt. field name for 7th series   (e.g. outTemp or "") |
+        ## | string  $series8  opt. field name for 8th series   (e.g. outTemp or "") |
         ## +-------------------------------------------------------------------------+
 
-        #def getChartJsCode($name, $id, $type, $series1, $series2 = "", $column = "avg", $series3 = "", $series4 = "")
+        #def getChartJsCode($name, $id, $type, $series1, $series2 = "", $column = "avg", $series3 = "", $series4 = "", $series5 = "", $series6 = "", $series7 = "", $series8 = "")
 
             ## Only add JS chart code if in array
             #if $name in $Extras.Appearance.charts_order
@@ -373,6 +377,30 @@
                                     ,{
                                         name: "$getVar('obs.label.' + series4)",
                                         data: [ $getChartData(series4, column) ]
+                                    }
+                                #end if
+                                #if $series5 != "" and $getVar('day.' + series5 + '.has_data')
+                                    ,{
+                                        name: "$getVar('obs.label.' + series5)",
+                                        data: [ $getChartData(series5, column) ]
+                                    }
+                                #end if
+                                #if $series6 != "" and $getVar('day.' + series6 + '.has_data')
+                                    ,{
+                                        name: "$getVar('obs.label.' + series6)",
+                                        data: [ $getChartData(series6, column) ]
+                                    }
+                                #end if
+                                #if $series7 != "" and $getVar('day.' + series7 + '.has_data')
+                                    ,{
+                                        name: "$getVar('obs.label.' + series7)",
+                                        data: [ $getChartData(series7, column) ]
+                                    }
+                                #end if
+                                #if $series8 != "" and $getVar('day.' + series8 + '.has_data')
+                                    ,{
+                                        name: "$getVar('obs.label.' + series8)",
+                                        data: [ $getChartData(series8, column) ]
                                     }
                                 #end if
                             ]
@@ -553,12 +581,12 @@
                 $getChartJsCode("leafTemp1", "leafTemp1chart", "area", "leafTemp1", "leafTemp2", "avg")
             #end if
 
-            #if $year.soilTemp1.has_data or $year.soilTemp2.has_data or $year.soilTemp3.has_data or $year.soilTemp4.has_data
-                $getChartJsCode("soilTemp1", "soilTemp1chart", "area", "soilTemp1", "soilTemp2", "avg", "soilTemp3", "soilTemp4")
+            #if $day.soilTemp1.has_data or $day.soilTemp2.has_data or $day.soilTemp3.has_data or $day.soilTemp4.has_data or $day.soilTemp5.has_data or $day.soilTemp6.has_data or $day.soilTemp7.has_data or $day.soilTemp8.has_data
+                $getChartJsCode("soilTemp1", "soilTemp1chart", "area", "soilTemp1", "soilTemp2", "avg", "soilTemp3", "soilTemp4", "soilTemp5", "soilTemp6", "soilTemp7", "soilTemp8")
             #end if
 
-            #if $year.soilMoist1.has_data or $year.soilMoist2.has_data or $year.soilMoist3.has_data or $year.soilMoist4.has_data
-                $getChartJsCode("soilMoist1", "soilMoist1chart", "area", "soilMoist1", "soilMoist2", "avg", "soilMoist3", "soilMoist4")
+            #if $day.soilMoist1.has_data or $day.soilMoist2.has_data or $day.soilMoist3.has_data or $day.soilMoist4.has_data or $day.soilMoist5.has_data or $day.soilMoist6.has_data or $day.soilMoist7.has_data or $day.soilMoist8.has_data
+                $getChartJsCode("soilMoist1", "soilMoist1chart", "area", "soilMoist1", "soilMoist2", "avg", "soilMoist3", "soilMoist4", "soilMoist5", "soilMoist6", "soilMoist7", "soilMoist8")
             #end if
 
             #if $year.cloudbase.has_data

--- a/skins/neowx-material/yesterday.html.tmpl
+++ b/skins/neowx-material/yesterday.html.tmpl
@@ -240,9 +240,13 @@
         ## | string  $column   the column of the display value  (e.g. min, max, avg) |
         ## | string  $series3  opt. field name for 3rd series   (e.g. outTemp or "") |
         ## | string  $series4  opt. field name for 4th series   (e.g. outTemp or "") |
+        ## | string  $series5  opt. field name for 5th series   (e.g. outTemp or "") |
+        ## | string  $series6  opt. field name for 6th series   (e.g. outTemp or "") |
+        ## | string  $series7  opt. field name for 7th series   (e.g. outTemp or "") |
+        ## | string  $series8  opt. field name for 8th series   (e.g. outTemp or "") |
         ## +-------------------------------------------------------------------------+
 
-        #def getChartJsCode($name, $id, $type, $series1, $series2 = "", $column = "avg", $series3 = "", $series4 = "")
+        #def getChartJsCode($name, $id, $type, $series1, $series2 = "", $column = "avg", $series3 = "", $series4 = "", $series5 = "", $series6 = "", $series7 = "", $series8 = "")
 
             ## Only add JS chart code if in array
             #if $name in $Extras.Appearance.charts_order
@@ -447,12 +451,12 @@
                 $getChartJsCode("leafTemp1", "leafTempchart", "area", "leafTemp1", "leafTemp2", "avg")
             #end if
 
-            #if $yesterday.soilTemp1.has_data or $yesterday.soilTemp2.has_data or $yesterday.soilTemp3.has_data or $yesterday.soilTemp4.has_data
-                $getChartJsCode("soilTemp1", "soilTemp1chart", "area", "soilTemp1", "soilTemp2", "avg", "soilTemp3", "soilTemp4")
+            #if $day.soilTemp1.has_data or $day.soilTemp2.has_data or $day.soilTemp3.has_data or $day.soilTemp4.has_data or $day.soilTemp5.has_data or $day.soilTemp6.has_data or $day.soilTemp7.has_data or $day.soilTemp8.has_data
+                $getChartJsCode("soilTemp1", "soilTemp1chart", "area", "soilTemp1", "soilTemp2", "avg", "soilTemp3", "soilTemp4", "soilTemp5", "soilTemp6", "soilTemp7", "soilTemp8")
             #end if
 
-            #if $yesterday.soilMoist1.has_data or $yesterday.soilMoist2.has_data or $yesterday.soilMoist3.has_data or $yesterday.soilMoist4.has_data
-                $getChartJsCode("soilMoist1", "soilMoist1chart", "area", "soilMoist1", "soilMoist2", "avg", "soilMoist3", "soilMoist4")
+            #if $day.soilMoist1.has_data or $day.soilMoist2.has_data or $day.soilMoist3.has_data or $day.soilMoist4.has_data or $day.soilMoist5.has_data or $day.soilMoist6.has_data or $day.soilMoist7.has_data or $day.soilMoist8.has_data
+                $getChartJsCode("soilMoist1", "soilMoist1chart", "area", "soilMoist1", "soilMoist2", "avg", "soilMoist3", "soilMoist4", "soilMoist5", "soilMoist6", "soilMoist7", "soilMoist8")
             #end if
 
             #if $yesterday.cloudbase.has_data


### PR DESCRIPTION
Support for additional soil sensors (up to 8 sensors)
<img width="1424" height="397" alt="image" src="https://github.com/user-attachments/assets/88ca4319-082f-44c5-b22e-68b40689b0b2" />

For correct unit handling, you need to extend your 

`/bin/user/extensions.py` file

Add:
```
import weewx.units

weewx.units.obs_group_dict['soilMoist5'] = 'group_moisture' 
weewx.units.obs_group_dict['soilMoist6'] = 'group_moisture' 
weewx.units.obs_group_dict['soilMoist7'] = 'group_moisture' 
weewx.units.obs_group_dict['soilMoist8'] = 'group_moisture' 

weewx.units.obs_group_dict['soilTemp5'] = 'group_temperature' 
weewx.units.obs_group_dict['soilTemp6'] = 'group_temperature' 
weewx.units.obs_group_dict['soilTemp7'] = 'group_temperature' 
weewx.units.obs_group_dict['soilTemp8'] = 'group_temperature' 
```
This PR solves https://github.com/seehase/neowx-material/issues/301