### PR TITLE
Custom charts

### DIFF
--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class BasicInstaller(ExtensionInstaller):
     def __init__(self):
         super(BasicInstaller, self).__init__(
-            version="1.55.1",
+            version="1.56.0",
             name="neowx-material",
             description="The most versatile and modern weewx skin",
             author="Neoweewx",

--- a/skins/neowx-material/header.inc
+++ b/skins/neowx-material/header.inc
@@ -1,4 +1,5 @@
 #encoding UTF-8
+#import time
 ## +-------------------------------------------------------------------------+
 ## |    header.inc                 Header section (nav) for all templates    |
 ## +-------------------------------------------------------------------------+
@@ -26,12 +27,10 @@
                 #end if
                 <span>
                     <strong>$station.location</strong><br>
-                    #if $active_nav == 'archive'
-                        <span class="font-small"></span>
-                    #else
+                    #if $active_nav == 'current'
                         #set $datetime_format = $Extras.Formatting.get('datetime', '%a %d %H:%M')
                         <span class="font-small datetime-header" id="current-datetime" data-timestamp="$current.dateTime.raw">$current.dateTime.format($datetime_format)</span>
-                        #if ($Extras.MQTT.enabled == "true" or $Extras.MQTT.enabled == True) and $active_nav == 'current'
+                        #if ($Extras.MQTT.enabled == "true" or $Extras.MQTT.enabled == True)
                             <span id="mqtt-status" class="font-small datetime-header" style="margin-left: 1px; display: inline-block;">
                                 <span id="mqtt-indicator" class="mdi mdi-resistor-nodes" data-toggle="tooltip" data-placement="bottom" style="vertical-align: middle;" title=""></span>
                             </span>
@@ -52,6 +51,9 @@
                                 <span class="mdi mdi-wifi" data-toggle="tooltip" data-placement="bottom" style="vertical-align: middle;" title="$gettext('System is online')"></span>
                             </span>
                         #end if
+                    #else
+                        #set $date_format = $Extras.Formatting.get('date', '%x')
+                        <span class="font-small datetime-header">$time.strftime($date_format)</span>
                     #end if
                     <span id="status-label" class="font-small red"><strong></strong></span>
                 </span>

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -245,7 +245,29 @@
 ## +-------------------------------------------------------------------------+
 
 #def chartCard($name, $name2 = "XX")
-    #if ($getVar('day.' + name + '.has_data') or $name == "windvec") and $name != "appTemp" and $name != "ET" and $name != "windrun"
+    #if $name.startswith('customChart')
+        ## Custom chart: read config from Extras.Appearance
+        #set $cc = $Extras.Appearance.get($name, {})
+        #if $cc
+            #set $cc_title = $cc.get('title', $name)
+            #set $cc_values_raw = $cc.get('values', '')
+            #if isinstance($cc_values_raw, list)
+                #set $cc_first = $cc_values_raw[0].strip() if len($cc_values_raw) > 0 else ""
+            #else
+                #set $cc_first = $cc_values_raw.split(',')[0].strip() if $cc_values_raw else ""
+            #end if
+            #if $cc_first and $getVar('day.' + $cc_first + '.has_data')
+                <div class="col-12 col-xl-6 mb-4">
+                    <div class="card card-chart" id="${name}-chart" data-name="$name">
+                        <div class="card-body text-center">
+                            <h5 class="h5-responsive $Extras.color-text">$cc_title</h5>
+                            <div id="${name}chart"></div>
+                        </div>
+                    </div>
+                </div>
+            #end if
+        #end if
+    #else if ($getVar('day.' + name + '.has_data') or $name == "windvec") and $name != "appTemp" and $name != "ET" and $name != "windrun"
         <div class="col-12 col-xl-6 mb-4">
             <div class="card card-chart" id="${name}-chart" data-name="$name">
                 <div class="card-body text-center">
@@ -525,7 +547,7 @@
                             yaxis: {
                                 labels: {
                                     formatter: function (val) {
-                                        return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
+                                        return formatNumber(val, "$getVar('unit.format.' + series1)") + "$getVar('unit.label.' + series1)";
                                     }
                                 },
                             },
@@ -885,6 +907,40 @@
             #if $day.lightning_energy.has_data
                 $getChartJsCode("lightning_energy", "lightning_energychart", "area", "lightning_energy")
             #end if
+
+            // Custom charts (dynamically generated from skin.conf [[Appearance]] [[[customChart*]]] sections)
+            #set $seen_custom_charts = set()
+            #for $x in $Extras.Appearance.charts_order
+                #if $x.startswith('customChart') and $x not in $seen_custom_charts
+                    #silent $seen_custom_charts.add($x)
+                    #set $cc = $Extras.Appearance.get($x, {})
+                    #if $cc
+                        #set $cc_type = $cc.get('charttype', 'area')
+                        #set $cc_column = $cc.get('column', 'avg')
+                        #set $cc_values_raw = $cc.get('values', '')
+                        #if isinstance($cc_values_raw, list)
+                            #set $cc_vals = [v.strip() for v in $cc_values_raw if v.strip()]
+                        #else
+                            #set $cc_vals = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
+                        #end if
+                        #if len($cc_vals) > 0
+                            #set $s1 = $cc_vals[0]
+                            #set $s2 = $cc_vals[1] if len($cc_vals) > 1 else ""
+                            #set $s3 = $cc_vals[2] if len($cc_vals) > 2 else ""
+                            #set $s4 = $cc_vals[3] if len($cc_vals) > 3 else ""
+                            #set $s5 = $cc_vals[4] if len($cc_vals) > 4 else ""
+                            #set $s6 = $cc_vals[5] if len($cc_vals) > 5 else ""
+                            #set $s7 = $cc_vals[6] if len($cc_vals) > 6 else ""
+                            #set $s8 = $cc_vals[7] if len($cc_vals) > 7 else ""
+                            ## Pre-compute the chart element ID as a plain Cheetah variable.
+                            ## Using "${x}chart" as a string literal in a function argument is
+                            ## NOT interpolated by Cheetah, causing querySelector to fail.
+                            #set $cc_id = $x + "chart"
+                            $getChartJsCode($x, $cc_id, $cc_type, $s1, $s2, $cc_column, $s3, $s4, $s5, $s6, $s7, $s8)
+                        #end if
+                    #end if
+                #end if
+            #end for
 
         </script>
 

--- a/skins/neowx-material/month-%Y-%m.html.tmpl
+++ b/skins/neowx-material/month-%Y-%m.html.tmpl
@@ -127,7 +127,29 @@
 ## +-------------------------------------------------------------------------+
 
 #def chartCard($name, $id, $name2 = "XX")
-    #if ($getVar('month.' + name + '.has_data') or $name == "windvec") and $name != "appTemp"
+    #if $name.startswith('customChart')
+        ## Custom chart: read config from Extras.Appearance
+        #set $cc = $Extras.Appearance.get($name, {})
+        #if $cc
+            #set $cc_title = $cc.get('title', $name)
+            #set $cc_values_raw = $cc.get('values', '')
+            #if isinstance($cc_values_raw, list)
+                #set $cc_first = $cc_values_raw[0].strip() if len($cc_values_raw) > 0 else ""
+            #else
+                #set $cc_first = $cc_values_raw.split(',')[0].strip() if $cc_values_raw else ""
+            #end if
+            #if $cc_first and $getVar('month.' + $cc_first + '.has_data')
+                <div class="col-12 col-xl-6 mb-4">
+                    <div class="card card-chart" id="${name}-chart" data-name="$name">
+                        <div class="card-body text-center">
+                            <h5 class="h5-responsive $Extras.color-text">$cc_title</h5>
+                            <div id="$id"></div>
+                        </div>
+                    </div>
+                </div>
+            #end if
+        #end if
+    #else if ($getVar('month.' + name + '.has_data') or $name == "windvec") and $name != "appTemp"
         <div class="col-12 col-xl-6 mb-4">
             <div class="card card-chart" id="${name}-chart" data-name="$name">
                 <div class="card-body text-center">
@@ -331,7 +353,7 @@
             ## Only add JS chart code if in array
             #if $name in $Extras.Appearance.charts_order
 
-                #if $series1 == "outTemp"
+                #if $name == "outTemp"
 
                     ## Special diagram for outside temp
 
@@ -437,15 +459,15 @@
                                         }
                                     },
                                 },
