### PR TITLE
feat: Update telemetry page, add battery gauge

### DIFF
--- a/CHANGELOG-VOLTAGE-GAUGE.md
+++ b/CHANGELOG-VOLTAGE-GAUGE.md
@@ -1,0 +1,253 @@
+# Changelog: Voltage-Based Battery Gauge Feature
+
+## Date: May 25, 2026
+
+## Summary
+Added support for **voltage-based battery percentage gauges** with dynamic color coding on the telemetry page. Previously, battery gauges always showed 100% green regardless of actual voltage. Now they display accurate percentages with red/green color coding based on configurable thresholds.
+
+---
+
+## Changes Made
+
+### 1. Modified Files
+
+#### `skins/neowx-material/telemetry.html.tmpl`
+
+**New Functions Added:**
+
+1. **`calculateBatteryPercentage($name, $value)`**
+   - Calculates actual battery percentage based on voltage
+   - Uses `max_voltage` and `min_voltage` from configuration
+   - Returns value clamped between 0-100%
+   - Formula: `((current - min) / (max - min)) * 100`
+
+2. **`getBatteryColor($name, $percentage)`**
+   - Determines gauge color based on threshold
+   - Returns green (#4caf50) when above threshold
+   - Returns red (#f44336) when below threshold
+   - Uses `low_threshold` from configuration (default: 20%)
+
+**Modified Function:**
+
+3. **`batteryCard($name)`**
+   - Now calculates actual battery percentage
+   - Applies dynamic color to gauge based on threshold
+   - Displays percentage below the gauge
+   - Shows voltage value as main display (e.g., "4.5 V")
+   - Gauge width now reflects actual battery level
+
+**Visual Changes:**
+```diff
+- Fixed 100% green gauge
+- Fixed percentage display
+
++ Dynamic width based on actual percentage
++ Color changes from green to red below threshold
++ Percentage displayed below gauge
++ Smooth transitions for width and color changes
+```
+
+---
+
+### 2. Documentation Updates
+
+#### `battery-config-guide.md`
+
+**Added Sections:**
+- "Voltage-Based Battery Gauge (For Voltage Sensors)"
+- Complete explanation of new configuration options
+- Example configurations for different voltage ranges
+- Troubleshooting for voltage-based sensors
+
+**New Configuration Options Documented:**
+- `max_voltage` - Maximum voltage representing 100%
+- `min_voltage` - Minimum voltage representing 0%
+- `low_threshold` - Percentage threshold for red color
+
+**New Examples:**
+- Console Battery (0-4.5V)
+- 12V Battery System (10.5-14.4V)
+- 3.3V LiPo Battery (3.0-4.2V)
+- Mixed configuration (status + voltage sensors)
+
+---
+
+### 3. New Documentation Files
+
+#### `VOLTAGE-BATTERY-GAUGE-UPDATE.md`
+- Quick start guide for new feature
+- Configuration examples
+- Visual display explanation
+- Troubleshooting guide
+- Complete example configurations
+
+---
+
+## Configuration Examples
+
+### Basic Voltage Sensor (4.5V Battery)
+```ini
+[[[[consBatteryVoltage]]]]
+    enabled = yes
+    max_voltage = 4.5
+    min_voltage = 0.0
+    low_threshold = 50
+```
+
+### Result:
+- **4.5V** → 100% green gauge
+- **3.6V** → 80% green gauge
+- **2.0V** → 44% red gauge (below 50% threshold)
+
+---
+
+## Technical Details
+
+### Percentage Calculation
+```python
+percentage = ((current_voltage - min_voltage) / (max_voltage - min_voltage)) * 100
+percentage = max(0, min(100, percentage))  # Clamp to 0-100
+```
+
+### Color Determination
+```python
+if percentage < low_threshold:
+    color = "#f44336"  # Red
+else:
+    color = "#4caf50"  # Green
+```
+
+### CSS Transitions
+- Width transition: 0.3s ease
+- Color transition: 0.3s ease
+- Smooth visual feedback
+
+---
+
+## Backward Compatibility
+
+✅ **Fully backward compatible**
+- Existing status-based sensors (0=OK, 1=Low) continue to work
+- Old configurations don't need any changes
+- New voltage options are optional
+- Falls back to 100% if voltage settings not configured
+
+---
+
+## Testing Checklist
+
+- [x] Template syntax validation (no errors)
+- [x] Percentage calculation logic
+- [x] Color threshold logic
+- [x] Integration with existing battery mapping
+- [x] CSS transitions for smooth animation
+- [x] Documentation completeness
+- [x] Example configurations
+- [x] Troubleshooting guide
+
+---
+
+## Migration Guide
+
+### For Existing Users with Status Sensors
+**No action required!** Your existing configuration continues to work.
+
+### For Users with Voltage Sensors
+Add these three lines to each voltage sensor:
+
+```ini
+max_voltage = 4.5      # Your battery's max voltage
+min_voltage = 0.0      # Usually 0
+low_threshold = 50     # Adjust to your preference
+```
+
+---
+
+## Configuration Reference
+
+### New Options (All Optional)
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `max_voltage` | float | 100 | Maximum voltage (100%) |
+| `min_voltage` | float | 0 | Minimum voltage (0%) |
+| `low_threshold` | float | 20 | Red color threshold (%) |
+
+### When to Use
+- **Voltage sensors** (e.g., 0-5V, 0-12V) → Use new options
+- **Status sensors** (e.g., 0=OK, 1=Low) → Don't use new options
+
+---
+
+## Future Enhancements (Possible)
+
+- [ ] Configurable colors (not just green/red)
+- [ ] Multiple color thresholds (green/yellow/orange/red)
+- [ ] Warning threshold in addition to critical threshold
+- [ ] Different gauge styles (circular, vertical, etc.)
+- [ ] Battery percentage in card title
+- [ ] History of battery changes overview
+
+---
+
+## Support
+
+For issues or questions:
+1. Check `battery-config-guide.md` for detailed documentation
+2. Check `VOLTAGE-BATTERY-GAUGE-UPDATE.md` for quick reference
+3. Verify configuration syntax in `skin.conf`
+4. Check troubleshooting section in documentation
+
+---
+
+## Files Modified Summary
+
+```
+Modified:
+  ✏️  skins/neowx-material/telemetry.html.tmpl
+  ✏️  battery-config-guide.md
+
+Created:
+  ✨  VOLTAGE-BATTERY-GAUGE-UPDATE.md
+  ✨  CHANGELOG-VOLTAGE-GAUGE.md
+```
+
+---
+
+## Example Before/After
+
+### Before Update
+```
+┌──────────────────────────────────┐
+│   Console Battery                │
+│  4.5 V                           │
+│  [████████████████████]  ← 100%  │  Always 100% green
+└──────────────────────────────────┘
+```
+
+### After Update (with 3.6V actual voltage)
+```
+┌──────────────────────────────────┐
+│   Console Battery                │
+│                                  │
+│  0.0 V        4.5 V        4.5 V │
+│  (00:00)                 (14:23) │
+│                                  │
+│  [████████████████░░]  ← 80%     │  Actual 80% green
+│         80%                      │
+└──────────────────────────────────┘
+```
+
+### After Update (with 2.0V actual voltage - below threshold)
+```
+┌──────────────────────────────────┐
+│   Console Battery                │
+│                                  │
+│  0.0 V        2.0 V        4.5 V │
+│  (00:00)                 (14:23) │
+│                                  │
+│  [████████░░░░░░░░░░░]  ← 44%    │  Red below 50%
+│         44%                      │
+└──────────────────────────────────┘
+```
+

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ This is an **actively maintained** continuation of the NeoWX Material skin. The 
 ### 📊 Advanced Telemetry & Battery Monitoring
 - Dedicated telemetry page for station health
 - Battery status tracking for all sensors
-- Historical battery trend charts
+- Historical battery trend charts with configurable display order
 - Signal quality monitoring
+- Customizable card and chart ordering
 
 ### 🎨 Beautiful Material Design
 - Modern, clean interface
@@ -100,6 +101,7 @@ Monitor all your weather station sensors:
 - Telemetry page setup
 - Custom sensor configuration
 - Low battery alerts and monitoring
+- Configurable display order for cards and charts
 
 **Quick Links:**
 - [Installation](#-installation) • [Configuration](#️-configuration) • [Troubleshooting](#-contribution--support) • [Contributing](#-contribution--support)

--- a/VOLTAGE-BATTERY-GAUGE-UPDATE.md
+++ b/VOLTAGE-BATTERY-GAUGE-UPDATE.md
@@ -1,0 +1,227 @@
+# Voltage-Based Battery Gauge Update
+
+## What Changed?
+
+The telemetry page now supports **percentage-based battery gauges** for voltage sensors with dynamic color coding!
+
+### Before:
+- Battery gauge always showed 100% green
+- No visual indication of actual battery level
+
+### After:
+- Battery gauge shows actual percentage based on voltage
+- Green when above threshold
+- Red when below threshold
+- Displays voltage value + percentage
+
+---
+
+## Quick Start Configuration
+
+Add this to your `skin.conf` under `[Extras]` → `[[Telemetry]]` → `[[[BatteryFields]]]`:
+
+```ini
+[[Telemetry]]
+    allow_zero_values = yes
+    chart_days = 1
+    
+    [[[BatteryFields]]]
+        [[[[consBatteryVoltage]]]]
+            enabled = yes
+            max_voltage = 4.5      # Your battery's max voltage (100%)
+            min_voltage = 0.0      # Your battery's min voltage (0%)
+            low_threshold = 50     # Below 50%, gauge turns red
+```
+
+---
+
+## Configuration Options
+
+### max_voltage (required for voltage sensors)
+- **Purpose:** The voltage that represents 100% battery
+- **Example:** `max_voltage = 4.5` (for a 4.5V battery)
+- **Default:** 100 (treats value as percentage)
+
+### min_voltage (optional)
+- **Purpose:** The voltage that represents 0% battery
+- **Example:** `min_voltage = 0.0`
+- **Default:** 0
+
+### low_threshold (optional)
+- **Purpose:** Percentage below which gauge turns red
+- **Example:** `low_threshold = 50` (red below 50%)
+- **Default:** 20 (red below 20%)
+
+---
+
+## Examples
+
+### Example 1: 4.5V Battery (Your Case)
+```ini
+[[[[consBatteryVoltage]]]]
+    enabled = yes
+    max_voltage = 4.5
+    min_voltage = 0.0
+    low_threshold = 50
+```
+
+**Results:**
+- 4.5V → 100% green gauge ✅
+- 3.6V → 80% green gauge ✅
+- 2.0V → 44% red gauge ⚠️ (below 50%)
+
+### Example 2: 12V Battery System
+```ini
+[[[[battery12v]]]]
+    enabled = yes
+    max_voltage = 14.4    # Fully charged
+    min_voltage = 10.5    # Discharged
+    low_threshold = 30
+```
+
+**Results:**
+- 14.4V → 100% green
+- 12.45V → 50% green
+- 11.0V → 12% red ⚠️ (below 30%)
+
+### Example 3: 3.3V LiPo Battery
+```ini
+[[[[lipoBattery]]]]
+    enabled = yes
+    max_voltage = 4.2
+    min_voltage = 3.0
+    low_threshold = 25
+```
+
+---
+
+## Visual Display
+
+The battery cards now show:
+
+```
+┌──────────────────────────────────┐
+│   Outside Temperature Battery    │
+│                                  │
+│  0.0 V        4.5 V        4.5 V │
+│  (00:00)                 (14:23) │
+│                                  │
+│  [████████████████░░]  ← 80%     │
+│         80%                      │
+└──────────────────────────────────┘
+```
+
+- **Top row:** Sensor name
+- **Second row:** Min value, Current value, Max value (with timestamps)
+- **Third row:** Visual battery gauge (green/red)
+- **Bottom:** Percentage display
+
+---
+
+## Color Coding
+
+| Condition | Color | Hex Code |
+|-----------|-------|----------|
+| Above threshold | Green | #4caf50 |
+| Below threshold | Red | #f44336 |
+
+The gauge smoothly transitions width and color.
+
+---
+
+## For Status-Based Sensors
+
+If your sensor reports status codes (0=OK, 1=Low) instead of voltage:
+- **Don't** add `max_voltage`, `min_voltage`, or `low_threshold`
+- **Do** use the standard text label configuration
+- See the main `battery-config-guide.md` for details
+
+---
+
+## Testing
+
+1. Add the configuration to your `skin.conf`
+2. Restart weewx:
+   ```bash
+   sudo systemctl restart weewx
+   ```
+3. Open the telemetry page
+4. Check the battery gauge shows the correct percentage
+5. Verify color changes to red when below threshold
+
+---
+
+## Troubleshooting
+
+**Gauge still shows 100%?**
+- Make sure `max_voltage` is set correctly
+- Check your sensor is actually reporting voltage (not status codes)
+- Restart WeeWX after configuration changes: `sudo systemctl restart weewx`
+- WeeWX formats values with units - the template now strips these automatically
+
+**Wrong percentage?**
+- Verify `max_voltage` matches your battery's actual maximum
+- Example: 4.5V max battery needs `max_voltage = 4.5`
+- If you see 4.5V = 100% but configured `max_voltage = 10.5`, check you restarted WeeWX
+
+**Charts not showing any values?**
+- This was fixed in the latest update
+- Make sure you have the latest telemetry.html.tmpl
+- For voltage sensors, charts now display raw voltage values
+- Restart WeeWX after updating the template
+
+**Values shown with commas (e.g., "4,5 V") causing issues?**
+- Fixed! The template now automatically strips units and handles both comma and period decimal separators
+- Works with: "4.5 V", "4,5 V", "4.5", "4,5"
+- No configuration needed
+
+**Not turning red?**
+- Check `low_threshold` value
+- Make sure voltage is actually below the threshold
+
+**Want it to turn red earlier?**
+- Increase the `low_threshold` value
+- Example: `low_threshold = 60` (red below 60%)
+
+---
+
+## Complete Example Configuration
+
+```ini
+[Extras]
+    [[Telemetry]]
+        allow_zero_values = yes
+        chart_days = 1
+        
+        [[[BatteryFields]]]
+            # Voltage-based sensors
+            [[[[consBatteryVoltage]]]]
+                enabled = yes
+                max_voltage = 4.5
+                min_voltage = 0.0
+                low_threshold = 50
+            
+            [[[[outTempBatteryVoltage]]]]
+                enabled = yes
+                max_voltage = 4.5
+                min_voltage = 0.0
+                low_threshold = 30
+            
+            # Status-based sensors (no voltage settings)
+            [[[[batteryStatus1]]]]
+                enabled = yes
+                0 = Normal
+                1 = Low
+                chart_position_0 = 1
+                chart_position_1 = 0
+                max_chart_position = 1
+                flip_values = no
+```
+
+---
+
+## See Also
+
+- `battery-config-guide.md` - Complete configuration guide
+- `skin.conf` - Your main configuration file
+

--- a/battery-config-guide.md
+++ b/battery-config-guide.md
@@ -282,6 +282,12 @@ chart_position_9 = 0  # CORRECT! Matches the raw value "9"
 ### Example 1: Ecowitt Battery (0=Normal, 9=Low)
 
 ```ini
+[[Appearance]]
+    # Card display order
+    telemetry_order = batteryStatus1, rxCheckPercent
+    # Chart display order (only sensors you want to track historically)
+    telemetry_chart_order = batteryStatus1
+
 [[Telemetry]]
     allow_zero_values = yes
     chart_days = 1
@@ -300,6 +306,10 @@ chart_position_9 = 0  # CORRECT! Matches the raw value "9"
 ### Example 2: Simple Battery (0=OK, 1=Change)
 
 ```ini
+[[Appearance]]
+    telemetry_order = outTempBatteryStatus, rxCheckPercent
+    telemetry_chart_order = outTempBatteryStatus
+
 [[Telemetry]]
     allow_zero_values = yes
     chart_days = 1
@@ -318,6 +328,10 @@ chart_position_9 = 0  # CORRECT! Matches the raw value "9"
 ### Example 3: Multi-Level Battery (0-4)
 
 ```ini
+[[Appearance]]
+    telemetry_order = extraBatteryStatus1, rxCheckPercent
+    telemetry_chart_order = extraBatteryStatus1
+
 [[Telemetry]]
     allow_zero_values = yes
     chart_days = 7
@@ -342,6 +356,10 @@ chart_position_9 = 0  # CORRECT! Matches the raw value "9"
 ### Example 4: Voltage-Based Battery (0V to 4.5V with percentage gauge)
 
 ```ini
+[[Appearance]]
+    telemetry_order = consBatteryVoltage, outTempBatteryVoltage, rxCheckPercent
+    telemetry_chart_order = consBatteryVoltage, outTempBatteryVoltage
+
 [[Telemetry]]
     allow_zero_values = yes
     chart_days = 1
@@ -369,6 +387,12 @@ chart_position_9 = 0  # CORRECT! Matches the raw value "9"
 ### Example 5: Mixed Configuration (Status + Voltage sensors)
 
 ```ini
+[[Appearance]]
+    # Display voltage sensor first, then status sensor
+    telemetry_order = consBatteryVoltage, batteryStatus1, rxCheckPercent
+    # Show both in charts
+    telemetry_chart_order = consBatteryVoltage, batteryStatus1
+
 [[Telemetry]]
     allow_zero_values = yes
     chart_days = 1
@@ -394,6 +418,46 @@ chart_position_9 = 0  # CORRECT! Matches the raw value "9"
 
 ---
 
+## Organizing Telemetry Display
+
+You can control the display order of both telemetry **cards** and **charts** on the telemetry page using two configuration options in `skin.conf`:
+
+### telemetry_order (Cards)
+Controls the order of telemetry value cards displayed on the left side of the telemetry page. These show current sensor values.
+
+```ini
+[[Appearance]]
+    telemetry_order = rxCheckPercent, txBatteryStatus, windBatteryStatus, rainBatteryStatus, outTempBatteryStatus, inTempBatteryStatus, consBatteryVoltage, heatingVoltage, supplyVoltage, referenceVoltage, extraBattery1, extraBattery2, extraBattery3, extraBattery4, extraBattery5, extraBattery6, extraBattery7, extraBattery8
+```
+
+### telemetry_chart_order (Charts)
+Controls the order of telemetry historical charts. These show battery trends over time (configurable via `chart_days`).
+
+```ini
+[[Appearance]]
+    telemetry_chart_order = outTempBatteryStatus, inTempBatteryStatus, consBatteryVoltage, supplyVoltage, referenceVoltage
+```
+
+**Usage tips:**
+- List sensors in the order you want them to appear
+- Only configured and enabled sensors will be displayed
+- Sensors not in the list won't be shown
+- Separate sensor names with commas
+
+**Example:**
+If you want to prioritize voltage sensors, you can reorder them:
+
+```ini
+[[Appearance]]
+    # Show voltage sensors first in cards
+    telemetry_order = consBatteryVoltage, supplyVoltage, referenceVoltage, outTempBatteryStatus, inTempBatteryStatus, rxCheckPercent
+    
+    # Show only critical voltage charts
+    telemetry_chart_order = consBatteryVoltage, supplyVoltage
+```
+
+---
+
 ## Quick Reference
 
 ### Text-Based Status Configuration
@@ -411,6 +475,13 @@ chart_position_9 = 0  # CORRECT! Matches the raw value "9"
 | `max_voltage` | Maximum voltage (100%) | `4.5` (for 4.5V max) |
 | `min_voltage` | Minimum voltage (0%) | `0.0` (typically 0) |
 | `low_threshold` | Percentage to turn red | `50` (below 50% = red) |
+
+### Telemetry Display Order
+| Setting | Purpose | Location in skin.conf |
+|---------|---------|---------------------|
+| `telemetry_order` | Order of value cards | `[[Appearance]]` section |
+| `telemetry_chart_order` | Order of historical charts | `[[Appearance]]` section |
+| `chart_days` | Days of history to show in charts | `[[Telemetry]]` section (default: 30) |
 
 **Note:** For voltage-based sensors, you don't need text labels or chart positions. The gauge automatically calculates the percentage and applies color coding.
 

--- a/battery-config-guide.md
+++ b/battery-config-guide.md
@@ -45,7 +45,81 @@ chart_days = 1
             
             # 4. FLIP: Whether to flip the chart upside-down
             flip_values = no
+            
+            # 5. VOLTAGE-BASED GAUGE (Optional): For voltage sensors (e.g., 0-5V)
+            max_voltage = 4.5      # Maximum voltage (100%)
+            min_voltage = 0.0      # Minimum voltage (0%)
+            low_threshold = 50     # Below this percentage, gauge turns red
 ```
+
+---
+
+### Voltage-Based Battery Gauge (For Voltage Sensors)
+
+If your battery sensor reports actual voltage values (e.g., 4.5V, 3.6V, 2.0V) instead of status codes, you can configure the battery gauge to show a **percentage-based visual indicator** with color coding:
+
+#### Configuration Options:
+
+```ini
+[[[[consBatteryVoltage]]]]
+    enabled = yes
+    
+    # Voltage range configuration
+    max_voltage = 4.5      # Full battery voltage (100%)
+    min_voltage = 0.0      # Empty battery voltage (0%)
+    low_threshold = 50     # Below 50%, gauge turns red
+```
+
+#### How It Works:
+
+1. **max_voltage**: The voltage that represents 100% battery
+2. **min_voltage**: The voltage that represents 0% battery (usually 0)
+3. **low_threshold**: Percentage below which the gauge turns red (default: 20%)
+
+#### Example Scenarios:
+
+**Scenario 1: Console Battery (0V to 4.5V)**
+```ini
+[[[[consBatteryVoltage]]]]
+    enabled = yes
+    max_voltage = 4.5
+    min_voltage = 0.0
+    low_threshold = 50
+```
+- Current: 4.5V → Shows 100% (green)
+- Current: 3.6V → Shows 80% (green)
+- Current: 2.0V → Shows 44% (red, below threshold)
+
+**Scenario 2: 12V Battery System**
+```ini
+[[[[batteryVoltage12v]]]]
+    enabled = yes
+    max_voltage = 14.4     # Fully charged 12V battery
+    min_voltage = 10.5     # Discharged 12V battery
+    low_threshold = 30
+```
+- Current: 14.4V → Shows 100% (green)
+- Current: 12.45V → Shows 50% (green)
+- Current: 11.0V → Shows 12% (red, below 30%)
+
+**Scenario 3: 3.3V LiPo Battery**
+```ini
+[[[[lipoBattery]]]]
+    enabled = yes
+    max_voltage = 4.2      # Fully charged LiPo
+    min_voltage = 3.0      # Minimum safe voltage
+    low_threshold = 25
+```
+
+#### Visual Display:
+
+The battery gauge will:
+- Display the actual voltage value (e.g., "3.6 V")
+- Show a visual gauge filled to the calculated percentage
+- Change from **green** to **red** when below the threshold
+- Display the percentage below the gauge (e.g., "80%")
+
+**Note:** For status-based sensors (0=OK, 9=Low), leave out the voltage options and use the standard text label configuration instead.
 
 ---
 
@@ -265,10 +339,64 @@ chart_position_9 = 0  # CORRECT! Matches the raw value "9"
             flip_values = no
 ```
 
+### Example 4: Voltage-Based Battery (0V to 4.5V with percentage gauge)
+
+```ini
+[[Telemetry]]
+    allow_zero_values = yes
+    chart_days = 1
+    
+    [[[BatteryFields]]]
+        [[[[consBatteryVoltage]]]]
+            enabled = yes
+            # Voltage range for percentage calculation
+            max_voltage = 4.5
+            min_voltage = 0.0
+            low_threshold = 50
+        
+        [[[[outTempBatteryVoltage]]]]
+            enabled = yes
+            max_voltage = 4.5
+            min_voltage = 0.0
+            low_threshold = 30
+```
+
+**Result:**
+- When voltage = 4.5V → Displays "4.5 V" with 100% green gauge
+- When voltage = 3.6V → Displays "3.6 V" with 80% green gauge
+- When voltage = 2.0V → Displays "2.0 V" with 44% red gauge (below 50% threshold)
+
+### Example 5: Mixed Configuration (Status + Voltage sensors)
+
+```ini
+[[Telemetry]]
+    allow_zero_values = yes
+    chart_days = 1
+    
+    [[[BatteryFields]]]
+        # Status-based sensor (0=OK, 1=Low)
+        [[[[batteryStatus1]]]]
+            enabled = yes
+            0 = Normal
+            1 = Low
+            chart_position_0 = 1
+            chart_position_1 = 0
+            max_chart_position = 1
+            flip_values = no
+        
+        # Voltage-based sensor
+        [[[[consBatteryVoltage]]]]
+            enabled = yes
+            max_voltage = 4.5
+            min_voltage = 0.0
+            low_threshold = 50
+```
+
 ---
 
 ## Quick Reference
 
+### Text-Based Status Configuration
 | Setting | Purpose | Example |
 |---------|---------|---------|
 | `enabled` | Turn mapping on/off | `yes` or `no` |
@@ -276,6 +404,15 @@ chart_position_9 = 0  # CORRECT! Matches the raw value "9"
 | `chart_position_X` | Y-axis position for value X | `chart_position_0 = 1` |
 | `max_chart_position` | Highest position used | `1` for 2 levels, `2` for 3 levels, etc. |
 | `flip_values` | Invert chart display | `yes` or `no` |
+
+### Voltage-Based Percentage Configuration
+| Setting | Purpose | Example |
+|---------|---------|---------|
+| `max_voltage` | Maximum voltage (100%) | `4.5` (for 4.5V max) |
+| `min_voltage` | Minimum voltage (0%) | `0.0` (typically 0) |
+| `low_threshold` | Percentage to turn red | `50` (below 50% = red) |
+
+**Note:** For voltage-based sensors, you don't need text labels or chart positions. The gauge automatically calculates the percentage and applies color coding.
 
 ---
 
@@ -294,6 +431,26 @@ chart_position_9 = 0  # CORRECT! Matches the raw value "9"
 
 **Problem:** Page breaks when sensor doesn't exist
 - **Solution:** Only configure sensors that actually exist, or set `enabled = no`
+
+**Problem:** Battery gauge always shows 100% green (voltage sensors)
+- **Solution:** Configure `max_voltage` and `min_voltage` for voltage-based sensors
+- **Example:** For a 4.5V battery, set `max_voltage = 4.5` and `min_voltage = 0.0`
+- **Note:** The template automatically strips units (" V") and handles both comma and period decimal separators
+- **Restart WeeWX** after configuration changes
+
+**Problem:** Battery gauge doesn't turn red when voltage is low
+- **Solution:** Adjust the `low_threshold` value (default is 20%)
+- **Example:** To turn red below 50%, set `low_threshold = 50`
+
+**Problem:** Battery percentage seems incorrect
+- **Check:** Make sure `max_voltage` matches your actual maximum battery voltage
+- **Check:** Verify your sensor is reporting voltage values, not status codes
+- **Example:** If your battery is 3.7V LiPo (max 4.2V), use `max_voltage = 4.2`
+- **Calculation:** Percentage = (current - min) ÷ (max - min) × 100
+
+**Problem:** Values appear with comma (e.g., "4,5 V") and gauge shows 100%
+- **Fixed!** The template now automatically handles European decimal format
+- **No action needed** - just restart WeeWX to apply template updates
 
 ---
 

--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class BasicInstaller(ExtensionInstaller):
     def __init__(self):
         super(BasicInstaller, self).__init__(
-            version="1.58.6",
+            version="1.59.0",
             name="neowx-material",
             description="The most versatile and modern weewx skin",
             author="Neoweewx",

--- a/skins/neowx-material/package-lock.json
+++ b/skins/neowx-material/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neowx-material",
-  "version": "1.58.6",
+  "version": "1.59.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neowx-material",
-      "version": "1.58.6",
+      "version": "1.59.0",
       "license": "MIT",
       "dependencies": {
         "sass": "1.100.0"

--- a/skins/neowx-material/package.json
+++ b/skins/neowx-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neowx-material",
-  "version": "1.58.6",
+  "version": "1.59.0",
   "description": "The most versatile and modern weewx skin",
   "main": "index.js",
   "repository": "https://github.com/neoground/neowx-material",

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -278,7 +278,8 @@
         embedded_order =
 
         # The order of cards on telemetry page
-        telemetry_order = rxCheckPercent, txBatteryStatus, windBatteryStatus, rainBatteryStatus, outTempBatteryStatus, inTempBatteryStatus, consBatteryVoltage, heatingVoltage, supplyVoltage, referenceVoltage, extraBatteryStatus1, extraBatteryStatus2, extraBatteryStatus3, extraBatteryStatus4, extraBatteryStatus5, extraBatteryStatus6, extraBatteryStatus7, extraBatteryStatus8
+        telemetry_order = rxCheckPercent, txBatteryStatus, windBatteryStatus, rainBatteryStatus, outTempBatteryStatus, inTempBatteryStatus, consBatteryVoltage, heatingVoltage, supplyVoltage, referenceVoltage, extraBattery1, extraBattery2, extraBattery3, extraBattery4, extraBattery5, extraBattery6, extraBattery7, extraBattery8
+        telemetry_chart_order = outTempBatteryStatus, inTempBatteryStatus, consBatteryVoltage, supplyVoltage, referenceVoltage
 
         # Show trend arrow with tooltip at these values on the "current" page
         show_trend_on = barometer, outTemp, outHumidity, inTemp, inHumidity, UV, co2, pm2_5, ET

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -767,6 +767,7 @@
             template = almanac.html.tmpl
 
         [[[telemetry]]]
+            stale_age = 3600
             template = telemetry.html.tmpl
 
         [[[history]]]

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -504,7 +504,7 @@
         # This will allow to display telemetry plots and cards if value is zero, it is required as some stations report 1 or 0 only.  yes/no
         allow_zero_values = no
 
-        # Number of days to show in telemetry charts (default: 1)
+        # Number of days to show in telemetry charts (default: 30)
         # Increase this to see historical battery trends
         chart_days = 30
 

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -18,7 +18,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
 
-    version = 1.58.6
+    version = 1.59.0
 
     # Language
     # -------------------------------------------------------------------------
@@ -525,7 +525,6 @@
             #    max_chart_position = 1
             #    # Flip chart display (yes/no)
             #    flip_values = no
-            unused = unused
 
     # Charts
     # -------------------------------------------------------------------------

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -506,7 +506,7 @@
 
         # Number of days to show in telemetry charts (default: 1)
         # Increase this to see historical battery trends
-        chart_days = 1
+        chart_days = 30
 
         [[[BatteryFields]]]
             # Check out how to configure this feature from battery-config-guide.md

--- a/skins/neowx-material/skin.conf.voltage-battery-sample
+++ b/skins/neowx-material/skin.conf.voltage-battery-sample
@@ -1,0 +1,103 @@
+# Sample skin.conf Configuration for Voltage-Based Battery Gauges
+# Copy the relevant section to your skin.conf under [Extras]
+
+[Extras]
+    [[Telemetry]]
+        allow_zero_values = yes
+        chart_days = 1
+
+        [[[BatteryFields]]]
+
+            # ================================================================
+            # EXAMPLE 1: Console Battery (0V to 4.5V)
+            # ================================================================
+            [[[[consBatteryVoltage]]]]
+                enabled = yes
+                max_voltage = 4.5      # Maximum voltage (100%)
+                min_voltage = 0.0      # Minimum voltage (0%)
+                low_threshold = 50     # Below 50%, gauge turns red
+
+            # ================================================================
+            # EXAMPLE 2: Outside Temperature Sensor Battery (0V to 4.5V)
+            # ================================================================
+            [[[[outTempBatteryVoltage]]]]
+                enabled = yes
+                max_voltage = 4.5
+                min_voltage = 0.0
+                low_threshold = 30     # Below 30%, gauge turns red
+
+            # ================================================================
+            # EXAMPLE 3: 12V Battery System
+            # ================================================================
+            [[[[battery12v]]]]
+                enabled = yes
+                max_voltage = 14.4     # Fully charged 12V battery
+                min_voltage = 10.5     # Discharged 12V battery
+                low_threshold = 30
+
+            # ================================================================
+            # EXAMPLE 4: 3.7V LiPo Battery
+            # ================================================================
+            [[[[lipoBattery]]]]
+                enabled = yes
+                max_voltage = 4.2      # Fully charged LiPo
+                min_voltage = 3.0      # Minimum safe voltage
+                low_threshold = 25     # Below 25%, gauge turns red
+
+            # ================================================================
+            # EXAMPLE 5: Status-Based Battery (NOT voltage)
+            # Use this format for sensors that report 0=OK, 1=Low, etc.
+            # Don't use max_voltage/min_voltage/low_threshold for these!
+            # ================================================================
+            [[[[batteryStatus1]]]]
+                enabled = yes
+                # Text labels for each status code
+                0 = Normal
+                1 = Low
+                # Chart positions (higher = better)
+                chart_position_0 = 1
+                chart_position_1 = 0
+                max_chart_position = 1
+                flip_values = no
+
+            # ================================================================
+            # EXAMPLE 6: Ecowitt Battery Status (0=Normal, 9=Low)
+            # ================================================================
+            [[[[wh31_batt]]]]
+                enabled = yes
+                0 = Normal
+                9 = Low
+                chart_position_0 = 1
+                chart_position_9 = 0
+                max_chart_position = 1
+                flip_values = no
+
+# ====================================================================
+# Configuration Notes:
+# ====================================================================
+#
+# FOR VOLTAGE SENSORS (e.g., 0-5V, 0-12V):
+#   - Use: max_voltage, min_voltage, low_threshold
+#   - Don't use: chart_position_X, max_chart_position, flip_values
+#   - The gauge will show percentage and change color
+#
+# FOR STATUS SENSORS (e.g., 0=OK, 1=Low):
+#   - Use: text labels (0 = OK), chart_position_X, max_chart_position
+#   - Don't use: max_voltage, min_voltage, low_threshold
+#   - The charts will show status levels
+#
+# ====================================================================
+
+# ====================================================================
+# Quick Configuration Template
+# ====================================================================
+# Copy this and customize for your sensor:
+#
+# [[[[YOUR_SENSOR_NAME]]]]
+#     enabled = yes
+#     max_voltage = 4.5      # Change to your max voltage
+#     min_voltage = 0.0      # Usually 0
+#     low_threshold = 50     # Change to your preference (0-100)
+#
+# ====================================================================
+

--- a/skins/neowx-material/telemetry.html.tmpl
+++ b/skins/neowx-material/telemetry.html.tmpl
@@ -346,7 +346,16 @@
                 #set chart_days = 1
             #end try
 
-            #set current_interval = int($Extras.Charts.current_timespan)
+			## Dynamic interval based on chart timespan
+			#if $chart_days <= 7
+				#set current_interval = 3600
+			#elif $chart_days <= 30
+				#set current_interval = 21600
+			#elif $chart_days <= 365
+				#set current_interval = 86400
+			#else
+				#set current_interval = 604800
+			#end if
 
             ## Check if this is an enabled battery field
             #set is_battery = $isBatteryFieldEnabled($name)

--- a/skins/neowx-material/telemetry.html.tmpl
+++ b/skins/neowx-material/telemetry.html.tmpl
@@ -314,7 +314,7 @@
 
                 <div class="row mt-3 graphrow align-content-start">
 
-                    #for $x in $Extras.Appearance.telemetry_order
+                    #for $x in $Extras.Appearance.telemetry_chart_order
                         $chartCard($x)
                     #end for
 
@@ -483,7 +483,7 @@
                 #include "graph_area_config.inc"
             }
 
-            #for $x in $Extras.Appearance.telemetry_order
+            #for $x in $Extras.Appearance.telemetry_chart_order
                 $getChartJsCode($x, $x)
             #end for
         </script>

--- a/skins/neowx-material/telemetry.html.tmpl
+++ b/skins/neowx-material/telemetry.html.tmpl
@@ -7,12 +7,30 @@
 ## | Template for display card of telemetry values                           |
 ## +-------------------------------------------------------------------------+
 
-#def valuesCard($name)
+#def formatBatteryValue($value)
+    #if $value is None
+        –
+    #else
+        #try
+            ${"%.0f" % float(str($value).replace(",", "."))}
+        #except
+            $value
+        #end try
+    #end if
+#end def
+
+## +-------------------------------------------------------------------------+
+## | Template for display card of battery symbol values (top section)        |
+## +-------------------------------------------------------------------------+
+
+#def batteryCard($name)
     #if $getVar('day.' + name + '.has_data') and ($getVar('day.' + name + '.max.raw') > 0 or $Extras.Telemetry.allow_zero_values == "yes")
-        <div class="col-12 col-lg-6 mb-4">
-            <div class="card">
+        <div class="col-12 col-md-6 col-xl-4 mb-4">
+            <div class="card card-value">
                 <div class="card-body text-center">
-                    <h5 class="h5-responsive $Extras.color-text">$getVar('obs.label.' + name)</h5>
+                    <h3 class="h5-responsive $Extras.color-text">
+                        $getVar('obs.label.' + name)
+                    </h3>
 
                     <div class="row">
                         <div class="col-3 text-muted font-small lo-text">
@@ -25,7 +43,21 @@
                         <div class="col-6">
                             #set current_value = $getVar('current.' + name)
                             #set display_value = $mapBatteryValue($name, $current_value)
-                            <h4 class="h2-responsive">$display_value</h4>
+
+                            ## Calculate actual battery percentage based on voltage
+                            #set battery_percentage = $calculateBatteryPercentage($name, $current_value)
+                            #set battery_color = $getBatteryColor($name, $battery_percentage)
+
+                            <h4 class="h2-responsive mb-2">
+                                $display_value
+                            </h4>
+
+                            <!-- Visual battery gauge -->
+                            <div class="battery-container" style="border: 2px solid #555; border-radius: 4px; width: 100px; height: 20px; margin: 0 auto; position: relative;">
+                                <div class="battery-fill" style="background-color: $battery_color;width: $battery_percentage%;height: 100%;border-radius: 2px;transition: width 0.3s ease, background-color 0.3s ease;"></div>
+                                <div style="position: absolute;top: 0;left: 100%;width: 6px;height: 12px;background: #555;border-radius: 2px;margin-left: 2px;"></div>
+                            </div>
+                            <div class="text-muted font-small mt-1">$battery_percentage%</div>
                         </div>
 
                         <div class="col-3 text-muted font-small hi-text">
@@ -34,11 +66,26 @@
                             $max_mapped <br>
                             ($getVar('day.' + name + '.maxtime').format($Extras.Formatting.datetime_today))
                         </div>
-
-                        <div class="col-12 mt-4">
-                            <div id="$name-chart"></div>
-                        </div>
                     </div>
+                </div>
+            </div>
+        </div>
+    #end if
+#end def
+
+## +-------------------------------------------------------------------------+
+## | Template for display card of chart (bottom section)                     |
+## +-------------------------------------------------------------------------+
+
+#def chartCard($name)
+    #if $getVar('day.' + name + '.has_data') and ($getVar('day.' + name + '.max.raw') > 0 or $Extras.Telemetry.allow_zero_values == "yes")
+        <div class="col-12 col-xl-6 mb-4">
+            <div class="card card-chart" id="${name}-chart-card" data-name="$name">
+                <div class="card-body text-center">
+                    <h5 class="h5-responsive $Extras.color-text">
+                        $getVar('obs.label.' + name)
+                    </h5>
+                    <div id="$name-chart"></div>
                 </div>
             </div>
         </div>
@@ -62,13 +109,41 @@
 #end def
 
 ## +-------------------------------------------------------------------------+
+## | Check if a battery field is voltage-based (has max_voltage configured)  |
+## +-------------------------------------------------------------------------+
+#def isVoltageBased($name)
+    #try
+        #set max_v = $getVar('Extras.Telemetry.BatteryFields.' + $name + '.max_voltage', None)
+        #if $max_v is not None and str($max_v).strip() != '' and str($max_v) != 'None'
+            #try
+                #set test_float = float($max_v)
+                #return True
+            #except
+                #return False
+            #end try
+        #else
+            #return False
+        #end if
+    #except
+        #return False
+    #end try
+#end def
+
+## +-------------------------------------------------------------------------+
 ## | Helper function to map battery values                                   |
+## | Only maps status-based sensors, not voltage-based sensors               |
 ## +-------------------------------------------------------------------------+
 #def mapBatteryValue($name, $value)
     #if not $isBatteryFieldEnabled($name)
         #return $value
     #end if
 
+    ## Don't map voltage-based sensors - return raw value
+    #if $isVoltageBased($name)
+        #return $value
+    #end if
+
+    ## Only map status-based sensors
     #try
         #set raw_val = str($value).strip()
         #set key = "0"
@@ -88,14 +163,92 @@
 #end def
 
 ## +-------------------------------------------------------------------------+
+## | Helper function to calculate battery percentage                         |
+## | Returns percentage (0-100) based on current voltage vs max voltage      |
+## +-------------------------------------------------------------------------+
+#def calculateBatteryPercentage($name, $value)
+    #try
+        ## Try to get max_voltage - if it exists, this is a voltage-based sensor
+        #set max_voltage_str = $getVar('Extras.Telemetry.BatteryFields.' + $name + '.max_voltage', None)
+
+        ## Check if max_voltage is configured
+        #if $max_voltage_str is None or str($max_voltage_str).strip() == '' or str($max_voltage_str) == 'None'
+            ## Not a voltage sensor, return 100 (full)
+            #return 100
+        #end if
+
+        ## Parse the raw value - need to get numeric value from string like "4,5 V"
+        #import re
+        #set value_str = str($value).strip()
+        ## Extract only numbers, comma, decimal point, and minus sign
+        #set numeric_str = re.sub(r'[^0-9,.\-]', '', value_str)
+        ## Replace comma with period for decimal point
+        #set numeric_str = numeric_str.replace(',', '.')
+        #set raw_val = float(numeric_str)
+
+        #set max_voltage = float(str($max_voltage_str).strip())
+        #set min_voltage_str = $getVar('Extras.Telemetry.BatteryFields.' + $name + '.min_voltage', '0')
+        #set min_voltage = float(str($min_voltage_str).strip())
+
+        ## Calculate percentage within range
+        #if $max_voltage > $min_voltage
+            #set percentage = (($raw_val - $min_voltage) / ($max_voltage - $min_voltage)) * 100
+            ## Clamp between 0 and 100
+            #if $percentage < 0
+                #set percentage = 0
+            #elif $percentage > 100
+                #set percentage = 100
+            #end if
+            #return int($percentage)
+        #else
+            #return 100
+        #end if
+    #except
+        #return 100
+    #end try
+#end def
+
+## +-------------------------------------------------------------------------+
+## | Helper function to determine battery gauge color                        |
+## | Returns color code based on threshold                                   |
+## +-------------------------------------------------------------------------+
+#def getBatteryColor($name, $percentage)
+    #try
+        ## Check if this is a voltage-based sensor (has max_voltage configured)
+        #set max_v = $getVar('Extras.Telemetry.BatteryFields.' + $name + '.max_voltage', None)
+        #if $max_v is None or str($max_v).strip() == '' or str($max_v) == 'None'
+            ## Not voltage-based, return default green
+            #return "#4caf50"
+        #end if
+
+        ## Get threshold
+        #set threshold = float($getVar('Extras.Telemetry.BatteryFields.' + $name + '.low_threshold', '20'))
+        #if float($percentage) < $threshold
+            #return "#f44336"  ## Red
+        #else
+            #return "#4caf50"  ## Green
+        #end if
+    #except
+        #return "#4caf50"  ## Default green
+    #end try
+#end def
+
+## +-------------------------------------------------------------------------+
 ## | Helper function to get chart value for battery fields                   |
 ## | Returns the numeric chart position based on mapping order               |
+## | For voltage-based sensors, returns the raw value                        |
 ## +-------------------------------------------------------------------------+
 #def getBatteryChartValue($name, $raw_value)
     #if not $isBatteryFieldEnabled($name)
         #return $raw_value
     #end if
 
+    ## Don't convert voltage-based sensors - use raw voltage in charts
+    #if $isVoltageBased($name)
+        #return $raw_value
+    #end if
+
+    ## Only convert status-based sensors to chart positions
     #try
         #set key = str(int(float($raw_value) + 0.000001))
 
@@ -143,18 +296,30 @@
         #include "header.inc"
 
         <main>
-            <div class="container">
-                <div class="row my-4 align-content-start">
+            <div class="container-fluid d-flex-xxl">
+
+                <div class="row my-4 temprow align-content-start">
 
                     <div class="col-12 mb-4 text-center">
                         <h2 class="h2-responsive text-dark">$gettext("telemetry")</h2>
                     </div>
 
                     #for $x in $Extras.Appearance.telemetry_order
-                        $valuesCard($x)
+                        $batteryCard($x)
                     #end for
 
                 </div>
+
+                <hr class="m-0 mb-4 rowdivider">
+
+                <div class="row mt-3 graphrow align-content-start">
+
+                    #for $x in $Extras.Appearance.telemetry_order
+                        $chartCard($x)
+                    #end for
+
+                </div>
+
             </div>
         </main>
 
@@ -220,11 +385,13 @@
 
                 ## Check if this is an enabled battery field for custom Y-axis
                 #set is_battery = $isBatteryFieldEnabled($name)
+                #set is_voltage = $isVoltageBased($name)
 
                 new ApexCharts(document.querySelector('#$name-chart'), {
                     ...graph_area_config,
                     yaxis: {
-                        #if $is_battery
+                        #if $is_battery and not $is_voltage
+                            ## Status-based battery: use custom position labels
                             #try
                                 #set max_pos = int($getVar('Extras.Telemetry.BatteryFields.' + $name + '.max_chart_position', '1'))
                             #except
@@ -276,6 +443,7 @@
                                 }
                             }
                         #else
+                            ## Voltage-based or regular sensor: use normal numeric labels
                             labels: {
                                 formatter: function (val) {
                                     return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";


### PR DESCRIPTION
Enhance telemetry page with battery gauge based on idea from @Einstein67

<img width="1415" height="680" alt="image" src="https://github.com/user-attachments/assets/4b371b01-2675-40d2-9143-fc38593cb85a" />

You can configure thresholds in skin.conf described in documentation
e.g.
```
 [[Telemetry]]
        allow_zero_values = yes
        chart_days = 180
        [[[BatteryFields]]]            
            [[[[consBatteryVoltage]]]]
                enabled = yes
                max_voltage = 10.5      # Your battery's max voltage (100%)
                min_voltage = 0.0      # Your battery's min voltage (0%)
                low_threshold = 50     # Below 50%, gauge turns red
```