### PR TITLE
Improve Pressure Trend Indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ This is an **actively maintained** continuation of the NeoWX Material skin. The 
 - Wind rose visualization
 - Customizable colors and appearance
 
+### 📈 Unit-Aware Trend Indicators
+- Rising / steady / falling arrows with tooltips on **current-page** values
+- Direction is computed in a canonical unit, so trends behave identically in **metric, imperial, or any other supported unit**
+- Selectable threshold style via `trend_type`: `multi` (WMO/NWS multi-tier, default), `davis` (Davis Vantage), or `strict` (simple up/steady/down)
+- Barometric pressure shows graded tendency (slowly / rising / rapidly) with steeper and doubled arrows
+- Pick which observations show a trend with `show_trend_on`
+
 ### 🔧 Highly Customizable
 - Extensive configuration options in `skin.conf`
 - Reorderable cards and charts

--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ Compact cheat-sheet for the multi-axis syntax:
 - Minimal working configuration snippets
 - All supported keys at a glance
 
+### 📈 [Trend Indicators – Usage Guide](docs/TREND-INDICATORS.md)
+How the current-page trend arrows work and how to tune them:
+- Unit-aware direction (metric / imperial / other behave identically)
+- `trend_type` styles: `multi` (WMO/NWS), `davis` (Davis Vantage), `strict`
+- Threshold tables, tooltip precision, and `show_trend_on` reference
+
 **Quick Links:**
 - [Installation](#-installation) • [Configuration](#️-configuration) • [Troubleshooting](#-contribution--support) • [Contributing](#-contribution--support)
 

--- a/docs/TREND-INDICATORS.md
+++ b/docs/TREND-INDICATORS.md
@@ -61,7 +61,8 @@ span between the first available reading and now, not a fixed 3 hours:
   isn't enough data for a meaningful tendency.
 - Between 1 and 3 hours, the pressure thresholds are **scaled to the real span** (so a
   rate that would be "rising" over 3 h is still classified correctly over a shorter
-  window), and the tooltip shows the true interval, e.g. `(over 1.5 h)`.
+  window), and the tooltip shows the true interval, e.g. `(over 1.5 h)`. A span within
+  **5 minutes** of the full 3 hours is treated as a complete window and shown as `3 h`.
 
 ## Threshold styles (`trend_type`)
 

--- a/docs/TREND-INDICATORS.md
+++ b/docs/TREND-INDICATORS.md
@@ -48,11 +48,20 @@ for the other observations too.
 > **Why not WeeWX `$trend`?** `$trend` only returns a value when an archive record
 > lands within a small grace window of *exactly* `now − 3h`; on many stations that
 > made the arrows disappear intermittently. The skin computes the change itself, so an