-                            #else
-                                yaxis: {
-                                    labels: {
-                                        formatter: function (val) {
-                                            return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
-                                        }
-                                    },
+                        #else
+                            yaxis: {
+                                labels: {
+                                    formatter: function (val) {
+                                        return formatNumber(val, "$getVar('unit.format.' + series1)") + "$getVar('unit.label.' + series1)";
+                                    }
                                 },
-                            #end if
+                            },
+                        #end if
                             series: [
                                 {
                                     name: "$getVar('obs.label.' + series1)",
@@ -467,6 +489,30 @@
                                     ,{
                                         name: "$getVar('obs.label.' + series4)",
                                         data: [ $getChartData(series4, column) ]
+                                    }
+                                #end if
+                                #if $series5 != "" and $getVar('month.' + series5 + '.has_data')
+                                    ,{
+                                        name: "$getVar('obs.label.' + series5)",
+                                        data: [ $getChartData(series5, column) ]
+                                    }
+                                #end if
+                                #if $series6 != "" and $getVar('month.' + series6 + '.has_data')
+                                    ,{
+                                        name: "$getVar('obs.label.' + series6)",
+                                        data: [ $getChartData(series6, column) ]
+                                    }
+                                #end if
+                                #if $series7 != "" and $getVar('month.' + series7 + '.has_data')
+                                    ,{
+                                        name: "$getVar('obs.label.' + series7)",
+                                        data: [ $getChartData(series7, column) ]
+                                    }
+                                #end if
+                                #if $series8 != "" and $getVar('month.' + series8 + '.has_data')
+                                    ,{
+                                        name: "$getVar('obs.label.' + series8)",
+                                        data: [ $getChartData(series8, column) ]
                                     }
                                 #end if
                             ]
@@ -782,6 +828,37 @@
             #if $month.lightning_energy.has_data
                 $getChartJsCode("lightning_energy", "lightning_energychart", "area", "lightning_energy")
             #end if
+
+            // Custom charts (dynamically generated from skin.conf [[Appearance]] [[[customChart*]]] sections)
+            #set $seen_custom_charts = set()
+            #for $x in $Extras.Appearance.charts_order
+                #if $x.startswith('customChart') and $x not in $seen_custom_charts
+                    #silent $seen_custom_charts.add($x)
+                    #set $cc = $Extras.Appearance.get($x, {})
+                    #if $cc
+                        #set $cc_type = $cc.get('charttype', 'area')
+                        #set $cc_column = $cc.get('column', 'avg')
+                        #set $cc_values_raw = $cc.get('values', '')
+                        #if isinstance($cc_values_raw, list)
+                            #set $cc_vals = [v.strip() for v in $cc_values_raw if v.strip()]
+                        #else
+                            #set $cc_vals = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
+                        #end if
+                        #if len($cc_vals) > 0
+                            #set $s1 = $cc_vals[0]
+                            #set $s2 = $cc_vals[1] if len($cc_vals) > 1 else ""
+                            #set $s3 = $cc_vals[2] if len($cc_vals) > 2 else ""
+                            #set $s4 = $cc_vals[3] if len($cc_vals) > 3 else ""
+                            #set $s5 = $cc_vals[4] if len($cc_vals) > 4 else ""
+                            #set $s6 = $cc_vals[5] if len($cc_vals) > 5 else ""
+                            #set $s7 = $cc_vals[6] if len($cc_vals) > 6 else ""
+                            #set $s8 = $cc_vals[7] if len($cc_vals) > 7 else ""
+                            #set $cc_id = $x + "chart"
+                            $getChartJsCode($x, $cc_id, $cc_type, $s1, $s2, $cc_column, $s3, $s4, $s5, $s6, $s7, $s8)
+                        #end if
+                    #end if
+                #end if
+            #end for
 
         </script>
 

--- a/skins/neowx-material/month.html.tmpl
+++ b/skins/neowx-material/month.html.tmpl
@@ -128,7 +128,29 @@
 ## +-------------------------------------------------------------------------+
 
 #def chartCard($name, $id, $name2 = "XX")
-    #if ($getVar('month.' + name + '.has_data') or $name == "windvec") and $name != "appTemp"
+    #if $name.startswith('customChart')
+        ## Custom chart: read config from Extras.Appearance
+        #set $cc = $Extras.Appearance.get($name, {})
+        #if $cc
+            #set $cc_title = $cc.get('title', $name)
+            #set $cc_values_raw = $cc.get('values', '')
+            #if isinstance($cc_values_raw, list)
+                #set $cc_first = $cc_values_raw[0].strip() if len($cc_values_raw) > 0 else ""
+            #else
+                #set $cc_first = $cc_values_raw.split(',')[0].strip() if $cc_values_raw else ""
+            #end if
+            #if $cc_first and $getVar('month.' + $cc_first + '.has_data')
+                <div class="col-12 col-xl-6 mb-4">
+                    <div class="card card-chart" id="${name}-chart" data-name="$name">
+                        <div class="card-body text-center">
+                            <h5 class="h5-responsive $Extras.color-text">$cc_title</h5>
+                            <div id="$id"></div>
+                        </div>
+                    </div>
+                </div>
+            #end if
+        #end if
+    #else if ($getVar('month.' + name + '.has_data') or $name == "windvec") and $name != "appTemp"
         <div class="col-12 col-xl-6 mb-4">
             <div class="card card-chart" id="${name}-chart" data-name="$name">
                 <div class="card-body text-center">
@@ -338,7 +360,7 @@
             ## Only add JS chart code if in array
             #if $name in $Extras.Appearance.charts_order
 
-                #if $series1 == "outTemp"
+                #if $name == "outTemp"
 
                     ## Special diagram for outside temp
 
@@ -444,15 +466,15 @@
                                         }
                                     },
                                 },
