### PR TITLE
year: use DD.MM.YY instead of dd DD HH:mm for charts x axis

### DIFF
--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -386,16 +386,16 @@
 
         <script type="text/javascript">
             var graph_area_config = {
-                #include "graph_area_config.inc"
+                #include "graph_area_archive_config.inc"
             }
             var graph_bar_config = {
-                #include "graph_bar_config.inc"
+                #include "graph_bar_archive_config.inc"
             }
             var graph_radar_config = {
                 #include "graph_radar_config.inc"
             }
             var graph_line_config = {
-                #include "graph_line_config.inc"
+                #include "graph_line_archive_config.inc"
             }
 
             // --- Special charts: multi-series or non-default columns ---


### PR DESCRIPTION
This restores the behavior of older versions. 

Current:
<img width="626" height="300" alt="hwco72bj" src="https://github.com/user-attachments/assets/a20c4593-b14e-4bc3-8821-76e260f952f5" />

Old/New: 
<img width="626" height="300" alt="e0zsa7tv" src="https://github.com/user-attachments/assets/119e42d6-6700-419b-b8e0-f906796b9b1d" />

