### PR TITLE
feat: multiple columns on customCharts

### DIFF
--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class BasicInstaller(ExtensionInstaller):
     def __init__(self):
         super(BasicInstaller, self).__init__(
-            version="1.57.2",
+            version="1.58.0",
             name="neowx-material",
             description="The most versatile and modern weewx skin",
             author="Neoweewx",

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -748,27 +748,70 @@
                     #set $cc = $Extras.Appearance.get($x, {})
                     #if $cc
                         #set $cc_type = $cc.get('charttype', 'area')
-                        #set $cc_column = $cc.get('column', 'avg')
-                        #set $cc_values_raw = $cc.get('values', '')
+                        ## Page-specific override subsection (key = "current" for this page).
+                        #set $cc_page = $cc.get('current', {})
+                        ## Resolve column list: page → top-level → 'avg'
+                        #set $cc_column_raw = $cc_page.get('column', $cc.get('column', 'avg'))
+                        #if isinstance($cc_column_raw, list)
+                            #set $cc_cols = [c.strip() for c in $cc_column_raw if c.strip()]
+                        #else
+                            #set $cc_cols = [c.strip() for c in $cc_column_raw.split(',') if c.strip()]
+                        #end if
+                        #if len($cc_cols) == 0
+                            #set $cc_cols = ['avg']
+                        #end if
+                        ## Resolve values list: page → top-level
+                        #set $cc_values_raw = $cc_page.get('values', $cc.get('values', ''))
                         #if isinstance($cc_values_raw, list)
                             #set $cc_vals = [v.strip() for v in $cc_values_raw if v.strip()]
                         #else
                             #set $cc_vals = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
                         #end if
-                        #if len($cc_vals) > 0
-                            #set $s1 = $cc_vals[0]
-                            #set $s2 = $cc_vals[1] if len($cc_vals) > 1 else ""
-                            #set $s3 = $cc_vals[2] if len($cc_vals) > 2 else ""
-                            #set $s4 = $cc_vals[3] if len($cc_vals) > 3 else ""
-                            #set $s5 = $cc_vals[4] if len($cc_vals) > 4 else ""
-                            #set $s6 = $cc_vals[5] if len($cc_vals) > 5 else ""
-                            #set $s7 = $cc_vals[6] if len($cc_vals) > 6 else ""
-                            #set $s8 = $cc_vals[7] if len($cc_vals) > 7 else ""
-                            ## Pre-compute the chart element ID as a plain Cheetah variable.
-                            ## Using "${x}chart" as a string literal in a function argument is
-                            ## NOT interpolated by Cheetah, causing querySelector to fail.
+                        ## Build cc_series_pairs from field-name keys or values+column fallback
+                        #set $CC_RESERVED = set(['column', 'values', 'title', 'charttype'])
+                        #set $cc_field_map = {k: v for k, v in $cc_page.items() if k not in $CC_RESERVED and isinstance(v, (str, list))}
+                        #if len($cc_field_map) > 0
+                            #set $cc_series_pairs = []
+                            #for $field_k, $col_v in $cc_field_map.items()
+                                #if isinstance($col_v, list)
+                                    #set $cols_k = [c.strip() for c in $col_v if c.strip()]
+                                #else
+                                    #set $cols_k = [c.strip() for c in $col_v.split(',') if c.strip()]
+                                #end if
+                                #if $cols_k
+                                    #silent $cc_series_pairs.append(($field_k, $cols_k))
+                                #end if
+                            #end for
+                        #else
+                            #set $cc_series_pairs = [($v, $cc_cols) for $v in $cc_vals]
+                        #end if
+                        ## Render – current page always uses only the first column per field
+                        ## (min/max are not meaningful at 10-min granularity; no column suffix)
+                        #if len($cc_series_pairs) > 0 and $x in $Extras.Appearance.charts_order
                             #set $cc_id = $x + "chart"
-                            $getChartJsCode($x, $cc_id, $cc_type, $s1, $s2, $cc_column, $s3, $s4, $s5, $s6, $s7, $s8)
+                            var chartElement = document.querySelector('#$cc_id');
+                            if (chartElement) {
+                                new ApexCharts(chartElement, {
+                                    ...graph_${cc_type}_config,
+                                    yaxis: {
+                                        labels: {
+                                            formatter: function (val) {
+                                                return formatNumber(val, "$getVar('unit.format.' + cc_series_pairs[0][0])") + "$getVar('unit.label.' + cc_series_pairs[0][0])";
+                                            }
+                                        },
+                                    },
+                                    series: [
+                                        #for $val, $cols in $cc_series_pairs
+                                            #if $getVar('day.' + val + '.has_data')
+                                                {
+                                                    name: "$getVar('obs.label.' + val)",
+                                                    data: [ $getChartData(val, cols[0]) ]
+                                                },
+                                            #end if
+                                        #end for
+                                    ]
+                                }).render()
+                            }
                         #end if
                     #end if
                 #end if

--- a/skins/neowx-material/month-%Y-%m.html.tmpl
+++ b/skins/neowx-material/month-%Y-%m.html.tmpl
@@ -494,7 +494,7 @@
                 #end if
             #end for
 
-            // Custom charts
+            // Custom charts (dynamically generated from skin.conf [[Appearance]] [[[customChart*]]] sections)
             #set $seen_custom_charts = set()
             #for $x in $Extras.Appearance.charts_order
                 #if $x.startswith('customChart') and $x not in $seen_custom_charts
@@ -502,24 +502,78 @@
                     #set $cc = $Extras.Appearance.get($x, {})
                     #if $cc
                         #set $cc_type = $cc.get('charttype', 'area')
-                        #set $cc_column = $cc.get('column', 'avg')
-                        #set $cc_values_raw = $cc.get('values', '')
+                        ## Page-specific override subsection (key = "month" for this page).
+                        #set $cc_page = $cc.get('month', {})
+                        ## Resolve column list: page → top-level → 'avg'
+                        #set $cc_column_raw = $cc_page.get('column', $cc.get('column', 'avg'))
+                        #if isinstance($cc_column_raw, list)
+                            #set $cc_cols = [c.strip() for c in $cc_column_raw if c.strip()]
+                        #else
+                            #set $cc_cols = [c.strip() for c in $cc_column_raw.split(',') if c.strip()]
+                        #end if
+                        #if len($cc_cols) == 0
+                            #set $cc_cols = ['avg']
+                        #end if
+                        ## Resolve values list: page → top-level
+                        #set $cc_values_raw = $cc_page.get('values', $cc.get('values', ''))
                         #if isinstance($cc_values_raw, list)
                             #set $cc_vals = [v.strip() for v in $cc_values_raw if v.strip()]
                         #else
                             #set $cc_vals = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
                         #end if
-                        #if len($cc_vals) > 0
-                            #set $s1 = $cc_vals[0]
-                            #set $s2 = $cc_vals[1] if len($cc_vals) > 1 else ""
-                            #set $s3 = $cc_vals[2] if len($cc_vals) > 2 else ""
-                            #set $s4 = $cc_vals[3] if len($cc_vals) > 3 else ""
-                            #set $s5 = $cc_vals[4] if len($cc_vals) > 4 else ""
-                            #set $s6 = $cc_vals[5] if len($cc_vals) > 5 else ""
-                            #set $s7 = $cc_vals[6] if len($cc_vals) > 6 else ""
-                            #set $s8 = $cc_vals[7] if len($cc_vals) > 7 else ""
+                        ## Build cc_series_pairs from field-name keys or values+column fallback
+                        #set $CC_RESERVED = set(['column', 'values', 'title', 'charttype'])
+                        #set $cc_field_map = {k: v for k, v in $cc_page.items() if k not in $CC_RESERVED and isinstance(v, (str, list))}
+                        #if len($cc_field_map) > 0
+                            #set $cc_series_pairs = []
+                            #for $field_k, $col_v in $cc_field_map.items()
+                                #if isinstance($col_v, list)
+                                    #set $cols_k = [c.strip() for c in $col_v if c.strip()]
+                                #else
+                                    #set $cols_k = [c.strip() for c in $col_v.split(',') if c.strip()]
+                                #end if
+                                #if $cols_k
+                                    #silent $cc_series_pairs.append(($field_k, $cols_k))
+                                #end if
+                            #end for
+                        #else
+                            #set $cc_series_pairs = [($v, $cc_cols) for $v in $cc_vals]
+                        #end if
+                        ## Render chart JS
+                        #if len($cc_series_pairs) > 0 and $x in $Extras.Appearance.charts_order
                             #set $cc_id = $x + "chart"
-                            $getChartJsCode($x, $cc_id, $cc_type, $s1, $s2, $cc_column, $s3, $s4, $s5, $s6, $s7, $s8)
+                            var chartElement = document.querySelector('#$cc_id');
+                            if (chartElement) {
+                                new ApexCharts(chartElement, {
+                                    ...graph_${cc_type}_config,
+                                    yaxis: {
+                                        labels: {
+                                            formatter: function (val) {
+                                                return formatNumber(val, "$getVar('unit.format.' + cc_series_pairs[0][0])") + "$getVar('unit.label.' + cc_series_pairs[0][0])";
+                                            }
+                                        },
+                                    },
+                                    series: [
+                                        #for $val, $cols in $cc_series_pairs
+                                            #if $getVar('month.' + val + '.has_data')
+                                                #if len($cols) == 1
+                                                    {
+                                                        name: "$getVar('obs.label.' + val)",
+                                                        data: [ $getChartData(val, cols[0]) ]
+                                                    },
+                                                #else
+                                                    #for $col in $cols
+                                                        {
+                                                            name: "$getVar('obs.label.' + val) $gettext($col)",
+                                                            data: [ $getChartData(val, col) ]
+                                                        },
+                                                    #end for
+                                                #end if
+                                            #end if
+                                        #end for
+                                    ]
+                                }).render()
+                            }
                         #end if
                     #end if
                 #end if

--- a/skins/neowx-material/month.html.tmpl
+++ b/skins/neowx-material/month.html.tmpl
@@ -631,24 +631,78 @@
                     #set $cc = $Extras.Appearance.get($x, {})
                     #if $cc
                         #set $cc_type = $cc.get('charttype', 'area')
-                        #set $cc_column = $cc.get('column', 'avg')
-                        #set $cc_values_raw = $cc.get('values', '')
+                        ## Page-specific override subsection (key = "month" for this page).
+                        #set $cc_page = $cc.get('month', {})
+                        ## Resolve column list: page → top-level → 'avg'
+                        #set $cc_column_raw = $cc_page.get('column', $cc.get('column', 'avg'))
+                        #if isinstance($cc_column_raw, list)
+                            #set $cc_cols = [c.strip() for c in $cc_column_raw if c.strip()]
+                        #else
+                            #set $cc_cols = [c.strip() for c in $cc_column_raw.split(',') if c.strip()]
+                        #end if
+                        #if len($cc_cols) == 0
+                            #set $cc_cols = ['avg']
+                        #end if
+                        ## Resolve values list: page → top-level
+                        #set $cc_values_raw = $cc_page.get('values', $cc.get('values', ''))
                         #if isinstance($cc_values_raw, list)
                             #set $cc_vals = [v.strip() for v in $cc_values_raw if v.strip()]
                         #else
                             #set $cc_vals = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
                         #end if
-                        #if len($cc_vals) > 0
-                            #set $s1 = $cc_vals[0]
-                            #set $s2 = $cc_vals[1] if len($cc_vals) > 1 else ""
-                            #set $s3 = $cc_vals[2] if len($cc_vals) > 2 else ""
-                            #set $s4 = $cc_vals[3] if len($cc_vals) > 3 else ""
-                            #set $s5 = $cc_vals[4] if len($cc_vals) > 4 else ""
-                            #set $s6 = $cc_vals[5] if len($cc_vals) > 5 else ""
-                            #set $s7 = $cc_vals[6] if len($cc_vals) > 6 else ""
-                            #set $s8 = $cc_vals[7] if len($cc_vals) > 7 else ""
+                        ## Build cc_series_pairs from field-name keys or values+column fallback
+                        #set $CC_RESERVED = set(['column', 'values', 'title', 'charttype'])
+                        #set $cc_field_map = {k: v for k, v in $cc_page.items() if k not in $CC_RESERVED and isinstance(v, (str, list))}
+                        #if len($cc_field_map) > 0
+                            #set $cc_series_pairs = []
+                            #for $field_k, $col_v in $cc_field_map.items()
+                                #if isinstance($col_v, list)
+                                    #set $cols_k = [c.strip() for c in $col_v if c.strip()]
+                                #else
+                                    #set $cols_k = [c.strip() for c in $col_v.split(',') if c.strip()]
+                                #end if
+                                #if $cols_k
+                                    #silent $cc_series_pairs.append(($field_k, $cols_k))
+                                #end if
+                            #end for
+                        #else
+                            #set $cc_series_pairs = [($v, $cc_cols) for $v in $cc_vals]
+                        #end if
+                        ## Render chart JS
+                        #if len($cc_series_pairs) > 0 and $x in $Extras.Appearance.charts_order
                             #set $cc_id = $x + "chart"
-                            $getChartJsCode($x, $cc_id, $cc_type, $s1, $s2, $cc_column, $s3, $s4, $s5, $s6, $s7, $s8)
+                            var chartElement = document.querySelector('#$cc_id');
+                            if (chartElement) {
+                                new ApexCharts(chartElement, {
+                                    ...graph_${cc_type}_config,
+                                    yaxis: {
+                                        labels: {
+                                            formatter: function (val) {
+                                                return formatNumber(val, "$getVar('unit.format.' + cc_series_pairs[0][0])") + "$getVar('unit.label.' + cc_series_pairs[0][0])";
+                                            }
+                                        },
+                                    },
+                                    series: [
+                                        #for $val, $cols in $cc_series_pairs
+                                            #if $getVar('month.' + val + '.has_data')
+                                                #if len($cols) == 1
+                                                    {
+                                                        name: "$getVar('obs.label.' + val)",
+                                                        data: [ $getChartData(val, cols[0]) ]
+                                                    },
+                                                #else
+                                                    #for $col in $cols
+                                                        {
+                                                            name: "$getVar('obs.label.' + val) $gettext($col)",
+                                                            data: [ $getChartData(val, col) ]
+                                                        },
+                                                    #end for
+                                                #end if
+                                            #end if
+                                        #end for
+                                    ]
+                                }).render()
+                            }
                         #end if
                     #end if
                 #end if

--- a/skins/neowx-material/package-lock.json
+++ b/skins/neowx-material/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neowx-material",
-  "version": "1.57.2",
+  "version": "1.58.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neowx-material",
-      "version": "1.57.2",
+      "version": "1.58.0",
       "license": "MIT",
       "dependencies": {
         "sass": "1.99.0"

--- a/skins/neowx-material/package.json
+++ b/skins/neowx-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neowx-material",
-  "version": "1.57.2",
+  "version": "1.58.0",
   "description": "The most versatile and modern weewx skin",
   "main": "index.js",
   "repository": "https://github.com/neoground/neowx-material",

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -18,7 +18,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
 
-    version = 1.57.2
+    version = 1.58.0
 
     # Language
     # -------------------------------------------------------------------------
@@ -308,29 +308,74 @@
         #
         # Available charttype values: area, bar, line
         # Available column values:    avg, min, max, sum, vecdir
-        # values: comma-separated list of up to 8 WeeWX field names
+        #   column can be a single value OR a comma-separated list of values.
+        #   When multiple columns are given, each field is plotted once per column.
+        #   Series labelled "<obs label> <column label>" when more than one column
+        #   is used for a field; otherwise just "<obs label>".
+        # values: comma-separated list of WeeWX field names
         #
-        # Example:
+        # Per-page overrides
+        # -------------------------------------------------------------------------
+        # By default the top-level "values" and "column" apply to every page.
+        # Add an optional subsection named after the page to override per page.
+        # Supported page keys: current, yesterday, week, month, year
+        #
+        # Inside a page subsection you can use:
+        #   column = avg              – same column(s) for all fields on this page
+        #   values = fieldA, fieldB   – override which fields are shown (uses 'column' above)
+        #
+        #   OR – per-field column assignment using the field name as the key:
+        #   fieldA = col1, col2       – fieldA gets two columns (e.g. min and max)
+        #   fieldB = avg              – fieldB gets one column
+        #   When any field-name key is present the 'values'/'column' keys in that
+        #   subsection are ignored; only the explicitly listed fields are shown.
+        #
+        # Example – simple, same column on every page:
         # [[[customChart1]]]
-        #     title = My Custom Temperature Chart
+        #     title     = My Chart
         #     charttype = area
-        #     column = avg
-        #     values = outTemp, inTemp, extraTemp1, extraTemp2, extraTemp3, extraTemp4, extraTemp5, extraTemp6
-        # [[[customChart2]]]
-        #     title = My Custom Humidity Chart
+        #     column    = avg
+        #     values    = outTemp, inTemp
+        #
+        # Example – per-page and per-field column control:
+        # [[[customChartOutTemp]]]
+        #     title     = Outdoor Temperature
         #     charttype = area
-        #     column = avg
-        #     values = outhumidity, inHumidity, extraHumid1, extraHumid2, extraHumid3, extraHumid4, extraHumid5, extraHumid6
+        #     values    = outTemp, dewpoint   # default (current + pages without a subsection)
+        #     column    = avg                 # default
+        #     [[[[week]]]]
+        #         outTemp  = min, max         # outTemp → "Outside Temperature Min" + "… Max"
+        #         dewpoint = avg              # dewpoint → "Dew Point"  (no suffix for single col)
+        #     [[[[year]]]]
+        #         outTemp  = min, avg, max
         [[[customChartOutTemp]]]
             title = Outdoor Temperature
             charttype = area
             column = avg
             values = outTemp, dewpoint
+            [[[[week]]]]
+                outTemp  = min, max
+                dewpoint = avg
+            [[[[month]]]]
+                outTemp  = min, max
+                dewpoint = avg
+            [[[[year]]]]
+                outTemp  = min, max
+                dewpoint = avg
         [[[customChartInTemp]]]
             title = Indoor Temperature
             charttype = area
             column = avg
             values = inTemp, inDewpoint
+            [[[[week]]]]
+                inTemp  = min, max
+                inDewpoint = avg
+            [[[[month]]]]
+                inTemp  = min, max
+                inDewpoint = avg
+            [[[[year]]]]
+                inTemp  = min, max
+                inDewpoint = avg
         [[[customChartTemp]]]
             title = Temperature
             charttype = area

--- a/skins/neowx-material/week.html.tmpl
+++ b/skins/neowx-material/week.html.tmpl
@@ -561,24 +561,97 @@
                     #set $cc = $Extras.Appearance.get($x, {})
                     #if $cc
                         #set $cc_type = $cc.get('charttype', 'area')
-                        #set $cc_column = $cc.get('column', 'avg')
-                        #set $cc_values_raw = $cc.get('values', '')
+                        ## Page-specific override subsection (key = "week" for this page).
+                        ## Keys absent from the subsection fall back to the top-level default.
+                        #set $cc_page = $cc.get('week', {})
+                        ## Resolve default column list: page → top-level → 'avg'
+                        #set $cc_column_raw = $cc_page.get('column', $cc.get('column', 'avg'))
+                        #if isinstance($cc_column_raw, list)
+                            #set $cc_cols = [c.strip() for c in $cc_column_raw if c.strip()]
+                        #else
+                            #set $cc_cols = [c.strip() for c in $cc_column_raw.split(',') if c.strip()]
+                        #end if
+                        #if len($cc_cols) == 0
+                            #set $cc_cols = ['avg']
+                        #end if
+                        ## Resolve default values list: page → top-level
+                        #set $cc_values_raw = $cc_page.get('values', $cc.get('values', ''))
                         #if isinstance($cc_values_raw, list)
                             #set $cc_vals = [v.strip() for v in $cc_values_raw if v.strip()]
                         #else
                             #set $cc_vals = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
                         #end if
-                        #if len($cc_vals) > 0
-                            #set $s1 = $cc_vals[0]
-                            #set $s2 = $cc_vals[1] if len($cc_vals) > 1 else ""
-                            #set $s3 = $cc_vals[2] if len($cc_vals) > 2 else ""
-                            #set $s4 = $cc_vals[3] if len($cc_vals) > 3 else ""
-                            #set $s5 = $cc_vals[4] if len($cc_vals) > 4 else ""
-                            #set $s6 = $cc_vals[5] if len($cc_vals) > 5 else ""
-                            #set $s7 = $cc_vals[6] if len($cc_vals) > 6 else ""
-                            #set $s8 = $cc_vals[7] if len($cc_vals) > 7 else ""
+                        ##
+                        ## Build cc_series_pairs: list of (field, [columns])
+                        ##
+                        ## If the page subsection contains any field-name keys (anything that is
+                        ## NOT a reserved key and whose value is a string or list), those define
+                        ## exactly which fields are shown and with which columns on this page.
+                        ## Reserved keys inside a page subsection: column, values, title, charttype
+                        ## Example:
+                        ##   [[[[week]]]]
+                        ##       outTemp  = min, max   <- two series for outTemp
+                        ##       dewpoint = avg        <- one series for dewpoint
+                        ## If NO field-name keys are present, fall back to cc_vals + cc_cols.
+                        ##
+                        #set $CC_RESERVED = set(['column', 'values', 'title', 'charttype'])
+                        #set $cc_field_map = {k: v for k, v in $cc_page.items() if k not in $CC_RESERVED and isinstance(v, (str, list))}
+                        #if len($cc_field_map) > 0
+                            ## Per-field column assignment found
+                            #set $cc_series_pairs = []
+                            #for $field_k, $col_v in $cc_field_map.items()
+                                #if isinstance($col_v, list)
+                                    #set $cols_k = [c.strip() for c in $col_v if c.strip()]
+                                #else
+                                    #set $cols_k = [c.strip() for c in $col_v.split(',') if c.strip()]
+                                #end if
+                                #if $cols_k
+                                    #silent $cc_series_pairs.append(($field_k, $cols_k))
+                                #end if
+                            #end for
+                        #else
+                            ## No field-name keys: every field gets the same column list
+                            #set $cc_series_pairs = [($v, $cc_cols) for $v in $cc_vals]
+                        #end if
+                        ##
+                        ## Render the chart JS
+                        ##
+                        #if len($cc_series_pairs) > 0 and $x in $Extras.Appearance.charts_order
                             #set $cc_id = $x + "chart"
-                            $getChartJsCode($x, $cc_id, $cc_type, $s1, $s2, $cc_column, $s3, $s4, $s5, $s6, $s7, $s8)
+                            var chartElement = document.querySelector('#$cc_id');
+                            if (chartElement) {
+                                new ApexCharts(chartElement, {
+                                    ...graph_${cc_type}_config,
+                                    yaxis: {
+                                        labels: {
+                                            formatter: function (val) {
+                                                return formatNumber(val, "$getVar('unit.format.' + cc_series_pairs[0][0])") + "$getVar('unit.label.' + cc_series_pairs[0][0])";
+                                            }
+                                        },
+                                    },
+                                    series: [
+                                        #for $val, $cols in $cc_series_pairs
+                                            #if $getVar('week.' + val + '.has_data')
+                                                #if len($cols) == 1
+                                                    ## Single column for this field → no column label suffix
+                                                    {
+                                                        name: "$getVar('obs.label.' + val)",
+                                                        data: [ $getChartData(val, cols[0]) ]
+                                                    },
+                                                #else
+                                                    ## Multiple columns → append column label to series name
+                                                    #for $col in $cols
+                                                        {
+                                                            name: "$getVar('obs.label.' + val) $gettext($col)",
+                                                            data: [ $getChartData(val, col) ]
+                                                        },
+                                                    #end for
+                                                #end if
+                                            #end if
+                                        #end for
+                                    ]
+                                }).render()
+                            }
                         #end if
                     #end if
                 #end if

--- a/skins/neowx-material/year-%Y.html.tmpl
+++ b/skins/neowx-material/year-%Y.html.tmpl
@@ -522,7 +522,7 @@
         #end if
     #end for
 
-    // Custom charts
+    // Custom charts (dynamically generated from skin.conf [[Appearance]] [[[customChart*]]] sections)
     #set $seen_custom_charts = set()
     #for $x in $Extras.Appearance.charts_order
         #if $x.startswith('customChart') and $x not in $seen_custom_charts
@@ -530,24 +530,78 @@
             #set $cc = $Extras.Appearance.get($x, {})
             #if $cc
                 #set $cc_type = $cc.get('charttype', 'area')
-                #set $cc_column = $cc.get('column', 'avg')
-                #set $cc_values_raw = $cc.get('values', '')
+                ## Page-specific override subsection (key = "year" for this page).
+                #set $cc_page = $cc.get('year', {})
+                ## Resolve column list: page → top-level → 'avg'
+                #set $cc_column_raw = $cc_page.get('column', $cc.get('column', 'avg'))
+                #if isinstance($cc_column_raw, list)
+                    #set $cc_cols = [c.strip() for c in $cc_column_raw if c.strip()]
+                #else
+                    #set $cc_cols = [c.strip() for c in $cc_column_raw.split(',') if c.strip()]
+                #end if
+                #if len($cc_cols) == 0
+                    #set $cc_cols = ['avg']
+                #end if
+                ## Resolve values list: page → top-level
+                #set $cc_values_raw = $cc_page.get('values', $cc.get('values', ''))
                 #if isinstance($cc_values_raw, list)
                     #set $cc_vals = [v.strip() for v in $cc_values_raw if v.strip()]
                 #else
                     #set $cc_vals = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
                 #end if
-                #if len($cc_vals) > 0
-                    #set $s1 = $cc_vals[0]
-                    #set $s2 = $cc_vals[1] if len($cc_vals) > 1 else ""
-                    #set $s3 = $cc_vals[2] if len($cc_vals) > 2 else ""
-                    #set $s4 = $cc_vals[3] if len($cc_vals) > 3 else ""
-                    #set $s5 = $cc_vals[4] if len($cc_vals) > 4 else ""
-                    #set $s6 = $cc_vals[5] if len($cc_vals) > 5 else ""
-                    #set $s7 = $cc_vals[6] if len($cc_vals) > 6 else ""
-                    #set $s8 = $cc_vals[7] if len($cc_vals) > 7 else ""
+                ## Build cc_series_pairs from field-name keys or values+column fallback
+                #set $CC_RESERVED = set(['column', 'values', 'title', 'charttype'])
+                #set $cc_field_map = {k: v for k, v in $cc_page.items() if k not in $CC_RESERVED and isinstance(v, (str, list))}
+                #if len($cc_field_map) > 0
+                    #set $cc_series_pairs = []
+                    #for $field_k, $col_v in $cc_field_map.items()
+                        #if isinstance($col_v, list)
+                            #set $cols_k = [c.strip() for c in $col_v if c.strip()]
+                        #else
+                            #set $cols_k = [c.strip() for c in $col_v.split(',') if c.strip()]
+                        #end if
+                        #if $cols_k
+                            #silent $cc_series_pairs.append(($field_k, $cols_k))
+                        #end if
+                    #end for
+                #else
+                    #set $cc_series_pairs = [($v, $cc_cols) for $v in $cc_vals]
+                #end if
+                ## Render chart JS
+                #if len($cc_series_pairs) > 0 and $x in $Extras.Appearance.charts_order
                     #set $cc_id = $x + "chart"
-                    $getChartJsCode($x, $cc_id, $cc_type, $s1, $s2, $cc_column, $s3, $s4, $s5, $s6, $s7, $s8)
+                    var chartElement = document.querySelector('#$cc_id');
+                    if (chartElement) {
+                        new ApexCharts(chartElement, {
+                            ...graph_${cc_type}_config,
+                            yaxis: {
+                                labels: {
+                                    formatter: function (val) {
+                                        return formatNumber(val, "$getVar('unit.format.' + cc_series_pairs[0][0])") + "$getVar('unit.label.' + cc_series_pairs[0][0])";
+                                    }
+                                },
+                            },
+                            series: [
+                                #for $val, $cols in $cc_series_pairs
+                                    #if $getVar('year.' + val + '.has_data')
+                                        #if len($cols) == 1
+                                            {
+                                                name: "$getVar('obs.label.' + val)",
+                                                data: [ $getChartData(val, cols[0]) ]
+                                            },
+                                        #else
+                                            #for $col in $cols
+                                                {
+                                                    name: "$getVar('obs.label.' + val) $gettext($col)",
+                                                    data: [ $getChartData(val, col) ]
+                                                },
+                                            #end for
+                                        #end if
+                                    #end if
+                                #end for
+                            ]
+                        }).render()
+                    }
                 #end if
             #end if
         #end if

--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -488,24 +488,87 @@
                     #set $cc = $Extras.Appearance.get($x, {})
                     #if $cc
                         #set $cc_type = $cc.get('charttype', 'area')
-                        #set $cc_column = $cc.get('column', 'avg')
-                        #set $cc_values_raw = $cc.get('values', '')
+                        ## Page-specific override subsection (key = "year" for this page).
+                        ## Keys absent from the subsection fall back to the top-level default.
+                        #set $cc_page = $cc.get('year', {})
+                        ## Resolve default column list: page → top-level → 'avg'
+                        #set $cc_column_raw = $cc_page.get('column', $cc.get('column', 'avg'))
+                        #if isinstance($cc_column_raw, list)
+                            #set $cc_cols = [c.strip() for c in $cc_column_raw if c.strip()]
+                        #else
+                            #set $cc_cols = [c.strip() for c in $cc_column_raw.split(',') if c.strip()]
+                        #end if
+                        #if len($cc_cols) == 0
+                            #set $cc_cols = ['avg']
+                        #end if
+                        ## Resolve default values list: page → top-level
+                        #set $cc_values_raw = $cc_page.get('values', $cc.get('values', ''))
                         #if isinstance($cc_values_raw, list)
                             #set $cc_vals = [v.strip() for v in $cc_values_raw if v.strip()]
                         #else
                             #set $cc_vals = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
                         #end if
-                        #if len($cc_vals) > 0
-                            #set $s1 = $cc_vals[0]
-                            #set $s2 = $cc_vals[1] if len($cc_vals) > 1 else ""
-                            #set $s3 = $cc_vals[2] if len($cc_vals) > 2 else ""
-                            #set $s4 = $cc_vals[3] if len($cc_vals) > 3 else ""
-                            #set $s5 = $cc_vals[4] if len($cc_vals) > 4 else ""
-                            #set $s6 = $cc_vals[5] if len($cc_vals) > 5 else ""
-                            #set $s7 = $cc_vals[6] if len($cc_vals) > 6 else ""
-                            #set $s8 = $cc_vals[7] if len($cc_vals) > 7 else ""
+                        ##
+                        ## Build cc_series_pairs: list of (field, [columns])
+                        ## Reserved keys that are NOT field→column mappings:
+                        #set $CC_RESERVED = set(['column', 'values', 'title', 'charttype'])
+                        #set $cc_field_map = {k: v for k, v in $cc_page.items() if k not in $CC_RESERVED and isinstance(v, (str, list))}
+                        #if len($cc_field_map) > 0
+                            ## Per-field column assignment: fieldName = col1, col2
+                            #set $cc_series_pairs = []
+                            #for $field_k, $col_v in $cc_field_map.items()
+                                #if isinstance($col_v, list)
+                                    #set $cols_k = [c.strip() for c in $col_v if c.strip()]
+                                #else
+                                    #set $cols_k = [c.strip() for c in $col_v.split(',') if c.strip()]
+                                #end if
+                                #if $cols_k
+                                    #silent $cc_series_pairs.append(($field_k, $cols_k))
+                                #end if
+                            #end for
+                        #else
+                            ## No field-name keys: every field gets the same column list
+                            #set $cc_series_pairs = [($v, $cc_cols) for $v in $cc_vals]
+                        #end if
+                        ##
+                        ## Render the chart JS
+                        ##
+                        #if len($cc_series_pairs) > 0 and $x in $Extras.Appearance.charts_order
                             #set $cc_id = $x + "chart"
-                            $getChartJsCode($x, $cc_id, $cc_type, $s1, $s2, $cc_column, $s3, $s4, $s5, $s6, $s7, $s8)
+                            var chartElement = document.querySelector('#$cc_id');
+                            if (chartElement) {
+                                new ApexCharts(chartElement, {
+                                    ...graph_${cc_type}_config,
+                                    yaxis: {
+                                        labels: {
+                                            formatter: function (val) {
+                                                return formatNumber(val, "$getVar('unit.format.' + cc_series_pairs[0][0])") + "$getVar('unit.label.' + cc_series_pairs[0][0])";
+                                            }
+                                        },
+                                    },
+                                    series: [
+                                        #for $val, $cols in $cc_series_pairs
+                                            #if $getVar('year.' + val + '.has_data')
+                                                #if len($cols) == 1
+                                                    ## Single column → no column label suffix
+                                                    {
+                                                        name: "$getVar('obs.label.' + val)",
+                                                        data: [ $getChartData(val, cols[0]) ]
+                                                    },
+                                                #else
+                                                    ## Multiple columns → append column label to series name
+                                                    #for $col in $cols
+                                                        {
+                                                            name: "$getVar('obs.label.' + val) $gettext($col)",
+                                                            data: [ $getChartData(val, col) ]
+                                                        },
+                                                    #end for
+                                                #end if
+                                            #end if
+                                        #end for
+                                    ]
+                                }).render()
+                            }
                         #end if
                     #end if
                 #end if

--- a/skins/neowx-material/yesterday.html.tmpl
+++ b/skins/neowx-material/yesterday.html.tmpl
@@ -625,24 +625,78 @@
                     #set $cc = $Extras.Appearance.get($x, {})
                     #if $cc
                         #set $cc_type = $cc.get('charttype', 'area')
-                        #set $cc_column = $cc.get('column', 'avg')
-                        #set $cc_values_raw = $cc.get('values', '')
+                        ## Page-specific override subsection (key = "yesterday" for this page).
+                        #set $cc_page = $cc.get('yesterday', {})
+                        ## Resolve column list: page → top-level → 'avg'
+                        #set $cc_column_raw = $cc_page.get('column', $cc.get('column', 'avg'))
+                        #if isinstance($cc_column_raw, list)
+                            #set $cc_cols = [c.strip() for c in $cc_column_raw if c.strip()]
+                        #else
+                            #set $cc_cols = [c.strip() for c in $cc_column_raw.split(',') if c.strip()]
+                        #end if
+                        #if len($cc_cols) == 0
+                            #set $cc_cols = ['avg']
+                        #end if
+                        ## Resolve values list: page → top-level
+                        #set $cc_values_raw = $cc_page.get('values', $cc.get('values', ''))
                         #if isinstance($cc_values_raw, list)
                             #set $cc_vals = [v.strip() for v in $cc_values_raw if v.strip()]
                         #else
                             #set $cc_vals = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
                         #end if
-                        #if len($cc_vals) > 0
-                            #set $s1 = $cc_vals[0]
-                            #set $s2 = $cc_vals[1] if len($cc_vals) > 1 else ""
-                            #set $s3 = $cc_vals[2] if len($cc_vals) > 2 else ""
-                            #set $s4 = $cc_vals[3] if len($cc_vals) > 3 else ""
-                            #set $s5 = $cc_vals[4] if len($cc_vals) > 4 else ""
-                            #set $s6 = $cc_vals[5] if len($cc_vals) > 5 else ""
-                            #set $s7 = $cc_vals[6] if len($cc_vals) > 6 else ""
-                            #set $s8 = $cc_vals[7] if len($cc_vals) > 7 else ""
+                        ## Build cc_series_pairs from field-name keys or values+column fallback
+                        #set $CC_RESERVED = set(['column', 'values', 'title', 'charttype'])
+                        #set $cc_field_map = {k: v for k, v in $cc_page.items() if k not in $CC_RESERVED and isinstance(v, (str, list))}
+                        #if len($cc_field_map) > 0
+                            #set $cc_series_pairs = []
+                            #for $field_k, $col_v in $cc_field_map.items()
+                                #if isinstance($col_v, list)
+                                    #set $cols_k = [c.strip() for c in $col_v if c.strip()]
+                                #else
+                                    #set $cols_k = [c.strip() for c in $col_v.split(',') if c.strip()]
+                                #end if
+                                #if $cols_k
+                                    #silent $cc_series_pairs.append(($field_k, $cols_k))
+                                #end if
+                            #end for
+                        #else
+                            #set $cc_series_pairs = [($v, $cc_cols) for $v in $cc_vals]
+                        #end if
+                        ## Render chart JS
+                        #if len($cc_series_pairs) > 0 and $x in $Extras.Appearance.charts_order
                             #set $cc_id = $x + "chart"
-                            $getChartJsCode($x, $cc_id, $cc_type, $s1, $s2, $cc_column, $s3, $s4, $s5, $s6, $s7, $s8)
+                            var chartElement = document.querySelector('#$cc_id');
+                            if (chartElement) {
+                                new ApexCharts(chartElement, {
+                                    ...graph_${cc_type}_config,
+                                    yaxis: {
+                                        labels: {
+                                            formatter: function (val) {
+                                                return formatNumber(val, "$getVar('unit.format.' + cc_series_pairs[0][0])") + "$getVar('unit.label.' + cc_series_pairs[0][0])";
+                                            }
+                                        },
+                                    },
+                                    series: [
+                                        #for $val, $cols in $cc_series_pairs
+                                            #if $getVar('yesterday.' + val + '.has_data')
+                                                #if len($cols) == 1
+                                                    {
+                                                        name: "$getVar('obs.label.' + val)",
+                                                        data: [ $getChartData(val, cols[0]) ]
+                                                    },
+                                                #else
+                                                    #for $col in $cols
+                                                        {
+                                                            name: "$getVar('obs.label.' + val) $gettext($col)",
+                                                            data: [ $getChartData(val, col) ]
+                                                        },
+                                                    #end for
+                                                #end if
+                                            #end if
+                                        #end for
+                                    ]
+                                }).render()
+                            }
                         #end if
                     #end if
                 #end if


### PR DESCRIPTION
Provide multiple columns in custom charts to provide more flexibility and to be able to configure latest status quo

in custom charts you  can now configure e.g

```
        [[[customChartOutTemp]]]
            title = Outdoor Temperature
            charttype = area
            column = avg
            values = outTemp, dewpoint
            [[[[week]]]]
                outTemp  = min, max
                dewpoint = avg
            [[[[month]]]]
                outTemp  = min, max
                dewpoint = avg
            [[[[year]]]]
                outTemp  = min, max, avg
```

Showing in current page only outTemp and dewPoint non week and month outTemp with min/max and dewpoing avg and on year only outTemp min/max/avg

with that config all options should be possible
Current:
<img width="707" height="388" alt="image" src="https://github.com/user-attachments/assets/9057ee27-1e19-43d9-8a91-d179233249a2" />

Week:
<img width="703" height="390" alt="image" src="https://github.com/user-attachments/assets/fe9bac4c-ce99-437b-a33b-cf9b26a118d5" />

this fixes https://github.com/seehase/neowx-material/issues/319