-                            #else
-                                yaxis: {
-                                    labels: {
-                                        formatter: function (val) {
-                                            return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
-                                        }
-                                    },
+                        #else
+                            yaxis: {
+                                labels: {
+                                    formatter: function (val) {
+                                        return formatNumber(val, "$getVar('unit.format.' + series1)") + "$getVar('unit.label.' + series1)";
+                                    }
                                 },
-                            #end if
+                            },
+                        #end if
                             series: [
                                 {
                                     name: "$getVar('obs.label.' + series1)",
@@ -813,6 +835,37 @@
             #if $month.lightning_energy.has_data
                 $getChartJsCode("lightning_energy", "lightning_energychart", "area", "lightning_energy")
             #end if
+
+            // Custom charts (dynamically generated from skin.conf [[Appearance]] [[[customChart*]]] sections)
+            #set $seen_custom_charts = set()
+            #for $x in $Extras.Appearance.charts_order
+                #if $x.startswith('customChart') and $x not in $seen_custom_charts
+                    #silent $seen_custom_charts.add($x)
+                    #set $cc = $Extras.Appearance.get($x, {})
+                    #if $cc
+                        #set $cc_type = $cc.get('charttype', 'area')
+                        #set $cc_column = $cc.get('column', 'avg')
+                        #set $cc_values_raw = $cc.get('values', '')
+                        #if isinstance($cc_values_raw, list)
+                            #set $cc_vals = [v.strip() for v in $cc_values_raw if v.strip()]
+                        #else
+                            #set $cc_vals = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
+                        #end if
+                        #if len($cc_vals) > 0
+                            #set $s1 = $cc_vals[0]
+                            #set $s2 = $cc_vals[1] if len($cc_vals) > 1 else ""
+                            #set $s3 = $cc_vals[2] if len($cc_vals) > 2 else ""
+                            #set $s4 = $cc_vals[3] if len($cc_vals) > 3 else ""
+                            #set $s5 = $cc_vals[4] if len($cc_vals) > 4 else ""
+                            #set $s6 = $cc_vals[5] if len($cc_vals) > 5 else ""
+                            #set $s7 = $cc_vals[6] if len($cc_vals) > 6 else ""
+                            #set $s8 = $cc_vals[7] if len($cc_vals) > 7 else ""
+                            #set $cc_id = $x + "chart"
+                            $getChartJsCode($x, $cc_id, $cc_type, $s1, $s2, $cc_column, $s3, $s4, $s5, $s6, $s7, $s8)
+                        #end if
+                    #end if
+                #end if
+            #end for
 
         </script>
 

--- a/skins/neowx-material/package-lock.json
+++ b/skins/neowx-material/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neowx-material",
-  "version": "1.55.1",
+  "version": "1.56.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neowx-material",
-      "version": "1.55.1",
+      "version": "1.56.0",
       "license": "MIT",
       "dependencies": {
         "sass": "1.99.0"

--- a/skins/neowx-material/package.json
+++ b/skins/neowx-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neowx-material",
-  "version": "1.55.1",
+  "version": "1.56.0",
   "description": "The most versatile and modern weewx skin",
   "main": "index.js",
   "repository": "https://github.com/neoground/neowx-material",

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -18,7 +18,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
 
-    version = 1.55.1
+    version = 1.56.0
 
     # Language
     # -------------------------------------------------------------------------
@@ -232,6 +232,7 @@
         #   1. Static page rendering in header.inc
         #   2. MQTT live updates in index.html.tmpl
         # If not set, defaults to: %a %d %H:%M (e.g., "Mon 02 13:45")
+        date = %d.%m.%Y
         datetime_today = %H:%M
         datetime = %a %d %H:%M
         datetime_archive = %d.%m. %H:%M
@@ -258,7 +259,7 @@
         values_order = soilMoist1, soilMoist2, soilMoist3, soilMoist4,soilMoist5, soilMoist6, outTemp, outHumidity, barometer, altimeter, pressure, windSpeed, windrun, rain, snowDepth, dewpoint, windchill, heatindex, inTemp, inHumidity, UV, ET, radiation, appTemp, cloudbase, extraTemp1, extraHumid1, extraTemp2, extraHumid2, extraTemp3, extraHumid3, extraTemp4, extraHumid4, extraTemp5, extraHumid5, extraTemp6, extraHumid6, extraTemp7, extraHumid7, extraTemp8, extraHumid8, soilMoist1, soilMoist2, soilMoist3, soilMoist4, soilMoist5, soilMoist6, soilMoist7, soilMoist8, soilTemp1, soilTemp2, soilTemp3, soilTemp4, soilTemp5, soilTemp6, soilTemp7, soilTemp8, lightning_strike_count, lightning_noise_count, lightning_disturber_count, lightning_distance, lightning_energy, pm2_5, co2, temperatureThresholdDays
 
         # The order of chart cards (right column)
-        charts_order = outTemp, windchill, barometer, altimeter, pressure, rain, snowDepth, windSpeed, windrun, windDir, windvec, UV, ET, radiation, outHumidity, inTemp, inHumidity, appTemp, cloudbase, extraTemp1, extraHumid1, extraTemp2, extraHumid2, extraTemp3, extraHumid3, extraTemp4, extraHumid4, extraTemp5, extraHumid5, extraTemp6, extraHumid6, extraTemp7, extraHumid7, extraTemp8, extraHumid8, soilMoist1, soilTemp1, lightning_strike_count, lightning_noise_count, lightning_disturber_count, lightning_distance, lightning_energy, pm2_5, co2
+        charts_order = outTemp, customChart1, windchill, customChart2, barometer, customChart3, altimeter, pressure, rain, snowDepth, windSpeed, windrun, windDir, windvec, UV, ET, radiation, outHumidity, inTemp, inHumidity, appTemp, cloudbase, extraTemp1, extraHumid1, extraTemp2, extraHumid2, extraTemp3, extraHumid3, extraTemp4, extraHumid4, extraTemp5, extraHumid5, extraTemp6, extraHumid6, extraTemp7, extraHumid7, extraTemp8, extraHumid8, soilMoist1, soilTemp1, lightning_strike_count, lightning_noise_count, lightning_disturber_count, lightning_distance, lightning_energy, pm2_5, co2
 
         # For enabling embedded iframes or images add their names to the list below
         # The names must match the ones defined in the [[Embedded]] section below
@@ -294,6 +295,29 @@
 
         # define if charts should have a zoom or pan by default, zoom/pan, default is zoom
         defaultChartBehavior = zoom
+
+        # Custom charts
+        # -------------------------------------------------------------------------
+        # Define your own charts with any name starting with "customChart".
+        # Add the name to charts_order above to display the chart.
+        # Names are case-sensitive and must be unique (e.g. customChart1, customChartMyTemp).
+        #
+        # Available charttype values: area, bar, line
+        # Available column values:    avg, min, max, sum, vecdir
+        # values: comma-separated list of up to 8 WeeWX field names
+        #
+        # Example:
+        # [[[customChart1]]]
+        #     title = My Custom Temperature Chart
+        #     charttype = area
+        #     column = avg
+        #     values = outTemp, inTemp, extraTemp1, extraTemp2, extraTemp3, extraTemp4, extraTemp5, extraTemp6
+        # [[[customChart2]]]
+        #     title = My Custom Humidity Chart
+        #     charttype = area
+        #     column = avg
+        #     values = outhumidity, inHumidity, extraHumid1, extraHumid2, extraHumid3, extraHumid4, extraHumid5, extraHumid6
+
 
     # Embedded iFrames and images
     # -------------------------------------------------------------------------

--- a/skins/neowx-material/week.html.tmpl
+++ b/skins/neowx-material/week.html.tmpl
@@ -119,7 +119,29 @@
 ## +-------------------------------------------------------------------------+
 
 #def chartCard($name, $id, $name2 = "XX")
-    #if ($getVar('week.' + name + '.has_data') or $name == "windvec") and $name != "appTemp"
+    #if $name.startswith('customChart')
+        ## Custom chart: read config from Extras.Appearance
+        #set $cc = $Extras.Appearance.get($name, {})
+        #if $cc
+            #set $cc_title = $cc.get('title', $name)
+            #set $cc_values_raw = $cc.get('values', '')
+            #if isinstance($cc_values_raw, list)
+                #set $cc_first = $cc_values_raw[0].strip() if len($cc_values_raw) > 0 else ""
+            #else
+                #set $cc_first = $cc_values_raw.split(',')[0].strip() if $cc_values_raw else ""
+            #end if
+            #if $cc_first and $getVar('week.' + $cc_first + '.has_data')
+                <div class="col-12 col-xl-6 mb-4">
+                    <div class="card card-chart" id="${name}-chart" data-name="$name">
+                        <div class="card-body text-center">
+                            <h5 class="h5-responsive $Extras.color-text">$cc_title</h5>
+                            <div id="$id"></div>
+                        </div>
+                    </div>
+                </div>
+            #end if
+        #end if
+    #else if ($getVar('week.' + name + '.has_data') or $name == "windvec") and $name != "appTemp"
         <div class="col-12 col-xl-6 mb-4">
             <div class="card card-chart" id="${name}-chart" data-name="$name">
                 <div class="card-body text-center">
@@ -294,7 +316,7 @@
                             yaxis: {
                                 labels: {
                                     formatter: function (val) {
-                                        return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
+                                        return formatNumber(val, "$getVar('unit.format.' + series1)") + "$getVar('unit.label.' + series1)";
                                     }
                                 },
                             },
@@ -657,6 +679,37 @@
             #if $week.lightning_energy.has_data
                 $getChartJsCode("lightning_energy", "lightning_energychart", "area", "lightning_energy")
             #end if
+
+            // Custom charts (dynamically generated from skin.conf [[Appearance]] [[[customChart*]]] sections)
+            #set $seen_custom_charts = set()
+            #for $x in $Extras.Appearance.charts_order
+                #if $x.startswith('customChart') and $x not in $seen_custom_charts
+                    #silent $seen_custom_charts.add($x)
+                    #set $cc = $Extras.Appearance.get($x, {})
+                    #if $cc
+                        #set $cc_type = $cc.get('charttype', 'area')
+                        #set $cc_column = $cc.get('column', 'avg')
+                        #set $cc_values_raw = $cc.get('values', '')
+                        #if isinstance($cc_values_raw, list)
+                            #set $cc_vals = [v.strip() for v in $cc_values_raw if v.strip()]
+                        #else
+                            #set $cc_vals = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
+                        #end if
+                        #if len($cc_vals) > 0
+                            #set $s1 = $cc_vals[0]
+                            #set $s2 = $cc_vals[1] if len($cc_vals) > 1 else ""
+                            #set $s3 = $cc_vals[2] if len($cc_vals) > 2 else ""
+                            #set $s4 = $cc_vals[3] if len($cc_vals) > 3 else ""
+                            #set $s5 = $cc_vals[4] if len($cc_vals) > 4 else ""
+                            #set $s6 = $cc_vals[5] if len($cc_vals) > 5 else ""
+                            #set $s7 = $cc_vals[6] if len($cc_vals) > 6 else ""
+                            #set $s8 = $cc_vals[7] if len($cc_vals) > 7 else ""
+                            #set $cc_id = $x + "chart"
+                            $getChartJsCode($x, $cc_id, $cc_type, $s1, $s2, $cc_column, $s3, $s4, $s5, $s6, $s7, $s8)
+                        #end if
+                    #end if
+                #end if
+            #end for
 
         </script>
 

--- a/skins/neowx-material/year-%Y.html.tmpl
+++ b/skins/neowx-material/year-%Y.html.tmpl
@@ -127,7 +127,29 @@
 ## +-------------------------------------------------------------------------+
 
 #def chartCard($name, $id, $name2 = "XX")
-    #if ($getVar('year.' + name + '.has_data') or $name == "windvec") and $name != "appTemp"
+    #if $name.startswith('customChart')
+        ## Custom chart: read config from Extras.Appearance
+        #set $cc = $Extras.Appearance.get($name, {})
+        #if $cc
+            #set $cc_title = $cc.get('title', $name)
+            #set $cc_values_raw = $cc.get('values', '')
+            #if isinstance($cc_values_raw, list)
+                #set $cc_first = $cc_values_raw[0].strip() if len($cc_values_raw) > 0 else ""
+            #else
+                #set $cc_first = $cc_values_raw.split(',')[0].strip() if $cc_values_raw else ""
+            #end if
+            #if $cc_first and $getVar('year.' + $cc_first + '.has_data')
+                <div class="col-12 col-xl-6 mb-4">
+                    <div class="card card-chart" id="${name}-chart" data-name="$name">
+                        <div class="card-body text-center">
+                            <h5 class="h5-responsive $Extras.color-text">$cc_title</h5>
+                            <div id="$id"></div>
+                        </div>
+                    </div>
+                </div>
+            #end if
+        #end if
+    #else if ($getVar('year.' + name + '.has_data') or $name == "windvec") and $name != "appTemp"
         <div class="col-12 col-xl-6 mb-4">
             <div class="card card-chart" id="${name}-chart" data-name="$name">
                 <div class="card-body text-center">
@@ -377,7 +399,7 @@
     ## Only add JS chart code if in array
     #if $name in $Extras.Appearance.charts_order
 
-        #if $series1 == "outTemp"
+        #if $name == "outTemp"
 
             ## Special diagram for outside temp
 
@@ -483,15 +505,15 @@
                                 }
                             },
                         },
-                    #else
-                        yaxis: {
-                            labels: {
-                                formatter: function (val) {
-                                    return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
-                                }
+                        #else
+                            yaxis: {
+                                labels: {
+                                    formatter: function (val) {
+                                        return formatNumber(val, "$getVar('unit.format.' + series1)") + "$getVar('unit.label.' + series1)";
+                                    }
+                                },
                             },
-                        },
-                    #end if
+                        #end if
                     series: [
                         {
                             name: "$getVar('obs.label.' + series1)",
@@ -513,6 +535,30 @@
                             ,{
                                 name: "$getVar('obs.label.' + series4)",
                                 data: [ $getChartData(series4, column) ]
+                            }
+                        #end if
+                        #if $series5 != "" and $getVar('year.' + series5 + '.has_data')
+                            ,{
+                                name: "$getVar('obs.label.' + series5)",
+                                data: [ $getChartData(series5, column) ]
+                            }
+                        #end if
+                        #if $series6 != "" and $getVar('year.' + series6 + '.has_data')
+                            ,{
+                                name: "$getVar('obs.label.' + series6)",
+                                data: [ $getChartData(series6, column) ]
+                            }
+                        #end if
+                        #if $series7 != "" and $getVar('year.' + series7 + '.has_data')
+                            ,{
+                                name: "$getVar('obs.label.' + series7)",
+                                data: [ $getChartData(series7, column) ]
+                            }
+                        #end if
+                        #if $series8 != "" and $getVar('year.' + series8 + '.has_data')
+                            ,{
+                                name: "$getVar('obs.label.' + series8)",
+                                data: [ $getChartData(series8, column) ]
                             }
                         #end if
                     ]
@@ -823,6 +869,37 @@
     #if $year.lightning_energy.has_data
         $getChartJsCode("lightning_energy", "lightning_energychart", "area", "lightning_energy")
     #end if
+
+    // Custom charts (dynamically generated from skin.conf [[Appearance]] [[[customChart*]]] sections)
+    #set $seen_custom_charts = set()
+    #for $x in $Extras.Appearance.charts_order
+        #if $x.startswith('customChart') and $x not in $seen_custom_charts
+            #silent $seen_custom_charts.add($x)
+            #set $cc = $Extras.Appearance.get($x, {})
+            #if $cc
+                #set $cc_type = $cc.get('charttype', 'area')
+                #set $cc_column = $cc.get('column', 'avg')
+                #set $cc_values_raw = $cc.get('values', '')
+                #if isinstance($cc_values_raw, list)
+                    #set $cc_vals = [v.strip() for v in $cc_values_raw if v.strip()]
+                #else
+                    #set $cc_vals = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
+                #end if
+                #if len($cc_vals) > 0
+                    #set $s1 = $cc_vals[0]
+                    #set $s2 = $cc_vals[1] if len($cc_vals) > 1 else ""
+                    #set $s3 = $cc_vals[2] if len($cc_vals) > 2 else ""
+                    #set $s4 = $cc_vals[3] if len($cc_vals) > 3 else ""
+                    #set $s5 = $cc_vals[4] if len($cc_vals) > 4 else ""
+                    #set $s6 = $cc_vals[5] if len($cc_vals) > 5 else ""
+                    #set $s7 = $cc_vals[6] if len($cc_vals) > 6 else ""
+                    #set $s8 = $cc_vals[7] if len($cc_vals) > 7 else ""
+                    #set $cc_id = $x + "chart"
+                    $getChartJsCode($x, $cc_id, $cc_type, $s1, $s2, $cc_column, $s3, $s4, $s5, $s6, $s7, $s8)
+                #end if
+            #end if
+        #end if
+    #end for
 
 </script>
 

--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -127,7 +127,29 @@
 ## +-------------------------------------------------------------------------+
 
 #def chartCard($name, $id, $name2 = "XX")
-    #if ($getVar('year.' + name + '.has_data') or $name == "windvec") and $name != "appTemp"
+    #if $name.startswith('customChart')
+        ## Custom chart: read config from Extras.Appearance
+        #set $cc = $Extras.Appearance.get($name, {})
+        #if $cc
+            #set $cc_title = $cc.get('title', $name)
+            #set $cc_values_raw = $cc.get('values', '')
+            #if isinstance($cc_values_raw, list)
+                #set $cc_first = $cc_values_raw[0].strip() if len($cc_values_raw) > 0 else ""
+            #else
+                #set $cc_first = $cc_values_raw.split(',')[0].strip() if $cc_values_raw else ""
+            #end if
+            #if $cc_first and $getVar('year.' + $cc_first + '.has_data')
+                <div class="col-12 col-xl-6 mb-4">
+                    <div class="card card-chart" id="${name}-chart" data-name="$name">
+                        <div class="card-body text-center">
+                            <h5 class="h5-responsive $Extras.color-text">$cc_title</h5>
+                            <div id="$id"></div>
+                        </div>
+                    </div>
+                </div>
+            #end if
+        #end if
+    #else if ($getVar('year.' + name + '.has_data') or $name == "windvec") and $name != "appTemp"
         <div class="col-12 col-xl-6 mb-4">
             <div class="card card-chart" id="${name}-chart" data-name="$name">
                 <div class="card-body text-center">
@@ -337,7 +359,7 @@
             ## Only add JS chart code if in array
             #if $name in $Extras.Appearance.charts_order
 
-                #if $series1 == "outTemp"
+                #if $name == "outTemp"
 
                     ## Special diagram for outside temp
 
@@ -443,15 +465,15 @@
                                         }
                                     },
                                 },
