### PR TITLE
fix: Jump marks for custom charts

### DIFF
--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class BasicInstaller(ExtensionInstaller):
     def __init__(self):
         super(BasicInstaller, self).__init__(
-            version="1.57.0",
+            version="1.57.1",
             name="neowx-material",
             description="The most versatile and modern weewx skin",
             author="Neoweewx",

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -230,9 +230,10 @@
                 #set $cc_vals_list = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
             #end if
             #set $cc_any_has_data = any($getVar('day.' + v + '.has_data') for v in $cc_vals_list)
+            #set $cc_sensors_str = chr(44).join($cc_vals_list)
             #if len($cc_vals_list) > 0 and $cc_any_has_data
                 <div class="col-12 col-xl-6 mb-4">
-                    <div class="card card-chart" id="${name}-chart" data-name="$name">
+                    <div class="card card-chart" id="${name}-chart" data-name="$name" data-sensors="$cc_sensors_str">
                         <div class="card-body text-center">
                             <h5 class="h5-responsive $Extras.color-text">$cc_title</h5>
                             <div id="${name}chart"></div>

--- a/skins/neowx-material/js/app.js
+++ b/skins/neowx-material/js/app.js
@@ -1,3 +1,4 @@
+// v1.0.1
 // Tooltip support
 $(function () {
     $('[data-toggle="tooltip"]').tooltip()
@@ -67,12 +68,24 @@ document.addEventListener('DOMContentLoaded', function () {
                 chartSensorName = 'windchill';
             }
 
-            // Find the corresponding chart card by data-name
-            const chartCard = document.querySelector('.card-chart[data-name="' + chartSensorName + '"]');
+            // Find the corresponding chart card by data-name (direct match first)
+            let chartCard = document.querySelector('.card-chart[data-name="' + chartSensorName + '"]');
+
+            // Fallback: search custom charts whose data-sensors attribute contains this sensor
+            if (!chartCard) {
+                const customCharts = document.querySelectorAll('.card-chart[data-sensors]');
+                for (const cc of customCharts) {
+                    const sensors = cc.getAttribute('data-sensors').split(',').map(function(s) { return s.trim(); });
+                    if (sensors.indexOf(chartSensorName) !== -1) {
+                        chartCard = cc;
+                        break;
+                    }
+                }
+            }
 
             if (chartCard) {
                 scrollToElement(chartCard, true);
-                debugLog('✓ Jumped from value card "' + sensorName + '" to chart "' + chartSensorName + '"');
+                debugLog('✓ Jumped from value card "' + sensorName + '" to chart "' + chartCard.getAttribute('data-name') + '"');
             } else {
                 debugLog('⚠️ No chart card found for sensor: ' + chartSensorName);
             }
@@ -102,12 +115,27 @@ document.addEventListener('DOMContentLoaded', function () {
                 valueSensorName = 'windSpeed';
             }
 
-            // Find the corresponding value card by data-name
-            const valueCard = document.querySelector('.card-value[data-name="' + valueSensorName + '"]');
+            // Find the corresponding value card by data-name (direct match first)
+            let valueCard = document.querySelector('.card-value[data-name="' + valueSensorName + '"]');
+
+            // Fallback: if this is a custom chart, use data-sensors to find first existing value card
+            if (!valueCard) {
+                const dataSensors = chartCard.getAttribute('data-sensors');
+                if (dataSensors) {
+                    const sensors = dataSensors.split(',').map(function(s) { return s.trim(); });
+                    for (const sensor of sensors) {
+                        const candidate = document.querySelector('.card-value[data-name="' + sensor + '"]');
+                        if (candidate) {
+                            valueCard = candidate;
+                            break;
+                        }
+                    }
+                }
+            }
 
             if (valueCard) {
                 scrollToElement(valueCard, true);
-                debugLog('✓ Jumped from chart "' + sensorName + '" to value card "' + valueSensorName + '"');
+                debugLog('✓ Jumped from chart "' + sensorName + '" to value card "' + valueCard.getAttribute('data-name') + '"');
                 e.preventDefault();
             } else {
                 debugLog('⚠️ No value card found for sensor: ' + valueSensorName);

--- a/skins/neowx-material/month-%Y-%m.html.tmpl
+++ b/skins/neowx-material/month-%Y-%m.html.tmpl
@@ -111,9 +111,10 @@
                 #set $cc_vals_list = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
             #end if
             #set $cc_any_has_data = any($getVar('month.' + v + '.has_data') for v in $cc_vals_list)
+            #set $cc_sensors_str = chr(44).join($cc_vals_list)
             #if len($cc_vals_list) > 0 and $cc_any_has_data
                 <div class="col-12 col-xl-6 mb-4">
-                    <div class="card card-chart" id="${name}-chart" data-name="$name">
+                    <div class="card card-chart" id="${name}-chart" data-name="$name" data-sensors="$cc_sensors_str">
                         <div class="card-body text-center">
                             <h5 class="h5-responsive $Extras.color-text">$cc_title</h5>
                             <div id="$id"></div>

--- a/skins/neowx-material/month.html.tmpl
+++ b/skins/neowx-material/month.html.tmpl
@@ -122,9 +122,10 @@
                 #set $cc_vals_list = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
             #end if
             #set $cc_any_has_data = any($getVar('month.' + v + '.has_data') for v in $cc_vals_list)
+            #set $cc_sensors_str = chr(44).join($cc_vals_list)
             #if len($cc_vals_list) > 0 and $cc_any_has_data
                 <div class="col-12 col-xl-6 mb-4">
-                    <div class="card card-chart" id="${name}-chart" data-name="$name">
+                    <div class="card card-chart" id="${name}-chart" data-name="$name" data-sensors="$cc_sensors_str">
                         <div class="card-body text-center">
                             <h5 class="h5-responsive $Extras.color-text">$cc_title</h5>
                             <div id="$id"></div>

--- a/skins/neowx-material/package-lock.json
+++ b/skins/neowx-material/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neowx-material",
-  "version": "1.57.0",
+  "version": "1.57.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neowx-material",
-      "version": "1.57.0",
+      "version": "1.57.1",
       "license": "MIT",
       "dependencies": {
         "sass": "1.99.0"

--- a/skins/neowx-material/package.json
+++ b/skins/neowx-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neowx-material",
-  "version": "1.57.0",
+  "version": "1.57.1",
   "description": "The most versatile and modern weewx skin",
   "main": "index.js",
   "repository": "https://github.com/neoground/neowx-material",

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -18,7 +18,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
 
-    version = 1.57.0
+    version = 1.57.1
 
     # Language
     # -------------------------------------------------------------------------
@@ -728,8 +728,10 @@
 #
 [CopyGenerator]
     # List of files to be copied each run (except templates)
-    # copy_always =
-    copy_once = css/*, js/*, weather-icons/*, img/*, fonts/*
+    # css/*, js/*, weather-icons/* are copied on every run so skin updates propagate automatically
+    copy_always = css/*, js/*, weather-icons/*
+    # img/* and fonts/* are copied only once (user may customise icons/fonts)
+    copy_once = img/*, fonts/*
 
 # HistoryReport
 # -------------------------------------------------------------------------

--- a/skins/neowx-material/week.html.tmpl
+++ b/skins/neowx-material/week.html.tmpl
@@ -113,9 +113,10 @@
                 #set $cc_vals_list = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
             #end if
             #set $cc_any_has_data = any($getVar('week.' + v + '.has_data') for v in $cc_vals_list)
+            #set $cc_sensors_str = chr(44).join($cc_vals_list)
             #if len($cc_vals_list) > 0 and $cc_any_has_data
                 <div class="col-12 col-xl-6 mb-4">
-                    <div class="card card-chart" id="${name}-chart" data-name="$name">
+                    <div class="card card-chart" id="${name}-chart" data-name="$name" data-sensors="$cc_sensors_str">
                         <div class="card-body text-center">
                             <h5 class="h5-responsive $Extras.color-text">$cc_title</h5>
                             <div id="$id"></div>

--- a/skins/neowx-material/year-%Y.html.tmpl
+++ b/skins/neowx-material/year-%Y.html.tmpl
@@ -111,9 +111,10 @@
                 #set $cc_vals_list = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
             #end if
             #set $cc_any_has_data = any($getVar('year.' + v + '.has_data') for v in $cc_vals_list)
+            #set $cc_sensors_str = chr(44).join($cc_vals_list)
             #if len($cc_vals_list) > 0 and $cc_any_has_data
                 <div class="col-12 col-xl-6 mb-4">
-                    <div class="card card-chart" id="${name}-chart" data-name="$name">
+                    <div class="card card-chart" id="${name}-chart" data-name="$name" data-sensors="$cc_sensors_str">
                         <div class="card-body text-center">
                             <h5 class="h5-responsive $Extras.color-text">$cc_title</h5>
                             <div id="$id"></div>

--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -111,9 +111,10 @@
                 #set $cc_vals_list = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
             #end if
             #set $cc_any_has_data = any($getVar('year.' + v + '.has_data') for v in $cc_vals_list)
+            #set $cc_sensors_str = chr(44).join($cc_vals_list)
             #if len($cc_vals_list) > 0 and $cc_any_has_data
                 <div class="col-12 col-xl-6 mb-4">
-                    <div class="card card-chart" id="${name}-chart" data-name="$name">
+                    <div class="card card-chart" id="${name}-chart" data-name="$name" data-sensors="$cc_sensors_str">
                         <div class="card-body text-center">
                             <h5 class="h5-responsive $Extras.color-text">$cc_title</h5>
                             <div id="$id"></div>
@@ -380,10 +381,18 @@
         #end def
 
         <script type="text/javascript">
-            var graph_area_config = { #include "graph_area_config.inc" }
-            var graph_bar_config = { #include "graph_bar_config.inc" }
-            var graph_radar_config = { #include "graph_radar_config.inc" }
-            var graph_line_config = { #include "graph_line_config.inc" }
+            var graph_area_config = {
+                #include "graph_area_config.inc"
+            }
+            var graph_bar_config = {
+                #include "graph_bar_config.inc"
+            }
+            var graph_radar_config = {
+                #include "graph_radar_config.inc"
+            }
+            var graph_line_config = {
+                #include "graph_line_config.inc"
+            }
 
             // --- Special charts: multi-series or non-default columns ---
             #set $processed_charts = set()

--- a/skins/neowx-material/yesterday.html.tmpl
+++ b/skins/neowx-material/yesterday.html.tmpl
@@ -113,9 +113,10 @@
                 #set $cc_vals_list = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
             #end if
             #set $cc_any_has_data = any($getVar('yesterday.' + v + '.has_data') for v in $cc_vals_list)
+            #set $cc_sensors_str = chr(44).join($cc_vals_list)
             #if len($cc_vals_list) > 0 and $cc_any_has_data
                 <div class="col-12 col-xl-6 mb-4">
-                    <div class="card card-chart" id="${name}-chart" data-name="$name">
+                    <div class="card card-chart" id="${name}-chart" data-name="$name" data-sensors="$cc_sensors_str">
                         <div class="card-body text-center">
                             <h5 class="h5-responsive $Extras.color-text">$cc_title</h5>
                             <div id="$id"></div>


### PR DESCRIPTION
Fixed jump between cards and charts
as jump marks must not be unique due to the fact that values can be on multiple customCharts it jumps to the first match
