### PR TITLE
fix: hide empty panels

### DIFF
--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class BasicInstaller(ExtensionInstaller):
     def __init__(self):
         super(BasicInstaller, self).__init__(
-            version="1.60.2",
+            version="1.60.3",
             name="neowx-material",
             description="The most versatile and modern weewx skin",
             author="Neoweewx",

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -294,28 +294,38 @@
         #end for
     #else
         ## Expansion panel
-        #set $p_exp   = ($seg['type'] == 'hr')
-        #set $p_exp_s = 'true' if $p_exp else 'false'
-        #set $p_show  = ' show' if $p_exp else ''
-        #set $p_id    = 'nwm-val-panel-' + str($panel_idx)
-        <div class="col-12 mb-3">
-            <div class="card nwm-expansion-panel">
-                <div class="nwm-panel-header" data-toggle="collapse"
-                     data-target="#${p_id}" aria-expanded="${p_exp_s}">
-                    <span class="nwm-panel-title">${seg['title']}</span>
-                    <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
-                </div>
-                <div id="${p_id}" class="collapse${p_show}">
-                    <div class="nwm-panel-body">
-                        <div class="row">
-                            #for $x in $seg['items']
-                                $renderValueItem($x)
-                            #end for
+        #set $any_has_data = False
+        #for $x in $seg['items']
+            #if $x != "forecast"
+                #if $getVar('day.' + $x + '.has_data')
+                    #set $any_has_data = True
+                #end if
+            #end if
+        #end for
+        #if $any_has_data
+            #set $p_exp   = ($seg['type'] == 'hr')
+            #set $p_exp_s = 'true' if $p_exp else 'false'
+            #set $p_show  = ' show' if $p_exp else ''
+            #set $p_id    = 'nwm-val-panel-' + str($panel_idx)
+            <div class="col-12 mb-3">
+                <div class="card nwm-expansion-panel">
+                    <div class="nwm-panel-header" data-toggle="collapse"
+                         data-target="#${p_id}" aria-expanded="${p_exp_s}">
+                        <span class="nwm-panel-title">${seg['title']}</span>
+                        <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
+                    </div>
+                    <div id="${p_id}" class="collapse${p_show}">
+                        <div class="nwm-panel-body">
+                            <div class="row">
+                                #for $x in $seg['items']
+                                    $renderValueItem($x)
+                                #end for
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
+        #end if
     #end if
 #end def
 
@@ -329,28 +339,50 @@
             $chartCard($x)
         #end for
     #else
-        #set $p_exp   = ($seg['type'] == 'hr')
-        #set $p_exp_s = 'true' if $p_exp else 'false'
-        #set $p_show  = ' show' if $p_exp else ''
-        #set $p_id    = 'nwm-chart-panel-' + str($panel_idx)
-        <div class="col-12 mb-3">
-            <div class="card nwm-expansion-panel">
-                <div class="nwm-panel-header" data-toggle="collapse"
-                     data-target="#${p_id}" aria-expanded="${p_exp_s}">
-                    <span class="nwm-panel-title">${seg['title']}</span>
-                    <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
-                </div>
-                <div id="${p_id}" class="collapse${p_show}">
-                    <div class="nwm-panel-body">
-                        <div class="row">
-                            #for $x in $seg['items']
-                                $chartCard($x)
-                            #end for
+        #set $any_has_data = False
+        #for $x in $seg['items']
+            #if $x.startswith('customChart')
+                #set $cc = $Extras.Appearance.get($x, {})
+                #if $cc
+                    #set $cc_values_raw = $cc.get('values', '')
+                    #if isinstance($cc_values_raw, list)
+                        #set $cc_vals_list = [v.strip() for v in $cc_values_raw if v.strip()]
+                    #else
+                        #set $cc_vals_list = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
+                    #end if
+                    #set $cc_any_has_data = any($getVar('day.' + v + '.has_data') for v in $cc_vals_list)
+                    #if len($cc_vals_list) > 0 and $cc_any_has_data
+                        #set $any_has_data = True
+                    #end if
+                #end if
+            #else if ($getVar('day.' + $x + '.has_data') or $x == "windvec") and $x not in ["appTemp", "windrun"] and ($x != 'ET' or ($day.ET.sum.raw is not None and $day.ET.sum.raw >= 0.0))
+                #set $any_has_data = True
+            #end if
+        #end for
+        #if $any_has_data
+            #set $p_exp   = ($seg['type'] == 'hr')
+            #set $p_exp_s = 'true' if $p_exp else 'false'
+            #set $p_show  = ' show' if $p_exp else ''
+            #set $p_id    = 'nwm-chart-panel-' + str($panel_idx)
+            <div class="col-12 mb-3">
+                <div class="card nwm-expansion-panel">
+                    <div class="nwm-panel-header" data-toggle="collapse"
+                         data-target="#${p_id}" aria-expanded="${p_exp_s}">
+                        <span class="nwm-panel-title">${seg['title']}</span>
+                        <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
+                    </div>
+                    <div id="${p_id}" class="collapse${p_show}">
+                        <div class="nwm-panel-body">
+                            <div class="row">
+                                #for $x in $seg['items']
+                                    $chartCard($x)
+                                #end for
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
+        #end if
     #end if
 #end def
 

--- a/skins/neowx-material/month-%Y-%m.html.tmpl
+++ b/skins/neowx-material/month-%Y-%m.html.tmpl
@@ -226,28 +226,44 @@
         #end for
     #else
         ## Expansion panel
-        #set $p_exp   = ($seg['type'] == 'hr')
-        #set $p_exp_s = 'true' if $p_exp else 'false'
-        #set $p_show  = ' show' if $p_exp else ''
-        #set $p_id    = 'nwm-val-panel-' + str($panel_idx)
-        <div class="col-12 mb-3">
-            <div class="card nwm-expansion-panel">
-                <div class="nwm-panel-header" data-toggle="collapse"
-                     data-target="#${p_id}" aria-expanded="${p_exp_s}">
-                    <span class="nwm-panel-title">${seg['title']}</span>
-                    <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
-                </div>
-                <div id="${p_id}" class="collapse${p_show}">
-                    <div class="nwm-panel-body">
-                        <div class="row">
-                            #for $x in $seg['items']
-                                $renderValueItem($x)
-                            #end for
+        #set $any_has_data = False
+        #for $x in $seg['items']
+            #if $x == "ET"
+                #if $month.ET.has_data and $month.ET.sum.raw is not None and $month.ET.sum.raw > 0.0
+                    #set $any_has_data = True
+                #end if
+            #else if $x == "temperatureThresholdDays"
+                #set $any_has_data = True
+            #else
+                #if $getVar('month.' + $x + '.has_data')
+                    #set $any_has_data = True
+                #end if
+            #end if
+        #end for
+        #if $any_has_data
+            #set $p_exp   = ($seg['type'] == 'hr')
+            #set $p_exp_s = 'true' if $p_exp else 'false'
+            #set $p_show  = ' show' if $p_exp else ''
+            #set $p_id    = 'nwm-val-panel-' + str($panel_idx)
+            <div class="col-12 mb-3">
+                <div class="card nwm-expansion-panel">
+                    <div class="nwm-panel-header" data-toggle="collapse"
+                         data-target="#${p_id}" aria-expanded="${p_exp_s}">
+                        <span class="nwm-panel-title">${seg['title']}</span>
+                        <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
+                    </div>
+                    <div id="${p_id}" class="collapse${p_show}">
+                        <div class="nwm-panel-body">
+                            <div class="row">
+                                #for $x in $seg['items']
+                                    $renderValueItem($x)
+                                #end for
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
+        #end if
     #end if
 #end def
 
@@ -261,28 +277,50 @@
             $chartCard($x, $x + 'chart')
         #end for
     #else
-        #set $p_exp   = ($seg['type'] == 'hr')
-        #set $p_exp_s = 'true' if $p_exp else 'false'
-        #set $p_show  = ' show' if $p_exp else ''
-        #set $p_id    = 'nwm-chart-panel-' + str($panel_idx)
-        <div class="col-12 mb-3">
-            <div class="card nwm-expansion-panel">
-                <div class="nwm-panel-header" data-toggle="collapse"
-                     data-target="#${p_id}" aria-expanded="${p_exp_s}">
-                    <span class="nwm-panel-title">${seg['title']}</span>
-                    <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
-                </div>
-                <div id="${p_id}" class="collapse${p_show}">
-                    <div class="nwm-panel-body">
-                        <div class="row">
-                            #for $x in $seg['items']
-                                $chartCard($x, $x + 'chart')
-                            #end for
+        #set $any_has_data = False
+        #for $x in $seg['items']
+            #if $x.startswith('customChart')
+                #set $cc = $Extras.Appearance.get($x, {})
+                #if $cc
+                    #set $cc_values_raw = $cc.get('values', '')
+                    #if isinstance($cc_values_raw, list)
+                        #set $cc_vals_list = [v.strip() for v in $cc_values_raw if v.strip()]
+                    #else
+                        #set $cc_vals_list = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
+                    #end if
+                    #set $cc_any_has_data = any($getVar('month.' + v + '.has_data') for v in $cc_vals_list)
+                    #if len($cc_vals_list) > 0 and $cc_any_has_data
+                        #set $any_has_data = True
+                    #end if
+                #end if
+            #else if ($getVar('month.' + $x + '.has_data') or $x == "windvec") and $x != "appTemp" and ($x != 'ET' or ($month.ET.sum.raw is not None and $month.ET.sum.raw > 0.0))
+                #set $any_has_data = True
+            #end if
+        #end for
+        #if $any_has_data
+            #set $p_exp   = ($seg['type'] == 'hr')
+            #set $p_exp_s = 'true' if $p_exp else 'false'
+            #set $p_show  = ' show' if $p_exp else ''
+            #set $p_id    = 'nwm-chart-panel-' + str($panel_idx)
+            <div class="col-12 mb-3">
+                <div class="card nwm-expansion-panel">
+                    <div class="nwm-panel-header" data-toggle="collapse"
+                         data-target="#${p_id}" aria-expanded="${p_exp_s}">
+                        <span class="nwm-panel-title">${seg['title']}</span>
+                        <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
+                    </div>
+                    <div id="${p_id}" class="collapse${p_show}">
+                        <div class="nwm-panel-body">
+                            <div class="row">
+                                #for $x in $seg['items']
+                                    $chartCard($x, $x + 'chart')
+                                #end for
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
+        #end if
     #end if
 #end def
 

--- a/skins/neowx-material/month.html.tmpl
+++ b/skins/neowx-material/month.html.tmpl
@@ -220,28 +220,44 @@
         #end for
     #else
         ## Expansion panel
-        #set $p_exp   = ($seg['type'] == 'hr')
-        #set $p_exp_s = 'true' if $p_exp else 'false'
-        #set $p_show  = ' show' if $p_exp else ''
-        #set $p_id    = 'nwm-val-panel-' + str($panel_idx)
-        <div class="col-12 mb-3">
-            <div class="card nwm-expansion-panel">
-                <div class="nwm-panel-header" data-toggle="collapse"
-                     data-target="#${p_id}" aria-expanded="${p_exp_s}">
-                    <span class="nwm-panel-title">${seg['title']}</span>
-                    <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
-                </div>
-                <div id="${p_id}" class="collapse${p_show}">
-                    <div class="nwm-panel-body">
-                        <div class="row">
-                            #for $x in $seg['items']
-                                $renderValueItem($x)
-                            #end for
+        #set $any_has_data = False
+        #for $x in $seg['items']
+            #if $x == "ET"
+                #if $month.ET.has_data and $month.ET.sum.raw is not None and $month.ET.sum.raw > 0.0
+                    #set $any_has_data = True
+                #end if
+            #else if $x == "temperatureThresholdDays"
+                #set $any_has_data = True
+            #else
+                #if $getVar('month.' + $x + '.has_data')
+                    #set $any_has_data = True
+                #end if
+            #end if
+        #end for
+        #if $any_has_data
+            #set $p_exp   = ($seg['type'] == 'hr')
+            #set $p_exp_s = 'true' if $p_exp else 'false'
+            #set $p_show  = ' show' if $p_exp else ''
+            #set $p_id    = 'nwm-val-panel-' + str($panel_idx)
+            <div class="col-12 mb-3">
+                <div class="card nwm-expansion-panel">
+                    <div class="nwm-panel-header" data-toggle="collapse"
+                         data-target="#${p_id}" aria-expanded="${p_exp_s}">
+                        <span class="nwm-panel-title">${seg['title']}</span>
+                        <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
+                    </div>
+                    <div id="${p_id}" class="collapse${p_show}">
+                        <div class="nwm-panel-body">
+                            <div class="row">
+                                #for $x in $seg['items']
+                                    $renderValueItem($x)
+                                #end for
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
+        #end if
     #end if
 #end def
 
@@ -255,28 +271,50 @@
             $chartCard($x, $x + 'chart')
         #end for
     #else
-        #set $p_exp   = ($seg['type'] == 'hr')
-        #set $p_exp_s = 'true' if $p_exp else 'false'
-        #set $p_show  = ' show' if $p_exp else ''
-        #set $p_id    = 'nwm-chart-panel-' + str($panel_idx)
-        <div class="col-12 mb-3">
-            <div class="card nwm-expansion-panel">
-                <div class="nwm-panel-header" data-toggle="collapse"
-                     data-target="#${p_id}" aria-expanded="${p_exp_s}">
-                    <span class="nwm-panel-title">${seg['title']}</span>
-                    <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
-                </div>
-                <div id="${p_id}" class="collapse${p_show}">
-                    <div class="nwm-panel-body">
-                        <div class="row">
-                            #for $x in $seg['items']
-                                $chartCard($x, $x + 'chart')
-                            #end for
+        #set $any_has_data = False
+        #for $x in $seg['items']
+            #if $x.startswith('customChart')
+                #set $cc = $Extras.Appearance.get($x, {})
+                #if $cc
+                    #set $cc_values_raw = $cc.get('values', '')
+                    #if isinstance($cc_values_raw, list)
+                        #set $cc_vals_list = [v.strip() for v in $cc_values_raw if v.strip()]
+                    #else
+                        #set $cc_vals_list = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
+                    #end if
+                    #set $cc_any_has_data = any($getVar('month.' + v + '.has_data') for v in $cc_vals_list)
+                    #if len($cc_vals_list) > 0 and $cc_any_has_data
+                        #set $any_has_data = True
+                    #end if
+                #end if
+            #else if ($getVar('month.' + $x + '.has_data') or $x == "windvec") and $x != "appTemp" and ($x != 'ET' or ($month.ET.sum.raw is not None and $month.ET.sum.raw > 0.0))
+                #set $any_has_data = True
+            #end if
+        #end for
+        #if $any_has_data
+            #set $p_exp   = ($seg['type'] == 'hr')
+            #set $p_exp_s = 'true' if $p_exp else 'false'
+            #set $p_show  = ' show' if $p_exp else ''
+            #set $p_id    = 'nwm-chart-panel-' + str($panel_idx)
+            <div class="col-12 mb-3">
+                <div class="card nwm-expansion-panel">
+                    <div class="nwm-panel-header" data-toggle="collapse"
+                         data-target="#${p_id}" aria-expanded="${p_exp_s}">
+                        <span class="nwm-panel-title">${seg['title']}</span>
+                        <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
+                    </div>
+                    <div id="${p_id}" class="collapse${p_show}">
+                        <div class="nwm-panel-body">
+                            <div class="row">
+                                #for $x in $seg['items']
+                                    $chartCard($x, $x + 'chart')
+                                #end for
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
+        #end if
     #end if
 #end def
 

--- a/skins/neowx-material/package-lock.json
+++ b/skins/neowx-material/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neowx-material",
-  "version": "1.60.2",
+  "version": "1.60.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neowx-material",
-      "version": "1.60.2",
+      "version": "1.60.3",
       "license": "MIT",
       "dependencies": {
         "sass": "1.100.0"

--- a/skins/neowx-material/package.json
+++ b/skins/neowx-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neowx-material",
-  "version": "1.60.2",
+  "version": "1.60.3",
   "description": "The most versatile and modern weewx skin",
   "main": "index.js",
   "repository": "https://github.com/neoground/neowx-material",

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -18,7 +18,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
 
-    version = 1.60.2
+    version = 1.60.3
 
     # Language
     # -------------------------------------------------------------------------
@@ -307,7 +307,7 @@
         values_order = soilMoist1, soilMoist2, soilMoist3, soilMoist4,soilMoist5, soilMoist6, outTemp, outHumidity, barometer, forecast, altimeter, pressure, windSpeed, windrun, rain, snowDepth, dewpoint, windchill, heatindex, inTemp, inHumidity, UV, ET, radiation, appTemp, cloudbase, lightning_noise_count, lightning_disturber_count, lightning_distance, lightning_energy, pm2_5, co2, temperatureThresholdDays, hrc:External Sensors, extraTemp1, extraHumid1, extraTemp2, extraHumid2, extraTemp3, extraHumid3, extraTemp4, extraHumid4, extraTemp5, extraHumid5, extraTemp6, extraHumid6, extraTemp7, extraHumid7, extraTemp8, extraHumid8, soilMoist1, soilMoist2, soilMoist3, soilMoist4, soilMoist5, soilMoist6, soilMoist7, soilMoist8, soilTemp1, soilTemp2, soilTemp3, soilTemp4, soilTemp5, soilTemp6, soilTemp7, soilTemp8, lightning_strike_count
 
         # The order of chart cards (right column)
-        charts_order = inTemp, outTemp, hr:Custom Charts, customChartOutTemp, customChartInTemp, customChartTemp, windchill, customChartBarometer, hr:Additional Charts, rain, snowDepth, windSpeed, windrun, windDir, windvec, UV, ET, radiation, outHumidity, inTemp, inHumidity,  cloudbase, hrc:External Sensor Charts, extraTemp1, extraHumid1, extraTemp2, extraHumid2, extraTemp3, extraHumid3, extraTemp4, extraHumid4, extraTemp5, extraHumid5, extraTemp6, extraHumid6, extraTemp7, extraHumid7, extraTemp8, extraHumid8, soilMoist1, soilTemp1, lightning_strike_count, hr:Other Charts, appTemp, lightning_noise_count, lightning_disturber_count, lightning_distance, lightning_energy, pm2_5, co2
+        charts_order = inTemp, outTemp, hr:Custom Charts, customChartOutTemp, customChartInTemp, customChartTemp, windchill, customChartBarometer, hr:Additional Charts, rain, snowDepth, windSpeed, windrun, windDir, windvec, UV, ET, radiation, outHumidity, inTemp, inHumidity,  cloudbase, hrc:External Sensor Charts, extraTemp1, extraHumid1, extraTemp2, extraHumid2, extraTemp3, extraHumid3, extraTemp4, extraHumid4, extraTemp5, extraHumid5, extraTemp6, extraHumid6, extraTemp7, extraHumid7, extraTemp8, extraHumid8, soilMoist1, soilTemp1, lightning_strike_count, hr:Other Charts, appTemp, lightning_noise_count, lightning_disturber_count, lightning_distance, lightning_energy, hr:empty, pm2_5, co2
 
         # For enabling embedded iframes or images add their names to the list below
         # The names must match the ones defined in the [[Embedded]] section below

--- a/skins/neowx-material/week.html.tmpl
+++ b/skins/neowx-material/week.html.tmpl
@@ -219,28 +219,44 @@
         #end for
     #else
         ## Expansion panel
-        #set $p_exp   = ($seg['type'] == 'hr')
-        #set $p_exp_s = 'true' if $p_exp else 'false'
-        #set $p_show  = ' show' if $p_exp else ''
-        #set $p_id    = 'nwm-val-panel-' + str($panel_idx)
-        <div class="col-12 mb-3">
-            <div class="card nwm-expansion-panel">
-                <div class="nwm-panel-header" data-toggle="collapse"
-                     data-target="#${p_id}" aria-expanded="${p_exp_s}">
-                    <span class="nwm-panel-title">${seg['title']}</span>
-                    <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
-                </div>
-                <div id="${p_id}" class="collapse${p_show}">
-                    <div class="nwm-panel-body">
-                        <div class="row">
-                            #for $x in $seg['items']
-                                $renderValueItem($x)
-                            #end for
+        #set $any_has_data = False
+        #for $x in $seg['items']
+            #if $x == "ET"
+                #if $week.ET.has_data and $week.ET.sum.raw is not None and $week.ET.sum.raw > 0.0
+                    #set $any_has_data = True
+                #end if
+            #else if $x == "temperatureThresholdDays"
+                #set $any_has_data = True
+            #else
+                #if $getVar('week.' + $x + '.has_data')
+                    #set $any_has_data = True
+                #end if
+            #end if
+        #end for
+        #if $any_has_data
+            #set $p_exp   = ($seg['type'] == 'hr')
+            #set $p_exp_s = 'true' if $p_exp else 'false'
+            #set $p_show  = ' show' if $p_exp else ''
+            #set $p_id    = 'nwm-val-panel-' + str($panel_idx)
+            <div class="col-12 mb-3">
+                <div class="card nwm-expansion-panel">
+                    <div class="nwm-panel-header" data-toggle="collapse"
+                         data-target="#${p_id}" aria-expanded="${p_exp_s}">
+                        <span class="nwm-panel-title">${seg['title']}</span>
+                        <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
+                    </div>
+                    <div id="${p_id}" class="collapse${p_show}">
+                        <div class="nwm-panel-body">
+                            <div class="row">
+                                #for $x in $seg['items']
+                                    $renderValueItem($x)
+                                #end for
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
+        #end if
     #end if
 #end def
 
@@ -254,28 +270,50 @@
             $chartCard($x, $x + 'chart')
         #end for
     #else
-        #set $p_exp   = ($seg['type'] == 'hr')
-        #set $p_exp_s = 'true' if $p_exp else 'false'
-        #set $p_show  = ' show' if $p_exp else ''
-        #set $p_id    = 'nwm-chart-panel-' + str($panel_idx)
-        <div class="col-12 mb-3">
-            <div class="card nwm-expansion-panel">
-                <div class="nwm-panel-header" data-toggle="collapse"
-                     data-target="#${p_id}" aria-expanded="${p_exp_s}">
-                    <span class="nwm-panel-title">${seg['title']}</span>
-                    <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
-                </div>
-                <div id="${p_id}" class="collapse${p_show}">
-                    <div class="nwm-panel-body">
-                        <div class="row">
-                            #for $x in $seg['items']
-                                $chartCard($x, $x + 'chart')
-                            #end for
+        #set $any_has_data = False
+        #for $x in $seg['items']
+            #if $x.startswith('customChart')
+                #set $cc = $Extras.Appearance.get($x, {})
+                #if $cc
+                    #set $cc_values_raw = $cc.get('values', '')
+                    #if isinstance($cc_values_raw, list)
+                        #set $cc_vals_list = [v.strip() for v in $cc_values_raw if v.strip()]
+                    #else
+                        #set $cc_vals_list = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
+                    #end if
+                    #set $cc_any_has_data = any($getVar('week.' + v + '.has_data') for v in $cc_vals_list)
+                    #if len($cc_vals_list) > 0 and $cc_any_has_data
+                        #set $any_has_data = True
+                    #end if
+                #end if
+            #else if ($getVar('week.' + $x + '.has_data') or $x == "windvec") and $x != "appTemp" and ($x != 'ET' or ($week.ET.sum.raw is not None and $week.ET.sum.raw > 0.0))
+                #set $any_has_data = True
+            #end if
+        #end for
+        #if $any_has_data
+            #set $p_exp   = ($seg['type'] == 'hr')
+            #set $p_exp_s = 'true' if $p_exp else 'false'
+            #set $p_show  = ' show' if $p_exp else ''
+            #set $p_id    = 'nwm-chart-panel-' + str($panel_idx)
+            <div class="col-12 mb-3">
+                <div class="card nwm-expansion-panel">
+                    <div class="nwm-panel-header" data-toggle="collapse"
+                         data-target="#${p_id}" aria-expanded="${p_exp_s}">
+                        <span class="nwm-panel-title">${seg['title']}</span>
+                        <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
+                    </div>
+                    <div id="${p_id}" class="collapse${p_show}">
+                        <div class="nwm-panel-body">
+                            <div class="row">
+                                #for $x in $seg['items']
+                                    $chartCard($x, $x + 'chart')
+                                #end for
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
+        #end if
     #end if
 #end def
 

--- a/skins/neowx-material/year-%Y.html.tmpl
+++ b/skins/neowx-material/year-%Y.html.tmpl
@@ -226,28 +226,44 @@
         #end for
     #else
         ## Expansion panel
-        #set $p_exp   = ($seg['type'] == 'hr')
-        #set $p_exp_s = 'true' if $p_exp else 'false'
-        #set $p_show  = ' show' if $p_exp else ''
-        #set $p_id    = 'nwm-val-panel-' + str($panel_idx)
-        <div class="col-12 mb-3">
-            <div class="card nwm-expansion-panel">
-                <div class="nwm-panel-header" data-toggle="collapse"
-                     data-target="#${p_id}" aria-expanded="${p_exp_s}">
-                    <span class="nwm-panel-title">${seg['title']}</span>
-                    <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
-                </div>
-                <div id="${p_id}" class="collapse${p_show}">
-                    <div class="nwm-panel-body">
-                        <div class="row">
-                            #for $x in $seg['items']
-                                $renderValueItem($x)
-                            #end for
+        #set $any_has_data = False
+        #for $x in $seg['items']
+            #if $x == "ET"
+                #if $year.ET.has_data and $year.ET.sum.raw is not None and $year.ET.sum.raw > 0.0
+                    #set $any_has_data = True
+                #end if
+            #else if $x == "temperatureThresholdDays"
+                #set $any_has_data = True
+            #else
+                #if $getVar('year.' + $x + '.has_data')
+                    #set $any_has_data = True
+                #end if
+            #end if
+        #end for
+        #if $any_has_data
+            #set $p_exp   = ($seg['type'] == 'hr')
+            #set $p_exp_s = 'true' if $p_exp else 'false'
+            #set $p_show  = ' show' if $p_exp else ''
+            #set $p_id    = 'nwm-val-panel-' + str($panel_idx)
+            <div class="col-12 mb-3">
+                <div class="card nwm-expansion-panel">
+                    <div class="nwm-panel-header" data-toggle="collapse"
+                         data-target="#${p_id}" aria-expanded="${p_exp_s}">
+                        <span class="nwm-panel-title">${seg['title']}</span>
+                        <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
+                    </div>
+                    <div id="${p_id}" class="collapse${p_show}">
+                        <div class="nwm-panel-body">
+                            <div class="row">
+                                #for $x in $seg['items']
+                                    $renderValueItem($x)
+                                #end for
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
+        #end if
     #end if
 #end def
 
@@ -261,28 +277,50 @@
             $chartCard($x, $x + 'chart')
         #end for
     #else
-        #set $p_exp   = ($seg['type'] == 'hr')
-        #set $p_exp_s = 'true' if $p_exp else 'false'
-        #set $p_show  = ' show' if $p_exp else ''
-        #set $p_id    = 'nwm-chart-panel-' + str($panel_idx)
-        <div class="col-12 mb-3">
-            <div class="card nwm-expansion-panel">
-                <div class="nwm-panel-header" data-toggle="collapse"
-                     data-target="#${p_id}" aria-expanded="${p_exp_s}">
-                    <span class="nwm-panel-title">${seg['title']}</span>
-                    <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
-                </div>
-                <div id="${p_id}" class="collapse${p_show}">
-                    <div class="nwm-panel-body">
-                        <div class="row">
-                            #for $x in $seg['items']
-                                $chartCard($x, $x + 'chart')
-                            #end for
+        #set $any_has_data = False
+        #for $x in $seg['items']
+            #if $x.startswith('customChart')
+                #set $cc = $Extras.Appearance.get($x, {})
+                #if $cc
+                    #set $cc_values_raw = $cc.get('values', '')
+                    #if isinstance($cc_values_raw, list)
+                        #set $cc_vals_list = [v.strip() for v in $cc_values_raw if v.strip()]
+                    #else
+                        #set $cc_vals_list = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
+                    #end if
+                    #set $cc_any_has_data = any($getVar('year.' + v + '.has_data') for v in $cc_vals_list)
+                    #if len($cc_vals_list) > 0 and $cc_any_has_data
+                        #set $any_has_data = True
+                    #end if
+                #end if
+            #else if ($getVar('year.' + $x + '.has_data') or $x == "windvec") and $x != "appTemp" and ($x != 'ET' or ($year.ET.sum.raw is not None and $year.ET.sum.raw > 0.0))
+                #set $any_has_data = True
+            #end if
+        #end for
+        #if $any_has_data
+            #set $p_exp   = ($seg['type'] == 'hr')
+            #set $p_exp_s = 'true' if $p_exp else 'false'
+            #set $p_show  = ' show' if $p_exp else ''
+            #set $p_id    = 'nwm-chart-panel-' + str($panel_idx)
+            <div class="col-12 mb-3">
+                <div class="card nwm-expansion-panel">
+                    <div class="nwm-panel-header" data-toggle="collapse"
+                         data-target="#${p_id}" aria-expanded="${p_exp_s}">
+                        <span class="nwm-panel-title">${seg['title']}</span>
+                        <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
+                    </div>
+                    <div id="${p_id}" class="collapse${p_show}">
+                        <div class="nwm-panel-body">
+                            <div class="row">
+                                #for $x in $seg['items']
+                                    $chartCard($x, $x + 'chart')
+                                #end for
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
+        #end if
     #end if
 #end def
 

--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -226,28 +226,44 @@
         #end for
     #else
         ## Expansion panel
-        #set $p_exp   = ($seg['type'] == 'hr')
-        #set $p_exp_s = 'true' if $p_exp else 'false'
-        #set $p_show  = ' show' if $p_exp else ''
-        #set $p_id    = 'nwm-val-panel-' + str($panel_idx)
-        <div class="col-12 mb-3">
-            <div class="card nwm-expansion-panel">
-                <div class="nwm-panel-header" data-toggle="collapse"
-                     data-target="#${p_id}" aria-expanded="${p_exp_s}">
-                    <span class="nwm-panel-title">${seg['title']}</span>
-                    <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
-                </div>
-                <div id="${p_id}" class="collapse${p_show}">
-                    <div class="nwm-panel-body">
-                        <div class="row">
-                            #for $x in $seg['items']
-                                $renderValueItem($x)
-                            #end for
+        #set $any_has_data = False
+        #for $x in $seg['items']
+            #if $x == "ET"
+                #if $year.ET.has_data and $year.ET.sum.raw is not None and $year.ET.sum.raw > 0.0
+                    #set $any_has_data = True
+                #end if
+            #else if $x == "temperatureThresholdDays"
+                #set $any_has_data = True
+            #else
+                #if $getVar('year.' + $x + '.has_data')
+                    #set $any_has_data = True
+                #end if
+            #end if
+        #end for
+        #if $any_has_data
+            #set $p_exp   = ($seg['type'] == 'hr')
+            #set $p_exp_s = 'true' if $p_exp else 'false'
+            #set $p_show  = ' show' if $p_exp else ''
+            #set $p_id    = 'nwm-val-panel-' + str($panel_idx)
+            <div class="col-12 mb-3">
+                <div class="card nwm-expansion-panel">
+                    <div class="nwm-panel-header" data-toggle="collapse"
+                         data-target="#${p_id}" aria-expanded="${p_exp_s}">
+                        <span class="nwm-panel-title">${seg['title']}</span>
+                        <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
+                    </div>
+                    <div id="${p_id}" class="collapse${p_show}">
+                        <div class="nwm-panel-body">
+                            <div class="row">
+                                #for $x in $seg['items']
+                                    $renderValueItem($x)
+                                #end for
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
+        #end if
     #end if
 #end def
 
@@ -261,28 +277,50 @@
             $chartCard($x, $x + 'chart')
         #end for
     #else
-        #set $p_exp   = ($seg['type'] == 'hr')
-        #set $p_exp_s = 'true' if $p_exp else 'false'
-        #set $p_show  = ' show' if $p_exp else ''
-        #set $p_id    = 'nwm-chart-panel-' + str($panel_idx)
-        <div class="col-12 mb-3">
-            <div class="card nwm-expansion-panel">
-                <div class="nwm-panel-header" data-toggle="collapse"
-                     data-target="#${p_id}" aria-expanded="${p_exp_s}">
-                    <span class="nwm-panel-title">${seg['title']}</span>
-                    <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
-                </div>
-                <div id="${p_id}" class="collapse${p_show}">
-                    <div class="nwm-panel-body">
-                        <div class="row">
-                            #for $x in $seg['items']
-                                $chartCard($x, $x + 'chart')
-                            #end for
+        #set $any_has_data = False
+        #for $x in $seg['items']
+            #if $x.startswith('customChart')
+                #set $cc = $Extras.Appearance.get($x, {})
+                #if $cc
+                    #set $cc_values_raw = $cc.get('values', '')
+                    #if isinstance($cc_values_raw, list)
+                        #set $cc_vals_list = [v.strip() for v in $cc_values_raw if v.strip()]
+                    #else
+                        #set $cc_vals_list = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
+                    #end if
+                    #set $cc_any_has_data = any($getVar('year.' + v + '.has_data') for v in $cc_vals_list)
+                    #if len($cc_vals_list) > 0 and $cc_any_has_data
+                        #set $any_has_data = True
+                    #end if
+                #end if
+            #else if ($getVar('year.' + $x + '.has_data') or $x == "windvec") and $x != "appTemp" and ($x != 'ET' or ($year.ET.sum.raw is not None and $year.ET.sum.raw > 0.0))
+                #set $any_has_data = True
+            #end if
+        #end for
+        #if $any_has_data
+            #set $p_exp   = ($seg['type'] == 'hr')
+            #set $p_exp_s = 'true' if $p_exp else 'false'
+            #set $p_show  = ' show' if $p_exp else ''
+            #set $p_id    = 'nwm-chart-panel-' + str($panel_idx)
+            <div class="col-12 mb-3">
+                <div class="card nwm-expansion-panel">
+                    <div class="nwm-panel-header" data-toggle="collapse"
+                         data-target="#${p_id}" aria-expanded="${p_exp_s}">
+                        <span class="nwm-panel-title">${seg['title']}</span>
+                        <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
+                    </div>
+                    <div id="${p_id}" class="collapse${p_show}">
+                        <div class="nwm-panel-body">
+                            <div class="row">
+                                #for $x in $seg['items']
+                                    $chartCard($x, $x + 'chart')
+                                #end for
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
+        #end if
     #end if
 #end def
 

--- a/skins/neowx-material/yesterday.html.tmpl
+++ b/skins/neowx-material/yesterday.html.tmpl
@@ -160,28 +160,44 @@
         #end for
     #else
         ## Expansion panel
-        #set $p_exp   = ($seg['type'] == 'hr')
-        #set $p_exp_s = 'true' if $p_exp else 'false'
-        #set $p_show  = ' show' if $p_exp else ''
-        #set $p_id    = 'nwm-val-panel-' + str($panel_idx)
-        <div class="col-12 mb-3">
-            <div class="card nwm-expansion-panel">
-                <div class="nwm-panel-header" data-toggle="collapse"
-                     data-target="#${p_id}" aria-expanded="${p_exp_s}">
-                    <span class="nwm-panel-title">${seg['title']}</span>
-                    <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
-                </div>
-                <div id="${p_id}" class="collapse${p_show}">
-                    <div class="nwm-panel-body">
-                        <div class="row">
-                            #for $x in $seg['items']
-                                $renderValueItem($x)
-                            #end for
+        #set $any_has_data = False
+        #for $x in $seg['items']
+            #if $x == "ET"
+                #if $yesterday.ET.has_data and $yesterday.ET.sum.raw is not None and $yesterday.ET.sum.raw > 0.0
+                    #set $any_has_data = True
+                #end if
+            #else if $x == "temperatureThresholdDays"
+                #set $any_has_data = True
+            #else
+                #if $getVar('yesterday.' + $x + '.has_data')
+                    #set $any_has_data = True
+                #end if
+            #end if
+        #end for
+        #if $any_has_data
+            #set $p_exp   = ($seg['type'] == 'hr')
+            #set $p_exp_s = 'true' if $p_exp else 'false'
+            #set $p_show  = ' show' if $p_exp else ''
+            #set $p_id    = 'nwm-val-panel-' + str($panel_idx)
+            <div class="col-12 mb-3">
+                <div class="card nwm-expansion-panel">
+                    <div class="nwm-panel-header" data-toggle="collapse"
+                         data-target="#${p_id}" aria-expanded="${p_exp_s}">
+                        <span class="nwm-panel-title">${seg['title']}</span>
+                        <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
+                    </div>
+                    <div id="${p_id}" class="collapse${p_show}">
+                        <div class="nwm-panel-body">
+                            <div class="row">
+                                #for $x in $seg['items']
+                                    $renderValueItem($x)
+                                #end for
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
+        #end if
     #end if
 #end def
 
@@ -195,28 +211,50 @@
             $chartCard($x, $x + 'chart')
         #end for
     #else
-        #set $p_exp   = ($seg['type'] == 'hr')
-        #set $p_exp_s = 'true' if $p_exp else 'false'
-        #set $p_show  = ' show' if $p_exp else ''
-        #set $p_id    = 'nwm-chart-panel-' + str($panel_idx)
-        <div class="col-12 mb-3">
-            <div class="card nwm-expansion-panel">
-                <div class="nwm-panel-header" data-toggle="collapse"
-                     data-target="#${p_id}" aria-expanded="${p_exp_s}">
-                    <span class="nwm-panel-title">${seg['title']}</span>
-                    <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
-                </div>
-                <div id="${p_id}" class="collapse${p_show}">
-                    <div class="nwm-panel-body">
-                        <div class="row">
-                            #for $x in $seg['items']
-                                $chartCard($x, $x + 'chart')
-                            #end for
+        #set $any_has_data = False
+        #for $x in $seg['items']
+            #if $x.startswith('customChart')
+                #set $cc = $Extras.Appearance.get($x, {})
+                #if $cc
+                    #set $cc_values_raw = $cc.get('values', '')
+                    #if isinstance($cc_values_raw, list)
+                        #set $cc_vals_list = [v.strip() for v in $cc_values_raw if v.strip()]
+                    #else
+                        #set $cc_vals_list = [v.strip() for v in $cc_values_raw.split(',') if v.strip()]
+                    #end if
+                    #set $cc_any_has_data = any($getVar('yesterday.' + v + '.has_data') for v in $cc_vals_list)
+                    #if len($cc_vals_list) > 0 and $cc_any_has_data
+                        #set $any_has_data = True
+                    #end if
+                #end if
+            #else if ($getVar('yesterday.' + $x + '.has_data') or $x == "windvec") and $x not in ["appTemp", "windrun"] and ($x != 'ET' or ($yesterday.ET.sum.raw is not None and $yesterday.ET.sum.raw > 0.0))
+                #set $any_has_data = True
+            #end if
+        #end for
+        #if $any_has_data
+            #set $p_exp   = ($seg['type'] == 'hr')
+            #set $p_exp_s = 'true' if $p_exp else 'false'
+            #set $p_show  = ' show' if $p_exp else ''
+            #set $p_id    = 'nwm-chart-panel-' + str($panel_idx)
+            <div class="col-12 mb-3">
+                <div class="card nwm-expansion-panel">
+                    <div class="nwm-panel-header" data-toggle="collapse"
+                         data-target="#${p_id}" aria-expanded="${p_exp_s}">
+                        <span class="nwm-panel-title">${seg['title']}</span>
+                        <span class="mdi mdi-chevron-down nwm-panel-icon"></span>
+                    </div>
+                    <div id="${p_id}" class="collapse${p_show}">
+                        <div class="nwm-panel-body">
+                            <div class="row">
+                                #for $x in $seg['items']
+                                    $chartCard($x, $x + 'chart')
+                                #end for
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
+        #end if
     #end if
 #end def
 

--- a/update_env.sh
+++ b/update_env.sh
@@ -76,7 +76,7 @@ rsync -a "$SRC_DIR/css/" "/Volumes/web/css/"
 
 # Run config_patcher.py
 cd "$DEST_DIR"
-python3 config_patcher.py skin.conf skin.conf.patch
+###python3 config_patcher.py skin.conf skin.conf.patch
 
 # Update version in destination skin.conf
 echo "Updating version to $NEW_VERSION in destination skin.conf..."


### PR DESCRIPTION
Hide panels if they are empty: meaning all configured cards or charts have not data
then hide the panel