-                            #else
-                                yaxis: {
-                                    labels: {
-                                        formatter: function (val) {
-                                            return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
-                                        }
-                                    },
+                        #else
+                            yaxis: {
+                                labels: {
+                                    formatter: function (val) {
+                                        return formatNumber(val, "$getVar('unit.format.' + series1)") + "$getVar('unit.label.' + series1)";
+                                    }
                                 },
-                            #end if
+                            },
+                        #end if
                             series: [
                                 {
                                     name: "$getVar('obs.label.' + series1)",
@@ -473,6 +495,30 @@
                                     ,{
                                         name: "$getVar('obs.label.' + series4)",
                                         data: [ $getChartData(series4, column) ]
+                                    }
+                                #end if
+                                #if $series5 != "" and $getVar('year.' + series5 + '.has_data')
+                                    ,{
+                                        name: "$getVar('obs.label.' + series5)",
+                                        data: [ $getChartData(series5, column) ]
+                                    }
+                                #end if
+                                #if $series6 != "" and $getVar('year.' + series6 + '.has_data')
+                                    ,{
+                                        name: "$getVar('obs.label.' + series6)",
+                                        data: [ $getChartData(series6, column) ]
+                                    }
+                                #end if
+                                #if $series7 != "" and $getVar('year.' + series7 + '.has_data')
+                                    ,{
+                                        name: "$getVar('obs.label.' + series7)",
+                                        data: [ $getChartData(series7, column) ]
+                                    }
+                                #end if
+                                #if $series8 != "" and $getVar('year.' + series8 + '.has_data')
+                                    ,{
+                                        name: "$getVar('obs.label.' + series8)",
+                                        data: [ $getChartData(series8, column) ]
                                     }
                                 #end if
                             ]
@@ -788,6 +834,37 @@
             #if $year.lightning_energy.has_data
                 $getChartJsCode("lightning_energy", "lightning_energychart", "area", "lightning_energy")
             #end if
+
+            // Custom charts (dynamically generated from skin.conf [[Appearance]] [[[customChart*]]] sections)
+            #set $seen_custom_charts = set()
+            #for $x in $Extras.Appearance.charts_order
+                #if $x.startswith('customChart') and $x not in $seen_custom_charts
+                    #silent $seen_custom_charts.add($x)
+                    #set $cc = $Extras.Appearance.get($x, {})
+                    #if $cc
+                        #set $cc_type = $cc.get('charttype', 'area')
+                        #set $cc_column = $cc.get('column', 'avg')
+                        #set $cc_values_raw = $cc.get('values', '')
+                        #if isinstance($cc_values_raw, list)
+                            #set $cc_vals = [v.strip() for v in $cc_values_raw if v.strip()]
+                        #else
+                            #set $cc_vals = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
+                        #end if
+                        #if len($cc_vals) > 0
+                            #set $s1 = $cc_vals[0]
+                            #set $s2 = $cc_vals[1] if len($cc_vals) > 1 else ""
+                            #set $s3 = $cc_vals[2] if len($cc_vals) > 2 else ""
+                            #set $s4 = $cc_vals[3] if len($cc_vals) > 3 else ""
+                            #set $s5 = $cc_vals[4] if len($cc_vals) > 4 else ""
+                            #set $s6 = $cc_vals[5] if len($cc_vals) > 5 else ""
+                            #set $s7 = $cc_vals[6] if len($cc_vals) > 6 else ""
+                            #set $s8 = $cc_vals[7] if len($cc_vals) > 7 else ""
+                            #set $cc_id = $x + "chart"
+                            $getChartJsCode($x, $cc_id, $cc_type, $s1, $s2, $cc_column, $s3, $s4, $s5, $s6, $s7, $s8)
+                        #end if
+                    #end if
+                #end if
+            #end for
 
         </script>
 

--- a/skins/neowx-material/yesterday.html.tmpl
+++ b/skins/neowx-material/yesterday.html.tmpl
@@ -119,7 +119,29 @@
 ## +-------------------------------------------------------------------------+
 
 #def chartCard($name, $id, $name2 = "XX")
-    #if ($getVar('yesterday.' + name + '.has_data') or $name == "windvec") and $name != "appTemp" and $name != "ET" and $name != "windrun"
+    #if $name.startswith('customChart')
+        ## Custom chart: read config from Extras.Appearance
+        #set $cc = $Extras.Appearance.get($name, {})
+        #if $cc
+            #set $cc_title = $cc.get('title', $name)
+            #set $cc_values_raw = $cc.get('values', '')
+            #if isinstance($cc_values_raw, list)
+                #set $cc_first = $cc_values_raw[0].strip() if len($cc_values_raw) > 0 else ""
+            #else
+                #set $cc_first = $cc_values_raw.split(',')[0].strip() if $cc_values_raw else ""
+            #end if
+            #if $cc_first and $getVar('yesterday.' + $cc_first + '.has_data')
+                <div class="col-12 col-xl-6 mb-4">
+                    <div class="card card-chart" id="${name}-chart" data-name="$name">
+                        <div class="card-body text-center">
+                            <h5 class="h5-responsive $Extras.color-text">$cc_title</h5>
+                            <div id="$id"></div>
+                        </div>
+                    </div>
+                </div>
+            #end if
+        #end if
+    #else if ($getVar('yesterday.' + name + '.has_data') or $name == "windvec") and $name != "appTemp" and $name != "ET" and $name != "windrun"
         <div class="col-12 col-xl-6 mb-4">
             <div class="card card-chart" id="${name}-chart" data-name="$name">
                 <div class="card-body text-center">
@@ -271,6 +293,26 @@
                     end_of_yesterday4 = Math.min(series4data.length, $number_of_records);
                 #end if
 
+                #if $series5 != ""
+                    series5data = [ $getChartData(series5, column) ];
+                    end_of_yesterday5 = Math.min(series5data.length, $number_of_records);
+                #end if
+
+                #if $series6 != ""
+                    series6data = [ $getChartData(series6, column) ];
+                    end_of_yesterday6 = Math.min(series6data.length, $number_of_records);
+                #end if
+
+                #if $series7 != ""
+                    series7data = [ $getChartData(series7, column) ];
+                    end_of_yesterday7 = Math.min(series7data.length, $number_of_records);
+                #end if
+
+                #if $series8 != ""
+                    series8data = [ $getChartData(series8, column) ];
+                    end_of_yesterday8 = Math.min(series8data.length, $number_of_records);
+                #end if
+
                 var chartElement = document.querySelector('#$id');
                 if (chartElement) {
                     new ApexCharts(chartElement, {
@@ -309,7 +351,7 @@
                             yaxis: {
                                 labels: {
                                     formatter: function (val) {
-                                        return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
+                                        return formatNumber(val, "$getVar('unit.format.' + series1)") + "$getVar('unit.label.' + series1)";
                                     }
                                 },
                             },
@@ -337,6 +379,30 @@
                                     data: series4data.splice(0,end_of_yesterday4)
                                 }
                             #end if
+                            #if $series5 != "" and $getVar('yesterday.' + series5 + '.has_data')
+                                ,{
+                                    name: "$getVar('obs.label.' + series5)",
+                                    data: series5data.splice(0,end_of_yesterday5)
+                                }
+                            #end if
+                            #if $series6 != "" and $getVar('yesterday.' + series6 + '.has_data')
+                                ,{
+                                    name: "$getVar('obs.label.' + series6)",
+                                    data: series6data.splice(0,end_of_yesterday6)
+                                }
+                            #end if
+                            #if $series7 != "" and $getVar('yesterday.' + series7 + '.has_data')
+                                ,{
+                                    name: "$getVar('obs.label.' + series7)",
+                                    data: series7data.splice(0,end_of_yesterday7)
+                                }
+                            #end if
+                            #if $series8 != "" and $getVar('yesterday.' + series8 + '.has_data')
+                                ,{
+                                    name: "$getVar('obs.label.' + series8)",
+                                    data: series8data.splice(0,end_of_yesterday8)
+                                }
+                            #end if
                         ]
                     }).render()
                 }
