### PR TITLE
Limit yesterday timespan to 24h (0:00-0:00) for customCharts

### DIFF
--- a/skins/neowx-material/yesterday.html.tmpl
+++ b/skins/neowx-material/yesterday.html.tmpl
@@ -688,13 +688,13 @@
                                                 #if len($cols) == 1
                                                     {
                                                         name: "$getVar('obs.label.' + val)",
-                                                        data: [ $getChartData(val, cols[0]) ]
+                                                        data: [ $getChartData(val, cols[0]) ].slice(0, $number_of_records)
                                                     },
                                                 #else
                                                     #for $col in $cols
                                                         {
                                                             name: "$getVar('obs.label.' + val) $gettext($col)",
-                                                            data: [ $getChartData(val, col) ]
+                                                            data: [ $getChartData(val, col) ].slice(0, $number_of_records)
                                                         },
                                                     #end for
                                                 #end if


### PR DESCRIPTION
Current behavior of customCharts in yesterday.html
<img width="626" height="300" alt="0zrdirrp-neu-zu-lang" src="https://github.com/user-attachments/assets/166dfe42-ad40-46b0-9146-e994be706577" />

With the fix customCharts using the same timespan as the default Charts
<img width="626" height="300" alt="c5yjisyr-alt-korrekt" src="https://github.com/user-attachments/assets/79d2c776-89bc-48e9-9dce-5d7757679c15" />

