### PR TITLE
Telemetry dynamic interval

### DIFF
--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -767,6 +767,7 @@
             template = almanac.html.tmpl
 
         [[[telemetry]]]
+            stale_age = 3600
             template = telemetry.html.tmpl
 
         [[[history]]]

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -504,7 +504,7 @@
         # This will allow to display telemetry plots and cards if value is zero, it is required as some stations report 1 or 0 only.  yes/no
         allow_zero_values = no
 
-        # Number of days to show in telemetry charts (default: 1)
+        # Number of days to show in telemetry charts (default: 30)
         # Increase this to see historical battery trends
         chart_days = 30
 

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -506,7 +506,7 @@
 
         # Number of days to show in telemetry charts (default: 1)
         # Increase this to see historical battery trends
-        chart_days = 1
+        chart_days = 30
 
         [[[BatteryFields]]]
             # Check out how to configure this feature from battery-config-guide.md

--- a/skins/neowx-material/telemetry.html.tmpl
+++ b/skins/neowx-material/telemetry.html.tmpl
@@ -346,7 +346,16 @@
                 #set chart_days = 1
             #end try
 
-            #set current_interval = int($Extras.Charts.current_timespan)
+			## Dynamic interval based on chart timespan
+			#if $chart_days <= 7
+				#set current_interval = 3600
+			#elif $chart_days <= 30
+				#set current_interval = 21600
+			#elif $chart_days <= 365
+				#set current_interval = 86400
+			#else
+				#set current_interval = 604800
+			#end if
 
             ## Check if this is an enabled battery field
             #set is_battery = $isBatteryFieldEnabled($name)


### PR DESCRIPTION
Reduction in the number of telemetry data points depending on the time range of the chart.

As battery discharge is a very slow process, even a small number of data points is sufficient to accurately represent the trend.

`			## Dynamic interval based on chart timespan
			#if $chart_days <= 7
				#set current_interval = 3600
			#elif $chart_days <= 30
				#set current_interval = 21600
			#elif $chart_days <= 365
				#set current_interval = 86400
			#else
				#set current_interval = 604800
			#end if
`