@@ -362,6 +428,18 @@
 
             var series4data = null;
             var end_of_yesterday4 = null;
+
+            var series5data = null;
+            var end_of_yesterday5 = null;
+
+            var series6data = null;
+            var end_of_yesterday6 = null;
+
+            var series7data = null;
+            var end_of_yesterday7 = null;
+
+            var series8data = null;
+            var end_of_yesterday8 = null;
 
             // Config templates
 
@@ -661,6 +739,37 @@
             #if $yesterday.lightning_energy.has_data
                 $getChartJsCode("lightning_energy", "lightning_energychart", "area", "lightning_energy")
             #end if
+
+            // Custom charts (dynamically generated from skin.conf [[Appearance]] [[[customChart*]]] sections)
+            #set $seen_custom_charts = set()
+            #for $x in $Extras.Appearance.charts_order
+                #if $x.startswith('customChart') and $x not in $seen_custom_charts
+                    #silent $seen_custom_charts.add($x)
+                    #set $cc = $Extras.Appearance.get($x, {})
+                    #if $cc
+                        #set $cc_type = $cc.get('charttype', 'area')
+                        #set $cc_column = $cc.get('column', 'avg')
+                        #set $cc_values_raw = $cc.get('values', '')
+                        #if isinstance($cc_values_raw, list)
+                            #set $cc_vals = [v.strip() for v in $cc_values_raw if v.strip()]
+                        #else
+                            #set $cc_vals = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
+                        #end if
+                        #if len($cc_vals) > 0
+                            #set $s1 = $cc_vals[0]
+                            #set $s2 = $cc_vals[1] if len($cc_vals) > 1 else ""
+                            #set $s3 = $cc_vals[2] if len($cc_vals) > 2 else ""
+                            #set $s4 = $cc_vals[3] if len($cc_vals) > 3 else ""
+                            #set $s5 = $cc_vals[4] if len($cc_vals) > 4 else ""
+                            #set $s6 = $cc_vals[5] if len($cc_vals) > 5 else ""
+                            #set $s7 = $cc_vals[6] if len($cc_vals) > 6 else ""
+                            #set $s8 = $cc_vals[7] if len($cc_vals) > 7 else ""
+                            #set $cc_id = $x + "chart"
+                            $getChartJsCode($x, $cc_id, $cc_type, $s1, $s2, $cc_column, $s3, $s4, $s5, $s6, $s7, $s8)
+                        #end if
+                    #end if
+                #end if
+            #end for
 
         </script>
 


