### PR TITLE
fix: bring back missing cards

### DIFF
--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class BasicInstaller(ExtensionInstaller):
     def __init__(self):
         super(BasicInstaller, self).__init__(
-            version="1.57.1",
+            version="1.57.2",
             name="neowx-material",
             description="The most versatile and modern weewx skin",
             author="Neoweewx",

--- a/skins/neowx-material/header.inc
+++ b/skins/neowx-material/header.inc
@@ -39,10 +39,10 @@
 
                     <!-- Row 2: Date + icons (icons column always rendered, empty on non-current pages) -->
                     <div style="display:flex; align-items:center; gap:0.4rem;">
+                        #set $date_format = $Extras.Formatting.get('date', '%x')
                         #if $active_nav == 'current'
-                            <div id="current-date" style="white-space:nowrap; font-size:0.95rem; color:#fff;">$current.dateTime.format($Extras.Formatting.date)</div>
+                            <div id="current-date" style="white-space:nowrap; font-size:0.95rem; color:#fff;">$current.dateTime.format($date_format)</div>
                         #else
-                            #set $date_format = $Extras.Formatting.get('date', '%x')
                             <div style="white-space:nowrap; font-size:0.95rem; color:#fff;">$time.strftime($date_format)</div>
                         #end if
                         <!-- Icon container: position:relative so OFFLINE badge can float below without affecting row height -->
@@ -270,7 +270,8 @@
                         </li>
                     </ul>
                 #end if
-            #end if<!-- end column 3 -->
+            #end if
+            ## end column 3
 
         </nav>
 

--- a/skins/neowx-material/month.html.tmpl
+++ b/skins/neowx-material/month.html.tmpl
@@ -1,14 +1,9 @@
-#errorCatcher Echo
 #encoding UTF-8
 ## +-------------------------------------------------------------------------+
 ## |    month.html.tmpl                    Template file for "month" page    |
 ## +-------------------------------------------------------------------------+
 
 #attr $active_nav = 'month'
-
-## +-------------------------------------------------------------------------+
-## | Template for display card of values (left column)                       |
-## +-------------------------------------------------------------------------+
 
 ## Access HistoryReport section from skin.conf
 #set $table_dict = $generator.skin_dict['HistoryReport']
@@ -17,6 +12,10 @@
 #set $TropicDay = ($table_dict.get('tropical_days_threshold', 30.0),  $threshold_unit)
 #set $TropicNight = ($table_dict.get('tropical_nights_threshold', 20.0),  $threshold_unit)
 #set $ArcticDay = ($table_dict.get('arctic_days_threshold', 0.0),  $threshold_unit)
+
+## +-------------------------------------------------------------------------+
+## | Template for display card of values (left column)                       |
+## +-------------------------------------------------------------------------+
 
 #def valuesCard($name)
     ## ET requires a valid positive sum to be shown
@@ -27,15 +26,11 @@
                     <h3 class="h5-responsive $Extras.color-text">
                         $getVar('obs.label.' + name)
                         #if $name == 'windSpeed'
-
                             <i class="wi wi-wind from-$month.wind.vecdir.formatted-deg"
                             title="$month.wind.vecdir.formatted°" data-toggle="tooltip" data-html="true"></i>
-
                         #end if
                     </h3>
-
                     #if $name == 'windSpeed'
-
                         <div class="row">
                             <div class="col-3 text-muted font-small lo-text">
                                 $month.wind.avg <br>
@@ -53,13 +48,9 @@
                                 ($month.wind.maxtime.format($Extras.Formatting.datetime))
                             </div>
                         </div>
-
                     #else if $name == 'rain'
-
                         <div class="row">
-                            <div class="col-3 text-muted font-small">
-
-                            </div>
+                            <div class="col-3 text-muted font-small"></div>
                             <div class="col-6">
                                 <h4 class="h2-responsive">$month.rain.sum</h4>
                             </div>
@@ -68,10 +59,7 @@
                                 ($month.rainRate.maxtime.format($Extras.Formatting.datetime))
                             </div>
                         </div>
-
                     #else if $name in set(['lightning_strike_count', 'windrun', 'ET'])
-
-                        ## Sum-only display: no min/max context
                         <div class="row">
                             <div class="col-3 text-muted font-small lo-text"></div>
                             <div class="col-6">
@@ -79,9 +67,7 @@
                             </div>
                             <div class="col-3 text-muted font-small hi-text"></div>
                         </div>
-
                     #else
-
                         <div class="row">
                             <div class="col-3 text-muted font-small lo-text">
                                 $getVar('month.' + name + '.min') <br>
@@ -95,9 +81,7 @@
                                 ($getVar('month.' + name + '.maxtime').format($Extras.Formatting.datetime))
                             </div>
                         </div>
-
                     #end if
-
                 </div>
             </div>
         </div>
@@ -106,12 +90,10 @@
 
 ## +-------------------------------------------------------------------------+
 ## | Template for display card of a single chart (right column)              |
-## | Chart values are defined in the JS section below                        |
 ## +-------------------------------------------------------------------------+
 
-#def chartCard($name, $id, $name2 = "XX")
+#def chartCard($name, $id, $name2="XX")
     #if $name.startswith('customChart')
-        ## Custom chart: read config from Extras.Appearance
         #set $cc = $Extras.Appearance.get($name, {})
         #if $cc
             #set $cc_title = $cc.get('title', $name)
@@ -153,6 +135,7 @@
     #end if
 #end def
 
+
 ## +-------------------------------------------------------------------------+
 ## | The main page layout                                                    |
 ## +-------------------------------------------------------------------------+
@@ -177,7 +160,11 @@
                     #for $x in $Extras.Appearance.values_order
                         #if $x not in $seen_cards
                             #silent $seen_cards.add($x)
-                            #if $x == "temperatureThresholdDays"
+                            #if $x == "ET"
+                                #if $month.ET.has_data and $month.ET.sum.raw is not None and $month.ET.sum.raw > 0.0
+                                    $valuesCard('ET')
+                                #end if
+                            #else if $x == "temperatureThresholdDays"
                                 <div class="col-12 col-md-6 col-xl-4 mb-4">
                                     <div class="card">
                                         <div class="card-body text-center">

--- a/skins/neowx-material/package-lock.json
+++ b/skins/neowx-material/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neowx-material",
-  "version": "1.57.1",
+  "version": "1.57.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neowx-material",
-      "version": "1.57.1",
+      "version": "1.57.2",
       "license": "MIT",
       "dependencies": {
         "sass": "1.99.0"

--- a/skins/neowx-material/package.json
+++ b/skins/neowx-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neowx-material",
-  "version": "1.57.1",
+  "version": "1.57.2",
   "description": "The most versatile and modern weewx skin",
   "main": "index.js",
   "repository": "https://github.com/neoground/neowx-material",

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -18,7 +18,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
 
-    version = 1.57.1
+    version = 1.57.2
 
     # Language
     # -------------------------------------------------------------------------

--- a/skins/neowx-material/week.html.tmpl
+++ b/skins/neowx-material/week.html.tmpl
@@ -18,15 +18,11 @@
                     <h3 class="h5-responsive $Extras.color-text">
                         $getVar('obs.label.' + name)
                         #if $name == 'windSpeed'
-
                             <i class="wi wi-wind from-$week.wind.vecdir.formatted-deg"
                             title="$week.wind.vecdir.formatted°" data-toggle="tooltip" data-html="true"></i>
-
                         #end if
                     </h3>
-
                     #if $name == 'windSpeed'
-
                         <div class="row">
                             <div class="col-3 text-muted font-small lo-text">
                                 $week.wind.avg <br>
@@ -44,13 +40,9 @@
                                 ($week.wind.maxtime.format($Extras.Formatting.datetime))
                             </div>
                         </div>
-
                     #else if $name == 'rain'
-
                         <div class="row">
-                            <div class="col-3 text-muted font-small">
-
-                            </div>
+                            <div class="col-3 text-muted font-small"></div>
                             <div class="col-6">
                                 <h4 class="h2-responsive">$week.rain.sum</h4>
                             </div>
@@ -59,10 +51,7 @@
                                 ($week.rainRate.maxtime.format($Extras.Formatting.datetime))
                             </div>
                         </div>
-
                     #else if $name in set(['lightning_strike_count', 'windrun', 'ET'])
-
-                        ## Sum-only display: no min/max context
                         <div class="row">
                             <div class="col-3 text-muted font-small lo-text"></div>
                             <div class="col-6">
@@ -70,9 +59,7 @@
                             </div>
                             <div class="col-3 text-muted font-small hi-text"></div>
                         </div>
-
                     #else
-
                         <div class="row">
                             <div class="col-3 text-muted font-small lo-text">
                                 $getVar('week.' + name + '.min') <br>
@@ -86,9 +73,7 @@
                                 ($getVar('week.' + name + '.maxtime').format($Extras.Formatting.datetime))
                             </div>
                         </div>
-
                     #end if
-
                 </div>
             </div>
         </div>
@@ -97,12 +82,10 @@
 
 ## +-------------------------------------------------------------------------+
 ## | Template for display card of a single chart (right column)              |
-## | Chart values are defined in the JS section below                        |
 ## +-------------------------------------------------------------------------+
 
-#def chartCard($name, $id, $name2 = "XX")
+#def chartCard($name, $id, $name2="XX")
     #if $name.startswith('customChart')
-        ## Custom chart: read config from Extras.Appearance
         #set $cc = $Extras.Appearance.get($name, {})
         #if $cc
             #set $cc_title = $cc.get('title', $name)
@@ -144,6 +127,14 @@
     #end if
 #end def
 
+## Access HistoryReport section from skin.conf
+#set $table_dict = $generator.skin_dict['HistoryReport']
+#set $threshold_unit = $table_dict.get('threshold_unit', 'degree_C')
+#set $SummerDay = ($table_dict.get('summer_days_threshold', 25.0),  $threshold_unit)
+#set $TropicDay = ($table_dict.get('tropical_days_threshold', 30.0),  $threshold_unit)
+#set $TropicNight = ($table_dict.get('tropical_nights_threshold', 20.0),  $threshold_unit)
+#set $ArcticDay = ($table_dict.get('arctic_days_threshold', 0.0),  $threshold_unit)
+
 ## +-------------------------------------------------------------------------+
 ## | The main page layout                                                    |
 ## +-------------------------------------------------------------------------+
@@ -168,8 +159,59 @@
                     #for $x in $Extras.Appearance.values_order
                         #if $x not in $seen_cards
                             #silent $seen_cards.add($x)
-                            #if $x == "forecast"
-                                #include "forecast.inc"
+                            #if $x == "ET"
+                                #if $week.ET.has_data and $week.ET.sum.raw is not None and $week.ET.sum.raw > 0.0
+                                    $valuesCard('ET')
+                                #end if
+                            #else if $x == "temperatureThresholdDays"
+                                <div class="col-12 col-md-6 col-xl-4 mb-4">
+                                    <div class="card">
+                                        <div class="card-body text-center">
+                                            <h3 class="h5-responsive $Extras.color-text">$gettext("summer_days")</h3>
+                                            <div class="row">
+                                                <div class="col-3 text-muted font-small"></div>
+                                                <div class="col-6"><h4 class="h2-responsive">$week.outTemp.max_ge($SummerDay).nolabel("%6d", " N/A")</h4></div>
+                                                <div class="col-3 text-muted font-small hi-text"></div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-12 col-md-6 col-xl-4 mb-4">
+                                    <div class="card">
+                                        <div class="card-body text-center">
+                                            <h3 class="h5-responsive $Extras.color-text">$gettext("tropical_days")</h3>
+                                            <div class="row">
+                                                <div class="col-3 text-muted font-small"></div>
+                                                <div class="col-6"><h4 class="h2-responsive">$week.outTemp.max_ge($TropicDay).nolabel("%6d", " N/A")</h4></div>
+                                                <div class="col-3 text-muted font-small hi-text"></div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-12 col-md-6 col-xl-4 mb-4">
+                                    <div class="card">
+                                        <div class="card-body text-center">
+                                            <h3 class="h5-responsive $Extras.color-text">$gettext("tropical_nights")</h3>
+                                            <div class="row">
+                                                <div class="col-3 text-muted font-small"></div>
+                                                <div class="col-6"><h4 class="h2-responsive">$week.outTemp.min_ge($TropicNight).nolabel("%6d", " N/A")</h4></div>
+                                                <div class="col-3 text-muted font-small hi-text"></div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-12 col-md-6 col-xl-4 mb-4">
+                                    <div class="card">
+                                        <div class="card-body text-center">
+                                            <h3 class="h5-responsive $Extras.color-text">$gettext("arctic_days")</h3>
+                                            <div class="row">
+                                                <div class="col-3 text-muted font-small"></div>
+                                                <div class="col-6"><h4 class="h2-responsive">$week.outTemp.max_le($ArcticDay).nolabel("%6d", " N/A")</h4></div>
+                                                <div class="col-3 text-muted font-small hi-text"></div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             #else
                                 $valuesCard($x)
                             #end if

--- a/skins/neowx-material/year-%Y.html.tmpl
+++ b/skins/neowx-material/year-%Y.html.tmpl
@@ -146,7 +146,7 @@
 <html lang="$lang">
     <head>
         <title>
-            $year_name | $station.location
+            $gettext("year") $year_name | $station.location
         </title>
         #include "head.inc"
     </head>
@@ -160,14 +160,67 @@
             <div class="row mt-3 temprow align-content-start">
 
                 <div class="col-12 mb-4 text-center">
-                    <h2 class="h2-responsive text-dark">$year_name</h2>
+                    <h2 class="h2-responsive text-dark">$gettext("year") $year_name</h2>
                 </div>
+
+                #for $month in $year.months
+                    #if $month.outTemp.has_data
+                        <div class="col-12 col-lg-6 mb-4 text-center">
+                            <div class="card">
+                                <div class="card-body">
+                                    <h4 class="h4-responsive $Extras.color-text">$month.dateTime.format("%B")</h4>
+                                    <div class="row text-dark my-2">
+                                        <div class="col-4">
+                                            <i class="wi wi-thermometer h5-responsive"></i><br>
+                                            $month.outTemp.min<br>$month.outTemp.max
+                                        </div>
+                                        <div class="col-4">
+                                            <i class="wi wi-strong-wind h5-responsive"></i><br>
+                                            $month.wind.max<br>
+                                            $month.wind.vecdir.ordinal_compass
+                                            <i class="wi wi-wind from-$month.wind.vecdir.formatted-deg mr-2"
+                                            title="$month.wind.vecdir.formatted°" data-toggle="tooltip" data-html="true"></i>
+                                        </div>
+                                        <div class="col-4">
+                                            <i class="wi wi-showers h5-responsive"></i><br>
+                                            $month.rain.sum
+                                        </div>
+                                    </div>
+                                    <div class="row d-flex align-items-center">
+                                        <div class="col-6">
+                                            <a href="month-${year_name}-${month.dateTime.format('%m')}.html"
+                                            class="btn btn-$Extras.color btn-block">
+                                            $gettext("more")
+                                            </a>
+                                        </div>
+                                        <div class="col-6">
+                                            <a href="archive/NOAA-${year_name}-${month.dateTime.format('%m')}.txt"
+                                            class="btn btn-primary btn-block">
+                                            $gettext("noaa_export")
+                                            </a>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    #end if
+                #end for
+
+            </div>
+
+            <hr class="m-0 mb-4 rowdivider">
+
+            <div class="row mt-3 graphrow align-content-start">
 
                 #set seen_cards = set()
                 #for $x in $Extras.Appearance.values_order
                     #if $x not in $seen_cards
                         #silent $seen_cards.add($x)
-                        #if $x == "temperatureThresholdDays"
+                        #if $x == "ET"
+                            #if $year.ET.has_data and $year.ET.sum.raw is not None and $year.ET.sum.raw > 0.0
+                                $valuesCard('ET')
+                            #end if
+                        #else if $x == "temperatureThresholdDays"
                             <div class="col-12 col-lg-6 mb-4">
                                 <div class="card">
                                     <div class="card-body text-center">
@@ -216,7 +269,7 @@
                                     </div>
                                 </div>
                             </div>
-                        #else
+                        #else if $x != "forecast"
                             $valuesCard($x)
                         #end if
                     #end if

--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -162,7 +162,11 @@
                     #for $x in $Extras.Appearance.values_order
                         #if $x not in $seen_cards
                             #silent $seen_cards.add($x)
-                            #if $x == "temperatureThresholdDays"
+                            #if $x == "ET"
+                                #if $year.ET.has_data and $year.ET.sum.raw is not None and $year.ET.sum.raw > 0.0
+                                    $valuesCard('ET')
+                                #end if
+                            #else if $x == "temperatureThresholdDays"
                                 <div class="col-12 col-md-6 col-xl-4 mb-4">
                                     <div class="card">
                                         <div class="card-body text-center">

--- a/skins/neowx-material/yesterday.html.tmpl
+++ b/skins/neowx-material/yesterday.html.tmpl
@@ -3,11 +3,11 @@
 ## |    yesterday.html.tmpl            Template file for "yesterday" page    |
 ## +-------------------------------------------------------------------------+
 
+#attr $active_nav = 'yesterday'
+
 ## +-------------------------------------------------------------------------+
 ## | Template for display card of values (left column)                       |
 ## +-------------------------------------------------------------------------+
-
-#set global $number_of_records = int(86400 / int($Extras.Charts.current_timespan)) + 1 ## Number of records corresponding to 24 hours
 
 #def valuesCard($name)
     ## ET requires a valid positive sum to be shown
@@ -18,15 +18,11 @@
                     <h3 class="h5-responsive $Extras.color-text">
                         $getVar('obs.label.' + name)
                         #if $name == 'windSpeed'
-
                             <i class="wi wi-wind from-$yesterday.wind.vecdir.formatted-deg"
                             title="$yesterday.wind.vecdir.formatted°" data-toggle="tooltip" data-html="true"></i>
-
                         #end if
                     </h3>
-
                     #if $name == 'windSpeed'
-
                         <div class="row">
                             <div class="col-3 text-muted font-small lo-text">
                                 $yesterday.wind.avg <br>
@@ -44,13 +40,9 @@
                                 ($yesterday.wind.maxtime.format($Extras.Formatting.datetime_today))
                             </div>
                         </div>
-
                     #else if $name == 'rain'
-
                         <div class="row">
-                            <div class="col-3 text-muted font-small">
-
-                            </div>
+                            <div class="col-3 text-muted font-small"></div>
                             <div class="col-6">
                                 <h4 class="h2-responsive">$yesterday.rain.sum</h4>
                             </div>
@@ -59,10 +51,7 @@
                                 ($yesterday.rainRate.maxtime.format($Extras.Formatting.datetime_today))
                             </div>
                         </div>
-
                     #else if $name in set(['lightning_strike_count', 'windrun', 'ET'])
-
-                        ## Sum-only display: no min/max context
                         <div class="row">
                             <div class="col-3 text-muted font-small lo-text"></div>
                             <div class="col-6">
@@ -70,9 +59,7 @@
                             </div>
                             <div class="col-3 text-muted font-small hi-text"></div>
                         </div>
-
                     #else
-
                         <div class="row">
                             <div class="col-3 text-muted font-small lo-text">
                                 $getVar('yesterday.' + name + '.min') <br>
@@ -86,9 +73,7 @@
                                 ($getVar('yesterday.' + name + '.maxtime').format($Extras.Formatting.datetime_today))
                             </div>
                         </div>
-
                     #end if
-
                 </div>
             </div>
         </div>
@@ -97,12 +82,10 @@
 
 ## +-------------------------------------------------------------------------+
 ## | Template for display card of a single chart (right column)              |
-## | Chart values are defined in the JS section below                        |
 ## +-------------------------------------------------------------------------+
 
-#def chartCard($name, $id, $name2 = "XX")
+#def chartCard($name, $id, $name2="XX")
     #if $name.startswith('customChart')
-        ## Custom chart: read config from Extras.Appearance
         #set $cc = $Extras.Appearance.get($name, {})
         #if $cc
             #set $cc_title = $cc.get('title', $name)
@@ -125,7 +108,7 @@
                 </div>
             #end if
         #end if
-    #else if ($getVar('yesterday.' + name + '.has_data') or $name == "windvec") and $name != "appTemp" and $name != "windrun" and ($name != 'ET' or ($yesterday.ET.sum.raw is not None and $yesterday.ET.sum.raw > 0.0))
+    #else if ($getVar('yesterday.' + name + '.has_data') or $name == "windvec") and $name not in ["appTemp", "windrun"] and ($name != 'ET' or ($yesterday.ET.sum.raw is not None and $yesterday.ET.sum.raw > 0.0))
         <div class="col-12 col-xl-6 mb-4">
             <div class="card card-chart" id="${name}-chart" data-name="$name">
                 <div class="card-body text-center">
@@ -144,6 +127,16 @@
     #end if
 #end def
 
+## Access HistoryReport section from skin.conf
+#set $table_dict = $generator.skin_dict['HistoryReport']
+#set $threshold_unit = $table_dict.get('threshold_unit', 'degree_C')
+#set $SummerDay = ($table_dict.get('summer_days_threshold', 25.0),  $threshold_unit)
+#set $TropicDay = ($table_dict.get('tropical_days_threshold', 30.0),  $threshold_unit)
+#set $TropicNight = ($table_dict.get('tropical_nights_threshold', 20.0),  $threshold_unit)
+#set $ArcticDay = ($table_dict.get('arctic_days_threshold', 0.0),  $threshold_unit)
+
+#set global $number_of_records = int(86400 / int($Extras.Charts.current_timespan)) + 1 ## Number of records corresponding to 24 hours
+
 ## +-------------------------------------------------------------------------+
 ## | The main page layout                                                    |
 ## +-------------------------------------------------------------------------+
@@ -158,7 +151,6 @@
     </head>
     <body class="${Extras.Appearance.mode}-theme main-bg" ontouchstart="">
 
-        #attr $active_nav = 'yesterday'
         #include "header.inc"
 
         <main>
@@ -169,8 +161,59 @@
                     #for $x in $Extras.Appearance.values_order
                         #if $x not in $seen_cards
                             #silent $seen_cards.add($x)
-                            #if $x == "forecast"
-                                #include "forecast.inc"
+                            #if $x == "ET"
+                                #if $yesterday.ET.has_data and $yesterday.ET.sum.raw is not None and $yesterday.ET.sum.raw > 0.0
+                                    $valuesCard('ET')
+                                #end if
+                            #else if $x == "temperatureThresholdDays"
+                                <div class="col-12 col-md-6 col-xl-4 mb-4">
+                                    <div class="card">
+                                        <div class="card-body text-center">
+                                            <h3 class="h5-responsive $Extras.color-text">$gettext("summer_days")</h3>
+                                            <div class="row">
+                                                <div class="col-3 text-muted font-small"></div>
+                                                <div class="col-6"><h4 class="h2-responsive">$yesterday.outTemp.max_ge($SummerDay).nolabel("%6d", " N/A")</h4></div>
+                                                <div class="col-3 text-muted font-small hi-text"></div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-12 col-md-6 col-xl-4 mb-4">
+                                    <div class="card">
+                                        <div class="card-body text-center">
+                                            <h3 class="h5-responsive $Extras.color-text">$gettext("tropical_days")</h3>
+                                            <div class="row">
+                                                <div class="col-3 text-muted font-small"></div>
+                                                <div class="col-6"><h4 class="h2-responsive">$yesterday.outTemp.max_ge($TropicDay).nolabel("%6d", " N/A")</h4></div>
+                                                <div class="col-3 text-muted font-small hi-text"></div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-12 col-md-6 col-xl-4 mb-4">
+                                    <div class="card">
+                                        <div class="card-body text-center">
+                                            <h3 class="h5-responsive $Extras.color-text">$gettext("tropical_nights")</h3>
+                                            <div class="row">
+                                                <div class="col-3 text-muted font-small"></div>
+                                                <div class="col-6"><h4 class="h2-responsive">$yesterday.outTemp.min_ge($TropicNight).nolabel("%6d", " N/A")</h4></div>
+                                                <div class="col-3 text-muted font-small hi-text"></div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-12 col-md-6 col-xl-4 mb-4">
+                                    <div class="card">
+                                        <div class="card-body text-center">
+                                            <h3 class="h5-responsive $Extras.color-text">$gettext("arctic_days")</h3>
+                                            <div class="row">
+                                                <div class="col-3 text-muted font-small"></div>
+                                                <div class="col-6"><h4 class="h2-responsive">$yesterday.outTemp.max_le($ArcticDay).nolabel("%6d", " N/A")</h4></div>
+                                                <div class="col-3 text-muted font-small hi-text"></div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             #else
                                 $valuesCard($x)
                             #end if
@@ -557,7 +600,7 @@
             // Chart type overrides for charts that are not 'area' (default)
             #set $default_chart_types = {'windDir': 'line', 'rain': 'bar', 'snowDepth': 'bar', 'lightning_strike_count': 'bar', 'lightning_noise_count': 'bar', 'lightning_disturber_count': 'bar', 'lightning_distance': 'bar'}
             // Aggregate column overrides for charts that are not 'avg' (default)
-            #set $default_chart_columns = {'windDir': 'vecdir', 'ET': 'sum', 'rain': 'sum', 'UV': 'max', 'radiation': 'max', 'luminosity': 'max', 'snowDepth': 'sum', 'lightning_strike_count': 'sum'}
+            #set $default_chart_columns = {'windDir':'vecdir', 'ET':'sum', 'rain':'sum', 'UV':'max', 'radiation':'max', 'luminosity':'max', 'snowDepth':'sum', 'lightning_strike_count':'sum'}
             // Series1 field overrides for charts where the series field name differs from the chart name
             #set $default_chart_series = {'windDir': 'wind'}
 


### PR DESCRIPTION
During the refactoring some feature got lost
now if you define 
values_order = ..., temperatureThresholdDays, ...
you will see again 
<img width="1420" height="251" alt="image" src="https://github.com/user-attachments/assets/e5f11a54-1de5-437b-820e-9a97adee810c" />
valid for week, month and year pages

Also fixed 
https://github.com/seehase/neowx-material/issues/318
to bring back
<img width="1434" height="786" alt="image" src="https://github.com/user-attachments/assets/26ce7e0c-d922-4f02-ac4c-7d9f73d829aa" />

to get year pages up to date, please remove all year-yyyy.html file from your web-root, to be regenerated again

<img width="770" height="489" alt="image" src="https://github.com/user-attachments/assets/40673f9b-a2fb-450c-9b37-8d34f4190261" />