-> arrow appears whenever there is any recent data.
+> arrow appears whenever there is enough recent data.
 
 The change is evaluated in a **canonical unit** (see
 [Unit independence](#unit-independence)) to decide the direction and tier, while the
 **tooltip** always shows the change in *your* display units.
+
+**Short windows (restarts, new installs, data gaps).** The skin uses the *actual*
+span between the first available reading and now, not a fixed 3 hours:
+
+- If less than **1 hour** of recent history exists, the trend is **hidden** — there
+  isn't enough data for a meaningful tendency.
+- Between 1 and 3 hours, the pressure thresholds are **scaled to the real span** (so a
+  rate that would be "rising" over 3 h is still classified correctly over a shorter
+  window), and the tooltip shows the true interval, e.g. `(over 1.5 h)`.
 
 ## Threshold styles (`trend_type`)
 
@@ -132,7 +141,8 @@ threshold would treat °F and °C differently.
 ## Tooltips
 
 The tooltip names the category and shows the signed change in your display units over the
-3-hour window, e.g. `Rapidly Rising: +0.1181 inHg (over 3 h)`.
+window actually covered by the data, e.g. `Rapidly Rising: +0.1181 inHg (over 3 h)` (or
+`(over 1.5 h)` shortly after a restart — see [How a trend is calculated](#how-a-trend-is-calculated)).
 
 Pressure is rounded to a unit-appropriate precision so small changes remain visible:
 
@@ -177,7 +187,12 @@ Arrows are drawn with the bundled [Weather Icons](https://erikflowers.github.io/
 **No arrow appears for an observation**
 - Confirm the observation name is listed in `show_trend_on` (names are case-sensitive and
   must match the WeeWX field, e.g. `outTemp`, not `Outside Temperature`).
-- The observation needs at least one archive record within the last 3 hours.
+- The observation needs archive records within the last 3 hours.
+
+**No arrow right after a restart, new install, or data gap**
+- The trend is hidden until at least **1 hour** of recent history is available, so the
+  tendency isn't computed from just a few minutes of data. It returns automatically once
+  the window is wide enough.
 
 **The barometer almost never leaves "steady" (or flickers constantly)**
 - That's the threshold style. The steady band is ±0.5 hPa in `strict` and ±0.7 hPa in

--- a/docs/TREND-INDICATORS.md
+++ b/docs/TREND-INDICATORS.md
@@ -70,31 +70,35 @@ All three styles share the same unit-canonical engine; they differ only in the b
 thresholds and how many tiers are shown. Non-pressure observations use a simple
 up / steady / down arrow in every style.
 
+In the tables below, **Δ** is the pressure change over the window. The ranges are
+half-open so every value maps to exactly one tier (a value exactly on a boundary falls
+into the *faster* tier — e.g. Δ = +2.0 hPa is "Rising", not "Slowly Rising").
+
 ### `multi` (default) — WMO/NWS-style multi-tier
 
 The barometer arrow steepens as the change grows, and doubles for the rapid tier.
 
-| 3-hour change | inHg equiv. | Arrow | Tooltip word |
+| Change (Δ) | inHg equiv. | Arrow | Tooltip word |
 |---|---|---|---|
-| ≥ +5.0 hPa | ≥ +0.148 | ↑↑ | Rapidly Rising |
-| +2.0 … +5.0 hPa | +0.059 … +0.148 | ↑ | Rising |
-| +0.7 … +2.0 hPa | +0.021 … +0.059 | ↗ | Slowly Rising |
-| −0.7 … +0.7 hPa | ±0.021 | → | Steady |
-| −0.7 … −2.0 hPa | −0.021 … −0.059 | ↘ | Slowly Falling |
-| −2.0 … −5.0 hPa | −0.059 … −0.148 | ↓ | Falling |
-| ≤ −5.0 hPa | ≤ −0.148 | ↓↓ | Rapidly Falling |
+| Δ ≥ +5.0 hPa | ≥ +0.148 | ↑↑ | Rapidly Rising |
+| +2.0 ≤ Δ < +5.0 hPa | +0.059 … +0.148 | ↑ | Rising |
+| +0.7 ≤ Δ < +2.0 hPa | +0.021 … +0.059 | ↗ | Slowly Rising |
+| −0.7 < Δ < +0.7 hPa | within ±0.021 | → | Steady |
+| −2.0 < Δ ≤ −0.7 hPa | −0.021 … −0.059 | ↘ | Slowly Falling |
+| −5.0 < Δ ≤ −2.0 hPa | −0.059 … −0.148 | ↓ | Falling |
+| Δ ≤ −5.0 hPa | ≤ −0.148 | ↓↓ | Rapidly Falling |
 
 ### `davis` — Davis Vantage thresholds
 
 Mirrors the 3-level rate descriptions used by Davis Vantage consoles.
 
-| 3-hour change | inHg equiv. | Arrow | Tooltip word |
+| Change (Δ) | inHg equiv. | Arrow | Tooltip word |
 |---|---|---|---|
-| ≥ +2.0 hPa | ≥ +0.059 | ↑ | Rising rapidly |
-| +0.7 … +2.0 hPa | +0.021 … +0.059 | ↗ | Rising slowly |
-| −0.7 … +0.7 hPa | ±0.021 | → | Steady |
-| −0.7 … −2.0 hPa | −0.021 … −0.059 | ↘ | Falling slowly |
-| ≤ −2.0 hPa | ≤ −0.059 | ↓ | Falling rapidly |
+| Δ ≥ +2.0 hPa | ≥ +0.059 | ↑ | Rising rapidly |
+| +0.7 ≤ Δ < +2.0 hPa | +0.021 … +0.059 | ↗ | Rising slowly |
+| −0.7 < Δ < +0.7 hPa | within ±0.021 | → | Steady |
+| −2.0 < Δ ≤ −0.7 hPa | −0.021 … −0.059 | ↘ | Falling slowly |
+| Δ ≤ −2.0 hPa | ≤ −0.059 | ↓ | Falling rapidly |
 
 These hPa cut-points reproduce Davis's published inHg table (≈ 0.02 inHg and 0.06 inHg).
 
@@ -103,11 +107,11 @@ These hPa cut-points reproduce Davis's published inHg table (≈ 0.02 inHg and 0
 Every observation, including the barometer, uses a single steady band and a simple
 rising / steady / falling arrow — no rapid tier, no doubled arrows.
 
-| 3-hour change (barometer) | Arrow | Tooltip word |
+| Change (Δ, barometer) | Arrow | Tooltip word |
 |---|---|---|
-| ≥ +0.5 hPa | ↗ | Rising |
-| −0.5 … +0.5 hPa | → | Steady |
-| ≤ −0.5 hPa | ↘ | Falling |
+| Δ > +0.5 hPa | ↗ | Rising |
+| −0.5 ≤ Δ ≤ +0.5 hPa | → | Steady |
+| Δ < −0.5 hPa | ↘ | Falling |
 
 The `0.5 hPa` band is the canonical pressure dead-band; the same single-band logic
 applies to all other observations (see the table below).

--- a/docs/TREND-INDICATORS.md
+++ b/docs/TREND-INDICATORS.md
@@ -33,7 +33,7 @@ Two settings under `[[Appearance]]` in `skin.conf` control everything:
 
 **Result:** each observation listed in `show_trend_on` shows a ↗ / → / ↘ arrow (and,
 for the barometer in `multi`/`davis`, a graded tendency) with a tooltip such as
-`Slowly Rising: +0.0089 inHg (over 3 h)`.
+`Slowly Rising: +0.009 inHg (over 3 h)`.
 
 ## How a trend is calculated
 
@@ -142,15 +142,15 @@ threshold would treat °F and °C differently.
 ## Tooltips
 
 The tooltip names the category and shows the signed change in your display units over the
-window actually covered by the data, e.g. `Rapidly Rising: +0.1181 inHg (over 3 h)` (or
+window actually covered by the data, e.g. `Rapidly Rising: +0.118 inHg (over 3 h)` (or
 `(over 1.5 h)` shortly after a restart — see [How a trend is calculated](#how-a-trend-is-calculated)).
 
 Pressure is rounded to a unit-appropriate precision so small changes remain visible:
 
 | Pressure unit | Decimal places |
 |---|---|
-| inHg | 4 |
-| kPa | 3 |
+| inHg | 3 |
+| kPa | 2 |
 | mmHg | 2 |
 | hPa / mbar | 1 |
 

--- a/docs/TREND-INDICATORS.md
+++ b/docs/TREND-INDICATORS.md
@@ -1,0 +1,189 @@
+# Trend Indicators – Usage Guide
+
+## Overview
+
+On the **current page**, selected observations can show a small **trend arrow** next
+to their value, with a tooltip describing how much the reading has changed. Barometer
+trends in particular are a classic forecasting aid — a falling barometer often
+precedes unsettled weather.
+
+neowx-material's trend indicators are **unit-aware**: the direction is always decided
+in a single canonical unit per measurement family, so a station running imperial units
+behaves exactly like one running metric (or any other supported unit). You can also
+choose how sensitive the thresholds are with the `trend_type` setting.
+
+This feature is useful when you want to:
+
+- See at a glance whether temperature, humidity, pressure, etc. are rising or falling
+- Get a graded barometric **tendency** (slowly / rising / rapidly) like a dedicated console
+- Match the behavior of a specific weather station brand (e.g. Davis Vantage)
+
+## Quick Start
+
+Two settings under `[[Appearance]]` in `skin.conf` control everything:
+
+```conf
+[[Appearance]]
+    # Which observations get a trend arrow on the current page
+    show_trend_on = barometer, outTemp, outHumidity, inTemp, inHumidity, UV, co2, pm2_5, ET
+
+    # How the thresholds behave: multi (default) | davis | strict
+    trend_type = multi
+```
+
+**Result:** each observation listed in `show_trend_on` shows a ↗ / → / ↘ arrow (and,
+for the barometer in `multi`/`davis`, a graded tendency) with a tooltip such as
+`Slowly Rising: +0.0089 inHg (over 3 h)`.
+
+## How a trend is calculated
+
+For each observation the skin compares:
+
+- the **current** reading, against
+- the **oldest reading in the last 3 hours** (`span(hour_delta=3).<obs>.first`)
+
+The 3-hour window is the meteorological standard for pressure tendency and works well
+for the other observations too.
+
+> **Why not WeeWX `$trend`?** `$trend` only returns a value when an archive record
+> lands within a small grace window of *exactly* `now − 3h`; on many stations that
+> made the arrows disappear intermittently. The skin computes the change itself, so an
+> arrow appears whenever there is any recent data.
+
+The change is evaluated in a **canonical unit** (see
+[Unit independence](#unit-independence)) to decide the direction and tier, while the
+**tooltip** always shows the change in *your* display units.
+
+## Threshold styles (`trend_type`)
+
+All three styles share the same unit-canonical engine; they differ only in the barometer
+thresholds and how many tiers are shown. Non-pressure observations use a simple
+up / steady / down arrow in every style.
+
+### `multi` (default) — WMO/NWS-style multi-tier
+
+The barometer arrow steepens as the change grows, and doubles for the rapid tier.
+
+| 3-hour change | inHg equiv. | Arrow | Tooltip word |
+|---|---|---|---|
+| ≥ +3.5 hPa | ≥ +0.103 | ↑↑ | Rapidly Rising |
+| +1.5 … +3.5 hPa | +0.044 … +0.103 | ↑ | Rising |
+| +0.25 … +1.5 hPa | +0.007 … +0.044 | ↗ | Slowly Rising |
+| −0.25 … +0.25 hPa | ±0.007 | → | Steady |
+| −0.25 … −1.5 hPa | −0.007 … −0.044 | ↘ | Slowly Falling |
+| −1.5 … −3.5 hPa | −0.044 … −0.103 | ↓ | Falling |
+| ≤ −3.5 hPa | ≤ −0.103 | ↓↓ | Rapidly Falling |
+
+### `davis` — Davis Vantage thresholds
+
+Mirrors the 3-level rate descriptions used by Davis Vantage consoles.
+
+| 3-hour change | inHg equiv. | Arrow | Tooltip word |
+|---|---|---|---|
+| ≥ +2.0 hPa | ≥ +0.059 | ↑ | Rising rapidly |
+| +0.7 … +2.0 hPa | +0.021 … +0.059 | ↗ | Rising slowly |
+| −0.7 … +0.7 hPa | ±0.021 | → | Steady |
+| −0.7 … −2.0 hPa | −0.021 … −0.059 | ↘ | Falling slowly |
+| ≤ −2.0 hPa | ≤ −0.059 | ↓ | Falling rapidly |
+
+These hPa cut-points reproduce Davis's published inHg table (≈ 0.02 inHg and 0.06 inHg).
+
+### `strict` — simple up / steady / down
+
+Every observation, including the barometer, uses a single steady band and a simple
+rising / steady / falling arrow — no rapid tier, no doubled arrows.
+
+| 3-hour change (barometer) | Arrow | Tooltip word |
+|---|---|---|
+| ≥ +0.5 hPa | ↗ | Rising |
+| −0.5 … +0.5 hPa | → | Steady |
+| ≤ −0.5 hPa | ↘ | Falling |
+
+The `0.5 hPa` band is the canonical pressure dead-band; the same single-band logic
+applies to all other observations (see the table below).
+
+> **Note:** an unrecognized `trend_type` value falls back to `multi`.
+
+## Unit independence
+
+The direction (and, for the barometer, the tier) is decided after converting the change
+into a **canonical unit** for that measurement family. This is what makes a trend behave
+identically regardless of the units your station reports in.
+
+| Family | Canonical unit | Steady dead-band (±) | Display units that map to it |
+|---|---|---|---|
+| Pressure | mbar (hPa) | 0.5 | inHg, mmHg, kPa, hPa, mbar |
+| Temperature | °C | 0.5 | °F, °K, °C |
+| Rain / ET | mm | 0.2 | inch, cm, mm |
+| Rain rate | mm/h | 0.2 | inch/h, cm/h, mm/h |
+| Wind speed | km/h | 1.0 | mph, knot, m/s, beaufort, km/h |
+| Distance (short) | meter | 10 | foot, meter |
+| Distance (long) | km | 0.5 | mile, km |
+| Unit-agnostic | — (compared directly) | 0.5 | %, UV index, ppm, µg/m³, W/m² |
+
+The dead-band is the "steady" threshold for `strict` and for all non-pressure
+observations in `multi`/`davis`. Because it is applied in the canonical unit, a small
+imperial change and the equivalent metric change produce the **same** result.
+
+**Example:** a **+0.8 °F** rise equals **+0.44 °C**, which is below the 0.5 °C dead-band,
+so it correctly shows **Steady** — exactly as a +0.44 °C reading would. A naïve raw
+threshold would treat °F and °C differently.
+
+## Tooltips
+
+The tooltip names the category and shows the signed change in your display units over the
+3-hour window, e.g. `Rapidly Rising: +0.1181 inHg (over 3 h)`.
+
+Pressure is rounded to a unit-appropriate precision so small changes remain visible:
+
+| Pressure unit | Decimal places |
+|---|---|
+| inHg | 4 |
+| kPa | 3 |
+| mmHg | 2 |
+| hPa / mbar | 1 |
+
+Non-pressure observations are rounded to 2 decimal places.
+
+## Arrow reference
+
+Arrows are drawn with the bundled [Weather Icons](https://erikflowers.github.io/weather-icons/) font:
+
+| Glyph | Class | Meaning |
+|---|---|---|
+| → | `wi-direction-right` | Steady |
+| ↗ / ↘ | `wi-direction-up-right` / `wi-direction-down-right` | Rising / falling (or "slowly") |
+| ↑ / ↓ | `wi-direction-up` / `wi-direction-down` | Rising / falling faster |
+| ↑↑ / ↓↓ | two `wi-direction-up` / `wi-direction-down` | `multi` rapid tier |
+
+## Choosing a style
+
+- **`multi`** — the richest readout; good if you like a graded barometric tendency and
+  want the most information at a glance. *(Default.)*
+- **`davis`** — pick this if you're used to a Davis Vantage console and want the arrows
+  to match its rise/fall rate descriptions.
+- **`strict`** — the simplest, least "twitchy" option: just up / steady / down for
+  everything, with no rapid tier.
+
+## Configuration reference
+
+| Setting | Section | Values | Default |
+|---|---|---|---|
+| `show_trend_on` | `[[Appearance]]` | comma-separated observation names | `barometer, outTemp, outHumidity, inTemp, inHumidity, UV, co2, pm2_5, ET` |
+| `trend_type` | `[[Appearance]]` | `multi`, `davis`, `strict` | `multi` |
+
+## Troubleshooting
+
+**No arrow appears for an observation**
+- Confirm the observation name is listed in `show_trend_on` (names are case-sensitive and
+  must match the WeeWX field, e.g. `outTemp`, not `Outside Temperature`).
+- The observation needs at least one archive record within the last 3 hours.
+
+**The barometer almost never leaves "steady" (or flickers constantly)**
+- That's the threshold style. `strict` has the widest steady band per change; `multi`
+  has the narrowest (±0.25 hPa). Switch `trend_type` to taste.
+
+**The tooltip value looks rounded/coarse for pressure**
+- inHg/kPa changes are tiny, so they use extra decimal places (see
+  [Tooltips](#tooltips)). If you display in hPa/mbar the change is larger and shown to 1
+  decimal place.

--- a/docs/TREND-INDICATORS.md
+++ b/docs/TREND-INDICATORS.md
@@ -66,13 +66,13 @@ The barometer arrow steepens as the change grows, and doubles for the rapid tier
 
 | 3-hour change | inHg equiv. | Arrow | Tooltip word |
 |---|---|---|---|
-| ≥ +3.5 hPa | ≥ +0.103 | ↑↑ | Rapidly Rising |
-| +1.5 … +3.5 hPa | +0.044 … +0.103 | ↑ | Rising |
-| +0.25 … +1.5 hPa | +0.007 … +0.044 | ↗ | Slowly Rising |
-| −0.25 … +0.25 hPa | ±0.007 | → | Steady |
-| −0.25 … −1.5 hPa | −0.007 … −0.044 | ↘ | Slowly Falling |
-| −1.5 … −3.5 hPa | −0.044 … −0.103 | ↓ | Falling |
-| ≤ −3.5 hPa | ≤ −0.103 | ↓↓ | Rapidly Falling |
+| ≥ +5.0 hPa | ≥ +0.148 | ↑↑ | Rapidly Rising |
+| +2.0 … +5.0 hPa | +0.059 … +0.148 | ↑ | Rising |
+| +0.7 … +2.0 hPa | +0.021 … +0.059 | ↗ | Slowly Rising |
+| −0.7 … +0.7 hPa | ±0.021 | → | Steady |
+| −0.7 … −2.0 hPa | −0.021 … −0.059 | ↘ | Slowly Falling |
+| −2.0 … −5.0 hPa | −0.059 … −0.148 | ↓ | Falling |
+| ≤ −5.0 hPa | ≤ −0.148 | ↓↓ | Rapidly Falling |
 
 ### `davis` — Davis Vantage thresholds
 
@@ -162,7 +162,7 @@ Arrows are drawn with the bundled [Weather Icons](https://erikflowers.github.io/
   want the most information at a glance. *(Default.)*
 - **`davis`** — pick this if you're used to a Davis Vantage console and want the arrows
   to match its rise/fall rate descriptions.
-- **`strict`** — the simplest, least "twitchy" option: just up / steady / down for
+- **`strict`** — the simplest, least cluttered option: just up / steady / down for
   everything, with no rapid tier.
 
 ## Configuration reference
@@ -180,8 +180,9 @@ Arrows are drawn with the bundled [Weather Icons](https://erikflowers.github.io/
 - The observation needs at least one archive record within the last 3 hours.
 
 **The barometer almost never leaves "steady" (or flickers constantly)**
-- That's the threshold style. `strict` has the widest steady band per change; `multi`
-  has the narrowest (±0.25 hPa). Switch `trend_type` to taste.
+- That's the threshold style. The steady band is ±0.5 hPa in `strict` and ±0.7 hPa in
+  `multi`/`davis`; beyond it, `multi` adds graded rising/rapid tiers while `strict` shows
+  a single rising/falling arrow. Switch `trend_type` to taste.
 
 **The tooltip value looks rounded/coarse for pressure**
 - inHg/kPa changes are tiny, so they use extra decimal places (see

--- a/install.py
+++ b/install.py
@@ -173,6 +173,7 @@ class BasicInstaller(ExtensionInstaller):
                         "skins/neowx-material/month.html.tmpl",
                         "skins/neowx-material/skin.conf",
                         "skins/neowx-material/telemetry.html.tmpl",
+                        "skins/neowx-material/trend_indicator.inc",
                         "skins/neowx-material/weather-icons/README.md",
                         "skins/neowx-material/weather-icons/css/weather-icons.min.css",
                         "skins/neowx-material/weather-icons/css/weather-icons-wind.min.css",

--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class BasicInstaller(ExtensionInstaller):
     def __init__(self):
         super(BasicInstaller, self).__init__(
-            version="1.63.0",
+            version="1.64.0",
             name="neowx-material",
             description="The most versatile and modern weewx skin",
             author="Neoweewx",

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -111,7 +111,7 @@
                         <h3 class="h5-responsive $Extras.color-text">
                             $getVar('obs.label.' + name)
 
-                            #if $name in $Extras.Appearance.show_trend_on and $getVar('trend.' + name + '.raw') is not None
+                            #if $name in $Extras.Appearance.show_trend_on
 
                                 #set global $_trend_obs = $name
                                 #include "trend_indicator.inc"

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -113,6 +113,7 @@
 
                             #if $name in $Extras.Appearance.show_trend_on and $getVar('trend.' + name + '.raw') is not None
 
+                                #set global $_trend_obs = $name
                                 #include "trend_indicator.inc"
 
                 #else if $name == 'windSpeed'

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -111,6 +111,11 @@
                         <h3 class="h5-responsive $Extras.color-text">
                             $getVar('obs.label.' + name)
 
+                            ## --- TEMP trend diagnostic (remove after testing) ---
+                            #set $_dbg_in  = $name in $Extras.Appearance.show_trend_on
+                            #set $_dbg_raw = $getVar('trend.' + $name + '.raw', 'NO-TREND-KEY')
+                            <!-- nwm-trend-dbg name="$name" inlist="$_dbg_in" raw="$_dbg_raw" -->
+
                             #if $name in $Extras.Appearance.show_trend_on and $getVar('trend.' + name + '.raw') is not None
 
                                 #set global $_trend_obs = $name

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -113,22 +113,7 @@
 
                             #if $name in $Extras.Appearance.show_trend_on and $getVar('trend.' + name + '.raw') is not None
 
-                                #if $getVar('trend.' + name + '.raw') > 0.5
-                                    <i class="wi wi-direction-up-right"
-                                    title="$gettext("trend"): $getVar('trend.' + name) ($trend.time_delta.hour)"
-                                    data-toggle="tooltip" data-html="true">
-                                </i>
-                            #else if $getVar('trend.' + name + '.raw') < -0.5
-                                <i class="wi wi-direction-down-right"
-                                title="$gettext("trend"): $getVar('trend.' + name) ($trend.time_delta.hour)"
-                                data-toggle="tooltip" data-html="true">
-                            </i>
-                        #else
-                            <i class="wi wi-direction-right"
-                            title="$gettext("trend"): $getVar('trend.' + name) ($trend.time_delta.hour)"
-                            data-toggle="tooltip" data-html="true">
-                        </i>
-                    #end if
+                                #include "trend_indicator.inc"
 
                 #else if $name == 'windSpeed'
 

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -111,11 +111,6 @@
                         <h3 class="h5-responsive $Extras.color-text">
                             $getVar('obs.label.' + name)
 
-                            ## --- TEMP trend diagnostic (remove after testing) ---
-                            #set $_dbg_in  = $name in $Extras.Appearance.show_trend_on
-                            #set $_dbg_raw = $getVar('trend.' + $name + '.raw', 'NO-TREND-KEY')
-                            <!-- nwm-trend-dbg name="$name" inlist="$_dbg_in" raw="$_dbg_raw" -->
-
                             #if $name in $Extras.Appearance.show_trend_on and $getVar('trend.' + name + '.raw') is not None
 
                                 #set global $_trend_obs = $name

--- a/skins/neowx-material/package-lock.json
+++ b/skins/neowx-material/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neowx-material",
-  "version": "1.63.0",
+  "version": "1.64.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neowx-material",
-      "version": "1.63.0",
+      "version": "1.64.0",
       "license": "MIT",
       "dependencies": {
         "sass": "1.100.0"

--- a/skins/neowx-material/package.json
+++ b/skins/neowx-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neowx-material",
-  "version": "1.63.0",
+  "version": "1.64.0",
   "description": "The most versatile and modern weewx skin",
   "main": "index.js",
   "repository": "https://github.com/neoground/neowx-material",

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -451,6 +451,19 @@
         # Show trend arrow with tooltip at these values on the "current" page
         show_trend_on = barometer, outTemp, outHumidity, inTemp, inHumidity, UV, co2, pm2_5, ET
 
+        # Threshold style for the trend arrows above. Direction is always decided
+        # in a canonical unit (mbar, degree_C, mm, km/h, ...), so metric, imperial
+        # and any other supported unit behave identically in every style.
+        #   multi  - (default) WMO/NWS-style multi-tier for the barometer:
+        #            arrow steepens as the change grows, doubled for "rapidly".
+        #            3-hour change (hPa/mb): <0.25 steady, 0.25-1.5 slowly,
+        #            1.5-3.5 rising, >=3.5 rapidly. Other obs: simple up/steady/down.
+        #   davis  - Davis Vantage thresholds for the barometer:
+        #            3-hour change (hPa/mb): <0.7 steady, 0.7-2.0 slowly,
+        #            >=2.0 rapidly. Other obs: simple up/steady/down.
+        #   strict - simple up / steady / down for every obs, no rapid tier.
+        trend_type = multi
+
         # Should the coordinates (latitude, longitude) be shown in the
         # NOAA TXT reports? yes/no
         show_coordinates = yes

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -18,7 +18,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
 
-    version = 1.63.0
+    version = 1.64.0
 
     # Language
     # -------------------------------------------------------------------------

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -456,8 +456,8 @@
         # and any other supported unit behave identically in every style.
         #   multi  - (default) WMO/NWS-style multi-tier for the barometer:
         #            arrow steepens as the change grows, doubled for "rapidly".
-        #            3-hour change (hPa/mb): <0.25 steady, 0.25-1.5 slowly,
-        #            1.5-3.5 rising, >=3.5 rapidly. Other obs: simple up/steady/down.
+        #            3-hour change (hPa/mb): <0.7 steady, 0.7-2.0 slowly,
+        #            2.0-5.0 rising, >=5.0 rapidly. Other obs: simple up/steady/down.
         #   davis  - Davis Vantage thresholds for the barometer:
         #            3-hour change (hPa/mb): <0.7 steady, 0.7-2.0 slowly,
         #            >=2.0 rapidly. Other obs: simple up/steady/down.

--- a/skins/neowx-material/trend_indicator.inc
+++ b/skins/neowx-material/trend_indicator.inc
@@ -58,20 +58,30 @@
         #end if
         #set $_mag = abs($_tv)
         #if $_mag < 0.1 * $_scale
+            ## steady
             <i class="wi wi-direction-right" title="$gettext('trend'): $_disp_r$_lbl ($_hours h)" data-toggle="tooltip" data-html="true"></i>
         #else
             #set $_dir = 'up' if $_tv > 0 else 'down'
+            #set $_double = False
             #if $_mag >= 6.0 * $_scale
-                #set $_chev = 'mdi-chevron-triple-' + $_dir
+                ## very rapidly: two straight arrows
+                #set $_wic = 'wi-direction-' + $_dir
+                #set $_double = True
                 #set $_word = 'Rising very rapidly' if $_dir == 'up' else 'Falling very rapidly'
             #else if $_mag >= 3.6 * $_scale
-                #set $_chev = 'mdi-chevron-double-' + $_dir
+                ## quickly: one straight arrow
+                #set $_wic = 'wi-direction-' + $_dir
                 #set $_word = 'Rising quickly' if $_dir == 'up' else 'Falling quickly'
             #else
-                #set $_chev = 'mdi-chevron-' + $_dir
+                ## slowly / rising: one diagonal arrow
+                #set $_wic = 'wi-direction-up-right' if $_dir == 'up' else 'wi-direction-down-right'
                 #set $_word = 'Rising' if $_dir == 'up' else 'Falling'
             #end if
-            <i class="mdi $_chev" title="$_word: $_disp_r$_lbl ($_hours h)" data-toggle="tooltip" data-html="true"></i>
+            #if $_double
+                <span title="$_word: $_disp_r$_lbl ($_hours h)" data-toggle="tooltip" data-html="true"><i class="wi $_wic"></i><i class="wi $_wic"></i></span>
+            #else
+                <i class="wi $_wic" title="$_word: $_disp_r$_lbl ($_hours h)" data-toggle="tooltip" data-html="true"></i>
+            #end if
         #end if
     #else
         #if $_tv > $_band

--- a/skins/neowx-material/trend_indicator.inc
+++ b/skins/neowx-material/trend_indicator.inc
@@ -36,7 +36,8 @@
 }
 ## "steady" dead-band per canonical unit (default 0.5 for unit-agnostic obs)
 #set $_deadbands = {'degree_C':0.5, 'mm':0.2, 'mm_per_hour':0.2, 'km_per_hour':1.0, 'meter':10.0, 'km':0.5}
-#set $_unit = $_canon.get($getVar('unit.unit_type.' + $name, ''), '')
+#set $_du   = $getVar('unit.unit_type.' + $name, '')
+#set $_unit = $_canon.get($_du, '')
 #if $_pressure
     #set $_unit = 'mbar'
 #end if
@@ -62,6 +63,9 @@
     #set $_lbl    = $getVar('unit.label.' + $name, '')
     #set $_disp_r = round($_disp, 2)
     #if $_pressure
+        ## Decimals per pressure display unit (small inHg/kPa deltas need more).
+        #set $_dec    = {'inHg': 4, 'kPa': 3, 'mmHg': 2, 'hPa': 1, 'mbar': 1}.get($_du, 2)
+        #set $_disp_s = ('%+.' + str($_dec) + 'f') % $_disp
         #set $_scale = float($_hours) / 3.0
         #if $_scale <= 0
             #set $_scale = 1.0
@@ -69,28 +73,29 @@
         #set $_mag = abs($_tv)
         #if $_mag < 0.25 * $_scale
             ## steady
-            <i class="wi wi-direction-right" title="$gettext('trend'): $_disp_r$_lbl ($_hours h)" data-toggle="tooltip" data-html="true"></i>
+            <i class="wi wi-direction-right" title="Steady: $_disp_s$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
         #else
-            #set $_dir = 'up' if $_tv > 0 else 'down'
+            #set $_ud  = 'up' if $_tv > 0 else 'down'
+            #set $_dir = 'rising' if $_tv > 0 else 'falling'
             #set $_double = False
             #if $_mag >= 6.0 * $_scale
-                ## very rapidly: two straight arrows
-                #set $_wic = 'wi-direction-' + $_dir
+                ## rapidly: two straight arrows
+                #set $_wic = 'wi-direction-' + $_ud
                 #set $_double = True
-                #set $_word = 'Rising very rapidly' if $_dir == 'up' else 'Falling very rapidly'
+                #set $_word = 'Rapidly ' + $_dir
             #else if $_mag >= 3.6 * $_scale
-                ## quickly: one straight arrow
-                #set $_wic = 'wi-direction-' + $_dir
-                #set $_word = 'Rising quickly' if $_dir == 'up' else 'Falling quickly'
+                ## one straight arrow
+                #set $_wic = 'wi-direction-' + $_ud
+                #set $_word = $_dir.capitalize()
             #else
-                ## slowly / rising: one diagonal arrow
-                #set $_wic = 'wi-direction-up-right' if $_dir == 'up' else 'wi-direction-down-right'
-                #set $_word = 'Rising' if $_dir == 'up' else 'Falling'
+                ## slowly: one diagonal arrow
+                #set $_wic = 'wi-direction-' + $_ud + '-right'
+                #set $_word = 'Slowly ' + $_dir
             #end if
             #if $_double
-                <span title="$_word: $_disp_r$_lbl ($_hours h)" data-toggle="tooltip" data-html="true"><i class="wi $_wic"></i><i class="wi $_wic"></i></span>
+                <span title="$_word: $_disp_s$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"><i class="wi $_wic"></i><i class="wi $_wic"></i></span>
             #else
-                <i class="wi $_wic" title="$_word: $_disp_r$_lbl ($_hours h)" data-toggle="tooltip" data-html="true"></i>
+                <i class="wi $_wic" title="$_word: $_disp_s$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
             #end if
         #end if
     #else

--- a/skins/neowx-material/trend_indicator.inc
+++ b/skins/neowx-material/trend_indicator.inc
@@ -67,7 +67,7 @@
             #set $_scale = 1.0
         #end if
         #set $_mag = abs($_tv)
-        #if $_mag < 0.1 * $_scale
+        #if $_mag < 0.25 * $_scale
             ## steady
             <i class="wi wi-direction-right" title="$gettext('trend'): $_disp_r$_lbl ($_hours h)" data-toggle="tooltip" data-html="true"></i>
         #else

--- a/skins/neowx-material/trend_indicator.inc
+++ b/skins/neowx-material/trend_indicator.inc
@@ -89,7 +89,7 @@
     #set $_win = '%g h' % round($_win_h, 1)
     #if $_pressure
         ## Decimals per pressure display unit (small inHg/kPa deltas need more).
-        #set $_dec    = {'inHg': 4, 'kPa': 3, 'mmHg': 2, 'hPa': 1, 'mbar': 1}.get($_du, 2)
+        #set $_dec    = {'inHg': 3, 'kPa': 2, 'mmHg': 2, 'hPa': 1, 'mbar': 1}.get($_du, 2)
         #set $_disp_s = ('%+.' + str($_dec) + 'f') % $_disp
     #end if
     #if $_pressure and $_mode != 'strict'

--- a/skins/neowx-material/trend_indicator.inc
+++ b/skins/neowx-material/trend_indicator.inc
@@ -99,19 +99,19 @@
                 <i class="wi $_wic" title="$_word: $_disp_s$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
             #end if
         #else
-            ## multi / WMO-style (3 h, hPa): steady <0.25, slowly 0.25-1.5,
-            ## rising 1.5-3.5, rapidly >=3.5 (doubled arrow).
-            #if $_mag < 0.25 * $_scale
+            ## multi / WMO-style (3 h, hPa): steady <0.7, slowly 0.7-2.0,
+            ## rising 2.0-5.0, rapidly >=5.0 (doubled arrow).
+            #if $_mag < 0.7 * $_scale
                 <i class="wi wi-direction-right" title="Steady: $_disp_s$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
             #else
                 #set $_dir = 'Rising' if $_tv > 0 else 'Falling'
                 #set $_double = False
-                #if $_mag >= 3.5 * $_scale
+                #if $_mag >= 5.0 * $_scale
                     ## rapidly: two straight arrows
                     #set $_wic  = 'wi-direction-' + $_ud
                     #set $_double = True
                     #set $_word = 'Rapidly ' + $_dir
-                #else if $_mag >= 1.5 * $_scale
+                #else if $_mag >= 2.0 * $_scale
                     ## rising: one straight arrow
                     #set $_wic  = 'wi-direction-' + $_ud
                     #set $_word = $_dir

--- a/skins/neowx-material/trend_indicator.inc
+++ b/skins/neowx-material/trend_indicator.inc
@@ -19,6 +19,10 @@
 ## Every other observation uses the simple up / steady / down arrow with a
 ## per-observation dead-band.
 ## ---------------------------------------------------------------------------
+## A Cheetah #include runs in its own scope and does NOT see the caller's
+## local loop variable $name, so the caller passes it via the $_trend_obs
+## global (see index.html.tmpl). Alias it back to $name for use below.
+#set $name = $_trend_obs
 #set $_pressure = $name in ('barometer', 'pressure', 'altimeter')
 ## Per-observation [canonical unit ('' = use the display unit), dead-band].
 #set $_bands = {'outTemp': ['degree_C', 0.5], 'inTemp': ['degree_C', 0.5], 'ET': ['mm', 0.02]}

--- a/skins/neowx-material/trend_indicator.inc
+++ b/skins/neowx-material/trend_indicator.inc
@@ -75,8 +75,9 @@
             ## steady
             <i class="wi wi-direction-right" title="Steady: $_disp_s$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
         #else
+            ## $_ud feeds the (lowercase) Weather-Icons class; $_dir is the word.
             #set $_ud  = 'up' if $_tv > 0 else 'down'
-            #set $_dir = 'rising' if $_tv > 0 else 'falling'
+            #set $_dir = 'Rising' if $_tv > 0 else 'Falling'
             #set $_double = False
             #if $_mag >= 6.0 * $_scale
                 ## rapidly: two straight arrows
@@ -86,7 +87,7 @@
             #else if $_mag >= 3.6 * $_scale
                 ## one straight arrow
                 #set $_wic = 'wi-direction-' + $_ud
-                #set $_word = $_dir.capitalize()
+                #set $_word = $_dir
             #else
                 ## slowly: one diagonal arrow
                 #set $_wic = 'wi-direction-' + $_ud + '-right'
@@ -100,11 +101,11 @@
         #end if
     #else
         #if $_tv > $_band
-            <i class="wi wi-direction-up-right" title="$gettext('trend'): $_disp_r$_lbl ($_hours h)" data-toggle="tooltip" data-html="true"></i>
+            <i class="wi wi-direction-up-right" title="Rising: $_disp_r$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
         #else if $_tv < -$_band
-            <i class="wi wi-direction-down-right" title="$gettext('trend'): $_disp_r$_lbl ($_hours h)" data-toggle="tooltip" data-html="true"></i>
+            <i class="wi wi-direction-down-right" title="Falling: $_disp_r$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
         #else
-            <i class="wi wi-direction-right" title="$gettext('trend'): $_disp_r$_lbl ($_hours h)" data-toggle="tooltip" data-html="true"></i>
+            <i class="wi wi-direction-right" title="Steady: $_disp_r$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
         #end if
     #end if
 #end if

--- a/skins/neowx-material/trend_indicator.inc
+++ b/skins/neowx-material/trend_indicator.inc
@@ -16,14 +16,21 @@
 ## imperial for ANY observation. Units not listed (percent, UV index, ppm,
 ## ug/m3, W/m2, counts) are already comparable across systems -> no conversion.
 ##
-## Barometric pressure additionally uses the WMO/NWS 3-hour tendency categories
-## (steady / slowly / quickly / very rapidly) shown with Weather-Icons arrows
-## (steeper = faster; two arrows = very rapidly). Everything else uses a simple
-## up / steady / down arrow with a per-family dead-band. The tooltip shows the
-## change in the user's display units.
+## Barometric pressure can use richer tendency categories selected by
+## $Extras.Appearance.trend_type:
+##   multi  - WMO/NWS-style steady/slowly/rising/rapidly (default); the arrow
+##            steepens as it climbs and is doubled for the rapid tier.
+##   davis  - Davis Vantage steady/slowly/rapidly thresholds.
+##   strict - simple up/steady/down, same as every other obs (no rapid tier).
+## Every obs (including pressure in strict) still decides direction in the
+## canonical unit, and the tooltip shows the change in the user's display units.
 ## ---------------------------------------------------------------------------
 #set $name = $_trend_obs
 #set $_hours = 3
+#set $_mode = str($getVar('Extras.Appearance.trend_type', 'multi')).lower()
+#if $_mode not in ('strict', 'multi', 'davis')
+    #set $_mode = 'multi'
+#end if
 #set $_pressure = $name in ('barometer', 'pressure', 'altimeter')
 ## display unit -> canonical unit (only families whose unit varies by system)
 #set $_canon = {
@@ -66,46 +73,70 @@
         ## Decimals per pressure display unit (small inHg/kPa deltas need more).
         #set $_dec    = {'inHg': 4, 'kPa': 3, 'mmHg': 2, 'hPa': 1, 'mbar': 1}.get($_du, 2)
         #set $_disp_s = ('%+.' + str($_dec) + 'f') % $_disp
+    #end if
+    #if $_pressure and $_mode != 'strict'
+        ## Pressure tendency categories, in canonical mbar, scaled to the window.
         #set $_scale = float($_hours) / 3.0
         #if $_scale <= 0
             #set $_scale = 1.0
         #end if
         #set $_mag = abs($_tv)
-        #if $_mag < 0.25 * $_scale
-            ## steady
-            <i class="wi wi-direction-right" title="Steady: $_disp_s$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
-        #else
-            ## $_ud feeds the (lowercase) Weather-Icons class; $_dir is the word.
-            #set $_ud  = 'up' if $_tv > 0 else 'down'
-            #set $_dir = 'Rising' if $_tv > 0 else 'Falling'
-            #set $_double = False
-            #if $_mag >= 6.0 * $_scale
-                ## rapidly: two straight arrows
-                #set $_wic = 'wi-direction-' + $_ud
-                #set $_double = True
-                #set $_word = 'Rapidly ' + $_dir
-            #else if $_mag >= 3.6 * $_scale
-                ## one straight arrow
-                #set $_wic = 'wi-direction-' + $_ud
-                #set $_word = $_dir
+        ## $_ud feeds the (lowercase) Weather-Icons class.
+        #set $_ud  = 'up' if $_tv > 0 else 'down'
+        #if $_mode == 'davis'
+            ## Davis Vantage (3 h, hPa): steady <0.7, slowly 0.7-2.0, rapidly >=2.0
+            #if $_mag < 0.7 * $_scale
+                <i class="wi wi-direction-right" title="Steady: $_disp_s$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
             #else
-                ## slowly: one diagonal arrow
-                #set $_wic = 'wi-direction-' + $_ud + '-right'
-                #set $_word = 'Slowly ' + $_dir
-            #end if
-            #if $_double
-                <span title="$_word: $_disp_s$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"><i class="wi $_wic"></i><i class="wi $_wic"></i></span>
-            #else
+                #set $_verb = 'Rising' if $_tv > 0 else 'Falling'
+                #if $_mag >= 2.0 * $_scale
+                    #set $_wic  = 'wi-direction-' + $_ud
+                    #set $_word = $_verb + ' rapidly'
+                #else
+                    #set $_wic  = 'wi-direction-' + $_ud + '-right'
+                    #set $_word = $_verb + ' slowly'
+                #end if
                 <i class="wi $_wic" title="$_word: $_disp_s$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
+            #end if
+        #else
+            ## multi / WMO-style (3 h, hPa): steady <0.25, slowly 0.25-1.5,
+            ## rising 1.5-3.5, rapidly >=3.5 (doubled arrow).
+            #if $_mag < 0.25 * $_scale
+                <i class="wi wi-direction-right" title="Steady: $_disp_s$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
+            #else
+                #set $_dir = 'Rising' if $_tv > 0 else 'Falling'
+                #set $_double = False
+                #if $_mag >= 3.5 * $_scale
+                    ## rapidly: two straight arrows
+                    #set $_wic  = 'wi-direction-' + $_ud
+                    #set $_double = True
+                    #set $_word = 'Rapidly ' + $_dir
+                #else if $_mag >= 1.5 * $_scale
+                    ## rising: one straight arrow
+                    #set $_wic  = 'wi-direction-' + $_ud
+                    #set $_word = $_dir
+                #else
+                    ## slowly: one diagonal arrow
+                    #set $_wic  = 'wi-direction-' + $_ud + '-right'
+                    #set $_word = 'Slowly ' + $_dir
+                #end if
+                #if $_double
+                    <span title="$_word: $_disp_s$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"><i class="wi $_wic"></i><i class="wi $_wic"></i></span>
+                #else
+                    <i class="wi $_wic" title="$_word: $_disp_s$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
+                #end if
             #end if
         #end if
     #else
+        ## Simple up / steady / down: strict mode for every obs, plus the
+        ## non-pressure path for multi/davis. Canonical dead-band per family.
+        #set $_simp = $_disp_s if $_pressure else $_disp_r
         #if $_tv > $_band
-            <i class="wi wi-direction-up-right" title="Rising: $_disp_r$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
+            <i class="wi wi-direction-up-right" title="Rising: $_simp$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
         #else if $_tv < -$_band
-            <i class="wi wi-direction-down-right" title="Falling: $_disp_r$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
+            <i class="wi wi-direction-down-right" title="Falling: $_simp$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
         #else
-            <i class="wi wi-direction-right" title="Steady: $_disp_r$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
+            <i class="wi wi-direction-right" title="Steady: $_simp$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
         #end if
     #end if
 #end if

--- a/skins/neowx-material/trend_indicator.inc
+++ b/skins/neowx-material/trend_indicator.inc
@@ -64,9 +64,11 @@
         #set $_tv = $_curvh.raw - $_oldvh.raw
     #end if
     #set $_disp = $_curvh.raw - $_oldvh.raw
-    ## hours actually covered by the data (first reading -> now), which after a
-    ## restart / new install / data gap can be far less than the requested span
-    #set $_elapsed = (float($current.dateTime.raw) - float($_binder.firsttime.raw)) / 3600.0
+    ## seconds (then hours) actually covered by the data (first reading -> now),
+    ## which after a restart / new install / data gap can be far less than the
+    ## requested span. Kept in seconds so the snap test below is exact.
+    #set $_secs    = float($current.dateTime.raw) - float($_binder.firsttime.raw)
+    #set $_elapsed = $_secs / 3600.0
 #except
     #set $_tv = None
 #end try
@@ -77,8 +79,14 @@
 #if $_tv is not None and $_elapsed is not None and $_elapsed >= $_min_hours
     #set $_lbl    = $getVar('unit.label.' + $name, '')
     #set $_disp_r = round($_disp, 2)
-    ## actual elapsed span, shown in the tooltip instead of a hard-coded "3 h"
-    #set $_win    = '%g h' % round($_elapsed, 1)
+    ## Effective window: the actual elapsed span, but snapped to the full target
+    ## when within 5 minutes of it (archive timing rarely lands exactly on now-3h),
+    ## so the normal case reads a clean "3 h" with nominal thresholds.
+    #set $_win_h = $_elapsed
+    #if abs($_secs - float($_hours) * 3600.0) <= 300.0
+        #set $_win_h = float($_hours)
+    #end if
+    #set $_win = '%g h' % round($_win_h, 1)
     #if $_pressure
         ## Decimals per pressure display unit (small inHg/kPa deltas need more).
         #set $_dec    = {'inHg': 4, 'kPa': 3, 'mmHg': 2, 'hPa': 1, 'mbar': 1}.get($_du, 2)
@@ -86,8 +94,8 @@
     #end if
     #if $_pressure and $_mode != 'strict'
         ## Pressure tendency categories, in canonical mbar. The thresholds are
-        ## defined per 3 h, so scale them to the actual elapsed span.
-        #set $_scale = $_elapsed / 3.0
+        ## defined per 3 h, so scale them to the effective (snapped) span.
+        #set $_scale = $_win_h / 3.0
         #if $_scale <= 0
             #set $_scale = 1.0
         #end if

--- a/skins/neowx-material/trend_indicator.inc
+++ b/skins/neowx-material/trend_indicator.inc
@@ -1,60 +1,64 @@
 #encoding UTF-8
 ## ---------------------------------------------------------------------------
 ## Trend indicator for observation $name (the "current" page).
-## The caller has already confirmed $name is in Extras.Appearance.show_trend_on
-## and that trend.<name>.raw is not None.
+## A Cheetah #include has its own scope and cannot see the caller's local
+## $name, so the caller passes it via the $_trend_obs global. The caller only
+## guarantees $name is in show_trend_on.
 ##
-## The up / steady / down decision is made on a UNIT-INDEPENDENT value: the
-## trend is converted to a canonical unit per observation, so the arrows
-## behave the same in metric and imperial (e.g. a barometer delta is always
-## judged in hPa, never 0.5 inHg ~= 17 hPa).
+## We compute the change OURSELVES rather than use WeeWX $trend: $trend returns
+## None unless an archive record lands within a small grace window of exactly
+## (now - time_delta), which fails intermittently on coarser archive intervals.
+## Here we use (current reading) - (oldest reading in the last N hours), which
+## has a value whenever there is any recent data.
 ##
-## Barometric pressure additionally follows the WMO/NWS 3-hour pressure
-## tendency categories, scaled to the configured trend window, shown with MDI
-## single / double / triple chevrons:
-##   < 0.1 hPa/3h  steady          (wi-direction-right)
-##   < 3.6         rising/falling  (mdi-chevron-up/down)
-##   < 6.0         quickly         (mdi-chevron-double-up/down)
-##   >= 6.0        very rapidly    (mdi-chevron-triple-up/down)
-## Every other observation uses the simple up / steady / down arrow with a
-## per-observation dead-band.
+## The direction decision is made in a canonical unit per observation
+## (barometer->hPa, temp->degC, ET->mm) so arrows behave the same in metric and
+## imperial. Pressure uses the WMO/NWS 3-hour tendency categories shown with MDI
+## single/double/triple chevrons; everything else uses a simple up/steady/down
+## arrow with a per-observation dead-band. The tooltip shows the change in the
+## user's display units.
+##
+## A debug HTML comment (<!-- nwm-trend ... -->) is emitted for every card so
+## you can see the current/old values and the timestamp the "old" reading came
+## from. Remove it once verified.
 ## ---------------------------------------------------------------------------
-## A Cheetah #include runs in its own scope and does NOT see the caller's
-## local loop variable $name, so the caller passes it via the $_trend_obs
-## global (see index.html.tmpl). Alias it back to $name for use below.
 #set $name = $_trend_obs
+#set $_hours = 3
 #set $_pressure = $name in ('barometer', 'pressure', 'altimeter')
-## Per-observation [canonical unit ('' = use the display unit), dead-band].
 #set $_bands = {'outTemp': ['degree_C', 0.5], 'inTemp': ['degree_C', 0.5], 'ET': ['mm', 0.02]}
 #set $_cfg  = $_bands.get($name, ['', 0.5])
 #set $_unit = 'mbar' if $_pressure else $_cfg[0]
 #set $_band = $_cfg[1]
-## Trend delta in the canonical unit (fall back to the display unit on error).
-#set $_vh = $getVar('trend.' + $name)
+## Current reading, and the oldest reading in the last $_hours hours.
+#set $_curvh   = $getattr($current, $name)
+#set $_binder  = $getattr($span($hour_delta=$_hours), $name)
+#set $_oldvh   = $_binder.first
+#set $_oldtime = $_binder.firsttime
+## Canonical-unit delta (decision) and display-unit delta (tooltip).
+#set $_tv = None
+#set $_disp = None
 #try
     #if $_unit
-        #set $_tv = $getattr($_vh, $_unit).raw
+        #set $_tv = $getattr($_curvh, $_unit).raw - $getattr($_oldvh, $_unit).raw
     #else
-        #set $_tv = $_vh.raw
+        #set $_tv = $_curvh.raw - $_oldvh.raw
     #end if
+    #set $_disp = $_curvh.raw - $_oldvh.raw
 #except
-    #set $_tv = $_vh.raw
+    #set $_tv = None
 #end try
-#set $_when = $trend.time_delta.hour
+<!-- nwm-trend obs="$name" unit="$_unit" now="$_curvh" now_time="$current.dateTime" old="$_oldvh" old_time="$_oldtime" canon_delta="$_tv" disp_delta="$_disp" -->
 #if $_tv is not None
+    #set $_lbl    = $getVar('unit.label.' + $name, '')
+    #set $_disp_r = round($_disp, 2)
     #if $_pressure
-        ## Scale the 3-hour standard to the actual trend window.
-        #try
-            #set $_scale = float($getVar('trend.time_delta.hour.raw')) / 3.0
-        #except
-            #set $_scale = 1.0
-        #end try
+        #set $_scale = float($_hours) / 3.0
         #if $_scale <= 0
             #set $_scale = 1.0
         #end if
         #set $_mag = abs($_tv)
         #if $_mag < 0.1 * $_scale
-            <i class="wi wi-direction-right" title="$gettext('trend'): $_vh ($_when)" data-toggle="tooltip" data-html="true"></i>
+            <i class="wi wi-direction-right" title="$gettext('trend'): $_disp_r$_lbl ($_hours h)" data-toggle="tooltip" data-html="true"></i>
         #else
             #set $_dir = 'up' if $_tv > 0 else 'down'
             #if $_mag >= 6.0 * $_scale
@@ -67,15 +71,15 @@
                 #set $_chev = 'mdi-chevron-' + $_dir
                 #set $_word = 'Rising' if $_dir == 'up' else 'Falling'
             #end if
-            <i class="mdi $_chev" title="$_word: $_vh ($_when)" data-toggle="tooltip" data-html="true"></i>
+            <i class="mdi $_chev" title="$_word: $_disp_r$_lbl ($_hours h)" data-toggle="tooltip" data-html="true"></i>
         #end if
     #else
         #if $_tv > $_band
-            <i class="wi wi-direction-up-right" title="$gettext('trend'): $_vh ($_when)" data-toggle="tooltip" data-html="true"></i>
+            <i class="wi wi-direction-up-right" title="$gettext('trend'): $_disp_r$_lbl ($_hours h)" data-toggle="tooltip" data-html="true"></i>
         #else if $_tv < -$_band
-            <i class="wi wi-direction-down-right" title="$gettext('trend'): $_vh ($_when)" data-toggle="tooltip" data-html="true"></i>
+            <i class="wi wi-direction-down-right" title="$gettext('trend'): $_disp_r$_lbl ($_hours h)" data-toggle="tooltip" data-html="true"></i>
         #else
-            <i class="wi wi-direction-right" title="$gettext('trend'): $_vh ($_when)" data-toggle="tooltip" data-html="true"></i>
+            <i class="wi wi-direction-right" title="$gettext('trend'): $_disp_r$_lbl ($_hours h)" data-toggle="tooltip" data-html="true"></i>
         #end if
     #end if
 #end if

--- a/skins/neowx-material/trend_indicator.inc
+++ b/skins/neowx-material/trend_indicator.inc
@@ -1,0 +1,77 @@
+#encoding UTF-8
+## ---------------------------------------------------------------------------
+## Trend indicator for observation $name (the "current" page).
+## The caller has already confirmed $name is in Extras.Appearance.show_trend_on
+## and that trend.<name>.raw is not None.
+##
+## The up / steady / down decision is made on a UNIT-INDEPENDENT value: the
+## trend is converted to a canonical unit per observation, so the arrows
+## behave the same in metric and imperial (e.g. a barometer delta is always
+## judged in hPa, never 0.5 inHg ~= 17 hPa).
+##
+## Barometric pressure additionally follows the WMO/NWS 3-hour pressure
+## tendency categories, scaled to the configured trend window, shown with MDI
+## single / double / triple chevrons:
+##   < 0.1 hPa/3h  steady          (wi-direction-right)
+##   < 3.6         rising/falling  (mdi-chevron-up/down)
+##   < 6.0         quickly         (mdi-chevron-double-up/down)
+##   >= 6.0        very rapidly    (mdi-chevron-triple-up/down)
+## Every other observation uses the simple up / steady / down arrow with a
+## per-observation dead-band.
+## ---------------------------------------------------------------------------
+#set $_pressure = $name in ('barometer', 'pressure', 'altimeter')
+## Per-observation [canonical unit ('' = use the display unit), dead-band].
+#set $_bands = {'outTemp': ['degree_C', 0.5], 'inTemp': ['degree_C', 0.5], 'ET': ['mm', 0.02]}
+#set $_cfg  = $_bands.get($name, ['', 0.5])
+#set $_unit = 'mbar' if $_pressure else $_cfg[0]
+#set $_band = $_cfg[1]
+## Trend delta in the canonical unit (fall back to the display unit on error).
+#set $_vh = $getVar('trend.' + $name)
+#try
+    #if $_unit
+        #set $_tv = $getattr($_vh, $_unit).raw
+    #else
+        #set $_tv = $_vh.raw
+    #end if
+#except
+    #set $_tv = $_vh.raw
+#end try
+#set $_when = $trend.time_delta.hour
+#if $_tv is not None
+    #if $_pressure
+        ## Scale the 3-hour standard to the actual trend window.
+        #try
+            #set $_scale = float($getVar('trend.time_delta.hour.raw')) / 3.0
+        #except
+            #set $_scale = 1.0
+        #end try
+        #if $_scale <= 0
+            #set $_scale = 1.0
+        #end if
+        #set $_mag = abs($_tv)
+        #if $_mag < 0.1 * $_scale
+            <i class="wi wi-direction-right" title="$gettext('trend'): $_vh ($_when)" data-toggle="tooltip" data-html="true"></i>
+        #else
+            #set $_dir = 'up' if $_tv > 0 else 'down'
+            #if $_mag >= 6.0 * $_scale
+                #set $_chev = 'mdi-chevron-triple-' + $_dir
+                #set $_word = 'Rising very rapidly' if $_dir == 'up' else 'Falling very rapidly'
+            #else if $_mag >= 3.6 * $_scale
+                #set $_chev = 'mdi-chevron-double-' + $_dir
+                #set $_word = 'Rising quickly' if $_dir == 'up' else 'Falling quickly'
+            #else
+                #set $_chev = 'mdi-chevron-' + $_dir
+                #set $_word = 'Rising' if $_dir == 'up' else 'Falling'
+            #end if
+            <i class="mdi $_chev" title="$_word: $_vh ($_when)" data-toggle="tooltip" data-html="true"></i>
+        #end if
+    #else
+        #if $_tv > $_band
+            <i class="wi wi-direction-up-right" title="$gettext('trend'): $_vh ($_when)" data-toggle="tooltip" data-html="true"></i>
+        #else if $_tv < -$_band
+            <i class="wi wi-direction-down-right" title="$gettext('trend'): $_vh ($_when)" data-toggle="tooltip" data-html="true"></i>
+        #else
+            <i class="wi wi-direction-right" title="$gettext('trend'): $_vh ($_when)" data-toggle="tooltip" data-html="true"></i>
+        #end if
+    #end if
+#end if

--- a/skins/neowx-material/trend_indicator.inc
+++ b/skins/neowx-material/trend_indicator.inc
@@ -56,6 +56,7 @@
 ## canonical-unit delta (decision) and display-unit delta (tooltip)
 #set $_tv = None
 #set $_disp = None
+#set $_elapsed = None
 #try
     #if $_unit
         #set $_tv = $getattr($_curvh, $_unit).raw - $getattr($_oldvh, $_unit).raw
@@ -63,20 +64,30 @@
         #set $_tv = $_curvh.raw - $_oldvh.raw
     #end if
     #set $_disp = $_curvh.raw - $_oldvh.raw
+    ## hours actually covered by the data (first reading -> now), which after a
+    ## restart / new install / data gap can be far less than the requested span
+    #set $_elapsed = (float($current.dateTime.raw) - float($_binder.firsttime.raw)) / 3600.0
 #except
     #set $_tv = None
 #end try
-#if $_tv is not None
+## Require enough recent history for a meaningful tendency: with only a few
+## minutes of data the 3-hour pressure categories and "over N h" label would be
+## misleading, so suppress the indicator until the window is wide enough.
+#set $_min_hours = 1.0
+#if $_tv is not None and $_elapsed is not None and $_elapsed >= $_min_hours
     #set $_lbl    = $getVar('unit.label.' + $name, '')
     #set $_disp_r = round($_disp, 2)
+    ## actual elapsed span, shown in the tooltip instead of a hard-coded "3 h"
+    #set $_win    = '%g h' % round($_elapsed, 1)
     #if $_pressure
         ## Decimals per pressure display unit (small inHg/kPa deltas need more).
         #set $_dec    = {'inHg': 4, 'kPa': 3, 'mmHg': 2, 'hPa': 1, 'mbar': 1}.get($_du, 2)
         #set $_disp_s = ('%+.' + str($_dec) + 'f') % $_disp
     #end if
     #if $_pressure and $_mode != 'strict'
-        ## Pressure tendency categories, in canonical mbar, scaled to the window.
-        #set $_scale = float($_hours) / 3.0
+        ## Pressure tendency categories, in canonical mbar. The thresholds are
+        ## defined per 3 h, so scale them to the actual elapsed span.
+        #set $_scale = $_elapsed / 3.0
         #if $_scale <= 0
             #set $_scale = 1.0
         #end if
@@ -86,7 +97,7 @@
         #if $_mode == 'davis'
             ## Davis Vantage (3 h, hPa): steady <0.7, slowly 0.7-2.0, rapidly >=2.0
             #if $_mag < 0.7 * $_scale
-                <i class="wi wi-direction-right" title="Steady: $_disp_s$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
+                <i class="wi wi-direction-right" title="Steady: $_disp_s$_lbl (over $_win)" data-toggle="tooltip" data-html="true"></i>
             #else
                 #set $_verb = 'Rising' if $_tv > 0 else 'Falling'
                 #if $_mag >= 2.0 * $_scale
@@ -96,13 +107,13 @@
                     #set $_wic  = 'wi-direction-' + $_ud + '-right'
                     #set $_word = $_verb + ' slowly'
                 #end if
-                <i class="wi $_wic" title="$_word: $_disp_s$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
+                <i class="wi $_wic" title="$_word: $_disp_s$_lbl (over $_win)" data-toggle="tooltip" data-html="true"></i>
             #end if
         #else
             ## multi / WMO-style (3 h, hPa): steady <0.7, slowly 0.7-2.0,
             ## rising 2.0-5.0, rapidly >=5.0 (doubled arrow).
             #if $_mag < 0.7 * $_scale
-                <i class="wi wi-direction-right" title="Steady: $_disp_s$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
+                <i class="wi wi-direction-right" title="Steady: $_disp_s$_lbl (over $_win)" data-toggle="tooltip" data-html="true"></i>
             #else
                 #set $_dir = 'Rising' if $_tv > 0 else 'Falling'
                 #set $_double = False
@@ -121,9 +132,9 @@
                     #set $_word = 'Slowly ' + $_dir
                 #end if
                 #if $_double
-                    <span title="$_word: $_disp_s$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"><i class="wi $_wic"></i><i class="wi $_wic"></i></span>
+                    <span title="$_word: $_disp_s$_lbl (over $_win)" data-toggle="tooltip" data-html="true"><i class="wi $_wic"></i><i class="wi $_wic"></i></span>
                 #else
-                    <i class="wi $_wic" title="$_word: $_disp_s$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
+                    <i class="wi $_wic" title="$_word: $_disp_s$_lbl (over $_win)" data-toggle="tooltip" data-html="true"></i>
                 #end if
             #end if
         #end if
@@ -132,11 +143,11 @@
         ## non-pressure path for multi/davis. Canonical dead-band per family.
         #set $_simp = $_disp_s if $_pressure else $_disp_r
         #if $_tv > $_band
-            <i class="wi wi-direction-up-right" title="Rising: $_simp$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
+            <i class="wi wi-direction-up-right" title="Rising: $_simp$_lbl (over $_win)" data-toggle="tooltip" data-html="true"></i>
         #else if $_tv < -$_band
-            <i class="wi wi-direction-down-right" title="Falling: $_simp$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
+            <i class="wi wi-direction-down-right" title="Falling: $_simp$_lbl (over $_win)" data-toggle="tooltip" data-html="true"></i>
         #else
-            <i class="wi wi-direction-right" title="Steady: $_simp$_lbl (over $_hours h)" data-toggle="tooltip" data-html="true"></i>
+            <i class="wi wi-direction-right" title="Steady: $_simp$_lbl (over $_win)" data-toggle="tooltip" data-html="true"></i>
         #end if
     #end if
 #end if

--- a/skins/neowx-material/trend_indicator.inc
+++ b/skins/neowx-material/trend_indicator.inc
@@ -5,36 +5,47 @@
 ## $name, so the caller passes it via the $_trend_obs global. The caller only
 ## guarantees $name is in show_trend_on.
 ##
-## We compute the change OURSELVES rather than use WeeWX $trend: $trend returns
+## We compute the change OURSELVES rather than use WeeWX $trend (which returns
 ## None unless an archive record lands within a small grace window of exactly
-## (now - time_delta), which fails intermittently on coarser archive intervals.
-## Here we use (current reading) - (oldest reading in the last N hours), which
-## has a value whenever there is any recent data.
+## now - time_delta): (current reading) - (oldest reading in the last N hours,
+## via span(hour_delta=N).<obs>.first). That has a value whenever there is any
+## recent data.
 ##
-## The direction decision is made in a canonical unit per observation
-## (barometer->hPa, temp->degC, ET->mm) so arrows behave the same in metric and
-## imperial. Pressure uses the WMO/NWS 3-hour tendency categories shown with MDI
-## single/double/triple chevrons; everything else uses a simple up/steady/down
-## arrow with a per-observation dead-band. The tooltip shows the change in the
-## user's display units.
+## The direction is decided in a CANONICAL unit per unit-family, derived from
+## the obs's current display unit, so trends behave identically in metric and
+## imperial for ANY observation. Units not listed (percent, UV index, ppm,
+## ug/m3, W/m2, counts) are already comparable across systems -> no conversion.
 ##
-## A debug HTML comment (<!-- nwm-trend ... -->) is emitted for every card so
-## you can see the current/old values and the timestamp the "old" reading came
-## from. Remove it once verified.
+## Barometric pressure additionally uses the WMO/NWS 3-hour tendency categories
+## (steady / slowly / quickly / very rapidly) shown with Weather-Icons arrows
+## (steeper = faster; two arrows = very rapidly). Everything else uses a simple
+## up / steady / down arrow with a per-family dead-band. The tooltip shows the
+## change in the user's display units.
 ## ---------------------------------------------------------------------------
 #set $name = $_trend_obs
 #set $_hours = 3
 #set $_pressure = $name in ('barometer', 'pressure', 'altimeter')
-#set $_bands = {'outTemp': ['degree_C', 0.5], 'inTemp': ['degree_C', 0.5], 'ET': ['mm', 0.02]}
-#set $_cfg  = $_bands.get($name, ['', 0.5])
-#set $_unit = 'mbar' if $_pressure else $_cfg[0]
-#set $_band = $_cfg[1]
-## Current reading, and the oldest reading in the last $_hours hours.
-#set $_curvh   = $getattr($current, $name)
-#set $_binder  = $getattr($span($hour_delta=$_hours), $name)
-#set $_oldvh   = $_binder.first
-#set $_oldtime = $_binder.firsttime
-## Canonical-unit delta (decision) and display-unit delta (tooltip).
+## display unit -> canonical unit (only families whose unit varies by system)
+#set $_canon = {
+    'inHg':'mbar', 'mmHg':'mbar', 'kPa':'mbar', 'hPa':'mbar', 'mbar':'mbar',
+    'degree_F':'degree_C', 'degree_K':'degree_C', 'degree_C':'degree_C',
+    'inch':'mm', 'cm':'mm', 'mm':'mm',
+    'inch_per_hour':'mm_per_hour', 'cm_per_hour':'mm_per_hour', 'mm_per_hour':'mm_per_hour',
+    'mile_per_hour':'km_per_hour', 'knot':'km_per_hour', 'meter_per_second':'km_per_hour', 'beaufort':'km_per_hour', 'km_per_hour':'km_per_hour',
+    'foot':'meter', 'meter':'meter', 'mile':'km', 'km':'km'
+}
+## "steady" dead-band per canonical unit (default 0.5 for unit-agnostic obs)
+#set $_deadbands = {'degree_C':0.5, 'mm':0.2, 'mm_per_hour':0.2, 'km_per_hour':1.0, 'meter':10.0, 'km':0.5}
+#set $_unit = $_canon.get($getVar('unit.unit_type.' + $name, ''), '')
+#if $_pressure
+    #set $_unit = 'mbar'
+#end if
+#set $_band = $_deadbands.get($_unit, 0.5)
+## current reading and the oldest reading in the last $_hours hours
+#set $_curvh  = $getattr($current, $name)
+#set $_binder = $getattr($span($hour_delta=$_hours), $name)
+#set $_oldvh  = $_binder.first
+## canonical-unit delta (decision) and display-unit delta (tooltip)
 #set $_tv = None
 #set $_disp = None
 #try
@@ -47,7 +58,6 @@
 #except
     #set $_tv = None
 #end try
-<!-- nwm-trend obs="$name" unit="$_unit" now="$_curvh" now_time="$current.dateTime" old="$_oldvh" old_time="$_oldtime" canon_delta="$_tv" disp_delta="$_disp" -->
 #if $_tv is not None
     #set $_lbl    = $getVar('unit.label.' + $name, '')
     #set $_disp_r = round($_disp, 2)


### PR DESCRIPTION
## Problem description

The trend arrows on the Current page (rising/falling next to temperature, pressure, etc.) were a bit unreliable and unit-dependent. This pulls all of that logic into one self-contained include, makes it behave the same whether you run metric or imperial, gives the barometer a proper sense of *how fast* it's moving, and lets you pick the style that suits you.

## What was wrong before

Three things bugged me about the old arrows:

1. **They were tied to one unit system.** The "is this steady or moving?" threshold was a hard-coded number that only really made sense in one set of units, so a metric station and an imperial station didn't behave the same way.
2. **They kept disappearing.** The old code leaned on WeeWX's `$trend`, which only returns a value when an archive record happens to land within a small grace window of *exactly* three hours ago. Miss that window and the arrow vanished.
3. **Pressure had no nuance.** A barometer drifting by 0.1 hPa and one dropping like a stone before a storm looked identical.

## How it works now

Instead of `$trend`, the skin works out the change itself: current reading minus the oldest reading in the recent window. It also looks at how much history actually exists rather than assuming a full three hours — which matters right after a restart, a fresh install, or a data gap, when there might only be a few minutes of data:

- Under an hour of history? The arrow stays hidden until there's enough to say something meaningful.
- Between one and three hours? The pressure thresholds scale to the real span, and the tooltip tells you the true interval (e.g. *over 1.5 h*) instead of fibbing about three hours.
- Within five minutes of a full window? It just rounds to a clean *3 h*.

Direction is always decided in a canonical unit per measurement family (pressure in mbar, temperature in °C, rain in mm, wind in km/h, and so on), so the result is identical no matter what units you display. Things that are already unit-neutral — humidity, UV, ppm, air quality — are compared as-is.

## Picking a style

There's a new `trend_type` setting under `[[Appearance]]` (default `multi`):

- **`multi`** — the richest readout. The barometer arrow steepens as the change grows and doubles up when it's really moving. Over three hours: under 0.7 hPa is steady, 0.7–2.0 is slowly rising/falling, 2.0–5.0 is rising/falling, and 5.0+ is rapid.
- **`davis`** — matches the rise/fall wording a Davis Vantage console uses: steady under 0.7 hPa, "slowly" up to 2.0, "rapidly" beyond.
- **`strict`** — the no-frills option: plain up / steady / down for everything, no rapid tier.  This was the way the previous trend indicators worked, but now fixed for imperial, KPa, metric etc.

A quick heads-up on the numbers: the `multi` cut-points (0.7 / 2.0 / 5.0) are tuned for this skin in the spirit of the World Meteorological Organization/US National Weather Service tendency categories — they're not the literal textbook values, and the config comments, the guide, and this description all use what's actually implemented.

The tooltip names the category and shows the signed change in your own units, rounded sensibly per unit (inHg to 3 places, kPa/mmHg to 2, hPa/mbar to 1).

## A couple of notes for whoever reviews this

- A Cheetah `#include` can't see the caller's local `$name`, so the observation name is handed over through a global — the same trick the date-format include already uses.
- Weather-Icons class names are case-sensitive and lowercase. The direction is kept lowercase for the CSS class but capitalized for the tooltip word, so the arrows never come out blank.
- Nothing outside the trend indicator changes, and which observations get an arrow (`show_trend_on`) works exactly as before.

## Testing

I checked it against mocked WeeWX data across inHg/kPa/hPa/mmHg and °C/°F — category wording, the per-unit decimals, signed values, the lowercase icon classes, all three styles, and the short-window scaling/suppression/snap edges — plus a standalone Cheetah compile. The local Cheetah test suite (69 tests) passes (I keep the tests locally right now as there was no defined test patters checked in that I could use)