### PR DESCRIPTION
Based on a screenshot from @Bunnyhop-rgb
I was inspired to introduce customCharts, so beside the default charts on data from weewx and Neowx-Material you are now able to define exactly the charts and data YOU want to see ... e.g. All your TempSensors in one chart, or any combination

<img width="1419" height="778" alt="image" src="https://github.com/user-attachments/assets/593b467f-ed4d-45f1-a9ed-c7d00731c098" />

In the skin.conf you can now define customChart*

so add `customChart1` to `charts_order`
and specify the properties
```
[[[customChart1]]]
             title = My Custom Temperature Chart
             charttype = area
             column = avg
             values = outTemp, dewpoint, extraTemp1, extraTemp2, extraTemp3, extraTemp4, extraTemp5, extraTemp6
```

and you will see your customChart
Ensure that the name in charts_order matches the subsection name
There is not limitation in number of customCharts, but only 8 Series are allowed per Chart
this is additional to existing charts and optional
If you specify a series which does not have data, no curve for this series is drawn (as usual)
is you add `customChartX` and you do not have a subsection [[[customChartX]]] customChartX will be ignorred

```
   [[Appearance]]
        # The order of chart cards (right column)
        charts_order = outTemp, customChart1, windchill, customChart2, barometer, customChartX
...
       [[[customChart1]]]
             title = My Custom Temperature Chart
             charttype = area
             column = avg
             values = outTemp, dewpoint, extraTemp1, extraTemp2, extraTemp3, extraTemp4, extraTemp5, extraTemp6
        [[[customChart2]]]
             title = My Custom Humidity Chart
             charttype = area
             column = avg
             values = outhumidity, inHumidity, extraHumid1, extraHumid2, extraHumid3, extraHumid4, extraHumid5, extraHumid6

...
```

posible values for
```
charttype: (area, bar, radar)
column: (min, max, avg)
```