### PR TITLE
Per-series chart colors (custom, built-in, telemetry, windvec) + multi-axis fixes

### DIFF
--- a/install.py
+++ b/install.py
@@ -37,6 +37,7 @@ class BasicInstaller(ExtensionInstaller):
                         "skins/neowx-material/card_datetime.inc",
                         "skins/neowx-material/chart_date_format.inc",
                         "skins/neowx-material/chart_tick_axis.inc",
+                        "skins/neowx-material/chart_colors_setup.inc",
                         "skins/neowx-material/chart_tick_setup.inc",
                         "skins/neowx-material/footer.inc",
                         "skins/neowx-material/forecast.inc",

--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class BasicInstaller(ExtensionInstaller):
     def __init__(self):
         super(BasicInstaller, self).__init__(
-            version="1.65.0",
+            version="1.66.0",
             name="neowx-material",
             description="The most versatile and modern weewx skin",
             author="Neoweewx",

--- a/skins/neowx-material/chart_colors_setup.inc
+++ b/skins/neowx-material/chart_colors_setup.inc
@@ -1,0 +1,25 @@
+#encoding UTF-8
+## ---------------------------------------------------------------------------
+## Resolve a custom chart's optional per-series color references into the
+## chart-scoped global $cc_color_refs. Include from the customChart* loop
+## AFTER setting (as #set global):
+##   $cc_name  - the customChart* key (e.g. customChartOutTemp)
+##   $cc_scope - per-page subsection name: current (index) / yesterday / week /
+##               month / year
+## The value (page subsection -> top-level) is a list of per-series entries:
+## a bare active-palette slot number, paletteN:M, a literal CSS color, or
+## "default". Entries are cleaned here; resolution to concrete colors happens
+## client-side in neowxChartColors (js.inc). Quotes and backslashes are
+## stripped because entries are emitted inside JS string literals.
+## Output (global): $cc_color_refs - list of cleaned reference strings,
+## empty when the chart configures no colors.
+## ---------------------------------------------------------------------------
+#set global $cc_color_refs = []
+#set $_ccc      = $Extras.Appearance.get($cc_name, {})
+#set $_ccc_page = $_ccc.get($cc_scope, {})
+#set $_ccc_raw  = $_ccc_page.get('colors', $_ccc.get('colors', []))
+#if isinstance($_ccc_raw, list)
+    #set global $cc_color_refs = [str(c).strip().replace('"', '').replace('\\', '') for c in $_ccc_raw if str(c).strip()]
+#else
+    #set global $cc_color_refs = [c.strip().replace('"', '').replace('\\', '') for c in str($_ccc_raw).split(',') if c.strip()]
+#end if

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -926,10 +926,23 @@
 
             // Display wind vector chart
 
+            #set global $cc_name  = 'windvec'
+            #set global $cc_scope = ''
+            #include "chart_colors_setup.inc"
+            #set $sc_color_list = []
+            #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
+            #silent $sc_color_list.append($cc_color_refs[1] if len($cc_color_refs) > 1 else 'default')
             var windvecchart = document.querySelector('#windvecchart');
             if (windvecchart) {
                 new ApexCharts(windvecchart, {
                     ...graph_radar_config,
+                    #if len($cc_color_refs) > 0
+                    colors: neowxChartColors([
+                        #for $cref in $sc_color_list
+                        "$cref",
+                        #end for
+                    ], $len($sc_color_list), "windvec"),
+                    #end if
                     yaxis: {
                         labels: {
                             formatter: function (val) {

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -707,7 +707,7 @@
                             #for $cref in $sc_color_list
                             "$cref",
                             #end for
-                        ], len($sc_color_list), "$name"),
+                        ], $len($sc_color_list), "$name"),
                         #end if
                         #if $pg_align_mid and $type != 'radar'
                             xaxis: {

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -979,13 +979,6 @@
                         #else
                             #set $cc_vals = [v.strip() for v in str($cc_values_raw).split(',') if v.strip()]
                         #end if
-                        ## Resolve per-series color references: page -> top-level (empty = theme default)
-                        #set $cc_colors_raw = $cc_page.get('colors', $cc.get('colors', []))
-                        #if isinstance($cc_colors_raw, list)
-                            #set $cc_color_refs = [str(c).strip().replace('"', '') for c in $cc_colors_raw if str(c).strip()]
-                        #else
-                            #set $cc_color_refs = [c.strip().replace('"', '') for c in str($cc_colors_raw).split(',') if c.strip()]
-                        #end if
                         ## Build cc_series_pairs from field-name keys or values+column fallback
                         ## Build cc_field_map without a generator (avoids Python 3 / Cheetah scope issue)
                         #set $cc_field_map = {}
@@ -1059,6 +1052,7 @@
                         #set global $cc_scope = 'current'
                         #include "chart_date_format.inc"
                         #include "chart_tick_setup.inc"
+                        #include "chart_colors_setup.inc"
 
                         ## Render chart JS
                         #if len($cc_series_pairs) > 0 and $x in $Extras.Appearance.charts_order
@@ -1166,14 +1160,14 @@
                                             #end if
                                             #set $cc_pos = $cc_pos + 1
                                         #end for
-                                    ]
-                                    #if len($cc_color_refs) > 0
+                                    ],
+                                    #if len($cc_color_refs) > 0 and len($cc_color_list) > 0
                                         #set $cc_color_count = len($cc_color_list)
-                                        , colors: neowxChartColors([
+                                        colors: neowxChartColors([
                                         #for $cref in $cc_color_list
                                             "$cref",
                                         #end for
-                                        ], $cc_color_count, "$x")
+                                        ], $cc_color_count, "$x"),
                                     #end if
                                 }).render()
                             }

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -1193,6 +1193,11 @@
                                             #end for
                                         ],
                                     #end if
+                                    #if len($axes_list) > 1
+                                    ## Multi-axis assigns each series an axis group, which makes ApexCharts
+                                    ## cluster the legend by axis (out of series order). Keep series order.
+                                    legend: { ...graph_${cc_type}_config.legend, clusterGroupedSeries: false },
+                                    #end if
                                     series: [
                                         #set $cc_color_list = []
                                         #set $cc_pos = 0

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -1092,6 +1092,21 @@
                                         },
                                     #else
                                         ## Multiple axes configuration
+                                        ## Build per-axis lists of the emitted series names so seriesName can be
+                                        ## an ARRAY. An array seriesName makes ApexCharts use its array-style axis
+                                        ## mapping, which avoids a crash in setSeriesYAxisMappings when a series'
+                                        ## index exceeds the y-axis count (e.g. >1 field on an axis, or >2 series).
+                                        #set $axis_series_names = {}
+                                        #for $asn_axis_id in $axes_list
+                                            #silent $axis_series_names[$asn_axis_id] = []
+                                        #end for
+                                        #for $asn_val, $asn_cols in $cc_series_pairs
+                                            #set $asn_axis = $axis_map.get($asn_val, $axes_list[0])
+                                            #if $asn_axis not in $axis_series_names
+                                                #set $asn_axis = $axes_list[0]
+                                            #end if
+                                            #silent $axis_series_names[$asn_axis].append($getVar('obs.label.' + $asn_val))
+                                        #end for
                                         yaxis: [
                                             #for $axis_entry in enumerate($axes_list)
                                                 #set $idx = $axis_entry[0]
@@ -1118,7 +1133,15 @@
                                                 #set $axis_min = $axis_cfg.get('min', None)
                                                 #set $axis_max = $axis_cfg.get('max', None)
                                             {
-                                                seriesName: "$getVar('obs.label.' + $first_field)",
+                                                #set $asn_list = $axis_series_names.get($axis_id, [])
+                                                #if not $asn_list
+                                                    #set $asn_list = [$getVar('obs.label.' + $first_field)]
+                                                #end if
+                                                seriesName: [
+                                                    #for $asn in $asn_list
+                                                        "$asn",
+                                                    #end for
+                                                ],
                                                 #if $axis_title
                                                 title: {
                                                     text: "$axis_title",

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -681,11 +681,33 @@
 
             ## Only add JS chart code if in array
             #if $name in $Extras.Appearance.charts_order
+                #set global $cc_name  = $name
+                #set global $cc_scope = ''
+                #include "chart_colors_setup.inc"
 
                 var chartElement = document.querySelector('#$id');
                 if (chartElement) {
                     new ApexCharts(chartElement, {
                         ...graph_${type}_config,
+                        #set $sc_color_list = []
+                        #set $sc_pos = 0
+                        #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
+                        #set $sc_pos = 1
+                        #for $sname in [$series2, $series3, $series4, $series5, $series6, $series7, $series8]
+                            #if $sname != ""
+                                #if $chartHasData($sname)
+                                    #silent $sc_color_list.append($cc_color_refs[$sc_pos] if $sc_pos < len($cc_color_refs) else 'default')
+                                #end if
+                                #set $sc_pos = $sc_pos + 1
+                            #end if
+                        #end for
+                        #if len($cc_color_refs) > 0 and len($sc_color_list) > 0
+                        colors: neowxChartColors([
+                            #for $cref in $sc_color_list
+                            "$cref",
+                            #end for
+                        ], len($sc_color_list), "$name"),
+                        #end if
                         #if $pg_align_mid and $type != 'radar'
                             xaxis: {
                                 ...graph_${type}_config.xaxis,

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -1075,10 +1075,33 @@
                                         #end if
                                     },
                                     #end if
-                                    #if $cc_tooltip_fmt
+                                    #if $cc_tooltip_fmt or len($axes_list) > 1
                                     tooltip: {
                                         ...graph_${cc_type}_config.tooltip,
-                                        x: { ...graph_${cc_type}_config.tooltip.x, formatter: neowxDateFormatter("$cc_tooltip_fmt") }
+                                        #if $cc_tooltip_fmt
+                                        x: { ...graph_${cc_type}_config.tooltip.x, formatter: neowxDateFormatter("$cc_tooltip_fmt") },
+                                        #end if
+                                        #if len($axes_list) > 1
+                                        ## Per-series tooltip unit formatter. ApexCharts picks the y-axis label
+                                        ## formatter by series index, which mismatches units on multi-axis charts
+                                        ## (e.g. >1 series per axis). Key the unit off the series name instead.
+                                        #set $series_field_by_name = {}
+                                        #for $ttf_val, $ttf_cols in $cc_series_pairs
+                                            #silent $series_field_by_name[$getVar('obs.label.' + $ttf_val)] = $ttf_val
+                                        #end for
+                                        y: {
+                                            formatter: function (val, opts) {
+                                                var u = {
+                                                    #for $ttn, $ttf in $series_field_by_name.items()
+                                                    "$ttn": ["$getVar('unit.format.' + $ttf)", "$getVar('unit.label.' + $ttf)"],
+                                                    #end for
+                                                };
+                                                var s = opts.w.config.series[opts.seriesIndex];
+                                                var p = s ? u[s.name] : null;
+                                                return p ? (formatNumber(val, p[0]) + p[1]) : val;
+                                            }
+                                        },
+                                        #end if
                                     },
                                     #end if
                                     #if len($axes_list) <= 1

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -689,8 +689,9 @@
                 if (chartElement) {
                     new ApexCharts(chartElement, {
                         ...graph_${type}_config,
+                        ## Per-series colors aligned to emitted series: series1 = slot 0; series2-8
+                        ## each advance a slot, appending a color only when the series has data.
                         #set $sc_color_list = []
-                        #set $sc_pos = 0
                         #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
                         #set $sc_pos = 1
                         #for $sname in [$series2, $series3, $series4, $series5, $series6, $series7, $series8]

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -979,11 +979,18 @@
                         #else
                             #set $cc_vals = [v.strip() for v in str($cc_values_raw).split(',') if v.strip()]
                         #end if
+                        ## Resolve per-series color references: page -> top-level (empty = theme default)
+                        #set $cc_colors_raw = $cc_page.get('colors', $cc.get('colors', []))
+                        #if isinstance($cc_colors_raw, list)
+                            #set $cc_color_refs = [str(c).strip().replace('"', '') for c in $cc_colors_raw if str(c).strip()]
+                        #else
+                            #set $cc_color_refs = [c.strip().replace('"', '') for c in str($cc_colors_raw).split(',') if c.strip()]
+                        #end if
                         ## Build cc_series_pairs from field-name keys or values+column fallback
                         ## Build cc_field_map without a generator (avoids Python 3 / Cheetah scope issue)
                         #set $cc_field_map = {}
                         #for $fk, $fv in $cc_page.items()
-                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format') and isinstance($fv, (str, list))
+                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style') and isinstance($fv, (str, list))
                                 #silent $cc_field_map[$fk] = $fv
                             #end if
                         #end for
@@ -1147,15 +1154,27 @@
                                         ],
                                     #end if
                                     series: [
+                                        #set $cc_color_list = []
+                                        #set $cc_pos = 0
                                         #for $val, $cols in $cc_series_pairs
                                             #if $chartHasData(val)
                                                 {
                                                     name: "$getVar('obs.label.' + val)",
                                                     data: [ $getChartData(val, cols[0]) ]
                                                 },
+                                                #silent $cc_color_list.append($cc_color_refs[$cc_pos] if $cc_pos < len($cc_color_refs) else 'default')
                                             #end if
+                                            #set $cc_pos = $cc_pos + 1
                                         #end for
                                     ]
+                                    #if len($cc_color_refs) > 0
+                                        #set $cc_color_count = len($cc_color_list)
+                                        , colors: neowxChartColors([
+                                        #for $cref in $cc_color_list
+                                            "$cref",
+                                        #end for
+                                        ], $cc_color_count, "$x")
+                                    #end if
                                 }).render()
                             }
                         #end if

--- a/skins/neowx-material/js.inc
+++ b/skins/neowx-material/js.inc
@@ -210,6 +210,7 @@
         palette10: ["#C91EFF", "#A94BFD", "#6C6AFE", "#2983FF", "#009ED8"]
     };
 
+    // ref must be a string (callers pass String(...).trim()).
     function neowxResolveColorRef(ref, activePalette, fallback, chartName) {
         if (!ref || ref.toLowerCase() === 'default') { return fallback; }
         if (/^\d+$/.test(ref)) {
@@ -219,13 +220,19 @@
                 ' out of range (1-' + activePalette.length + ') - using default');
             return fallback;
         }
+        // No CSS color syntax contains ':', so this never shadows a literal color.
         if (ref.indexOf(':') !== -1) {
             var m = /^palette(\d+):(\d+)$/i.exec(ref);
             var pal = m ? NEOWX_PALETTES['palette' + m[1]] : null;
             var slot = m ? parseInt(m[2], 10) : 0;
             if (pal && slot >= 1 && slot <= pal.length) { return pal[slot - 1]; }
-            console.warn('neowx-material: chart "' + chartName + '": unrecognized palette reference "' +
-                ref + '" - using default');
+            if (pal) {
+                console.warn('neowx-material: chart "' + chartName + '": color slot ' + m[2] +
+                    ' out of range (1-' + pal.length + ') - using default');
+            } else {
+                console.warn('neowx-material: chart "' + chartName + '": unrecognized palette reference "' +
+                    ref + '" - using default');
+            }
             return fallback;
         }
         if (typeof CSS !== 'undefined' && CSS.supports && !CSS.supports('color', ref)) {

--- a/skins/neowx-material/js.inc
+++ b/skins/neowx-material/js.inc
@@ -189,6 +189,69 @@
         },
     }
 
+    // --- neowxChartColors ---------------------------------------------------
+    // Resolves skin.conf per-series color references into concrete colors.
+    // Accepted per entry: "N" (Nth color of the ACTIVE palette, 1-based),
+    // "paletteN:M" (Mth color of built-in palette N), a literal CSS color,
+    // or "default" (keep the active palette's positional color).
+    // Palette tables mirror getThemePalettes() in
+    // js/vendor/apexcharts/apexcharts.js - keep in sync when upgrading the
+    // vendored ApexCharts build.
+    var NEOWX_PALETTES = {
+        palette1: ["#008FFB", "#00A86F", "#CA8501", "#FF4560", "#846DD5"],
+        palette2: ["#6978CB", "#039DE2", "#49A84D", "#B39105", "#D68000"],
+        palette3: ["#209FCC", "#648291", "#D4526E", "#0FA783", "#A19285"],
+        palette4: ["#2FA59D", "#73A20B", "#099DE1", "#FD5D5D", "#648291"],
+        palette5: ["#2B908F", "#F56566", "#2EAB16", "#FA4443", "#1EA2BD"],
+        palette6: ["#449DD1", "#F86624", "#EA3A4A", "#9C63D1", "#899E2A"],
+        palette7: ["#DF475B", "#1B998B", "#7E75B7", "#F46036", "#B1911B"],
+        palette8: ["#9C63D1", "#F86624", "#B38F04", "#EA3A4A", "#2FA2B3"],
+        palette9: ["#98776F", "#A19285", "#A8705E", "#BA6560", "#A0927F"],
+        palette10: ["#C91EFF", "#A94BFD", "#6C6AFE", "#2983FF", "#009ED8"]
+    };
+
+    function neowxResolveColorRef(ref, activePalette, fallback, chartName) {
+        if (!ref || ref.toLowerCase() === 'default') { return fallback; }
+        if (/^\d+$/.test(ref)) {
+            var n = parseInt(ref, 10);
+            if (n >= 1 && n <= activePalette.length) { return activePalette[n - 1]; }
+            console.warn('neowx-material: chart "' + chartName + '": color slot ' + ref +
+                ' out of range (1-' + activePalette.length + ') - using default');
+            return fallback;
+        }
+        if (ref.indexOf(':') !== -1) {
+            var m = /^palette(\d+):(\d+)$/i.exec(ref);
+            var pal = m ? NEOWX_PALETTES['palette' + m[1]] : null;
+            var slot = m ? parseInt(m[2], 10) : 0;
+            if (pal && slot >= 1 && slot <= pal.length) { return pal[slot - 1]; }
+            console.warn('neowx-material: chart "' + chartName + '": unrecognized palette reference "' +
+                ref + '" - using default');
+            return fallback;
+        }
+        if (typeof CSS !== 'undefined' && CSS.supports && !CSS.supports('color', ref)) {
+            console.warn('neowx-material: chart "' + chartName + '": invalid color "' +
+                ref + '" - using default');
+            return fallback;
+        }
+        return ref;
+    }
+
+    function neowxChartColors(refs, seriesCount, chartName) {
+        var active = NEOWX_PALETTES.palette1;
+        try {
+            var palName = window.Apex.theme.palette;
+            if (NEOWX_PALETTES[palName]) { active = NEOWX_PALETTES[palName]; }
+        } catch (e) {}
+        var out = [];
+        for (var i = 0; i < seriesCount; i++) {
+            var fallback = active[i % active.length];
+            var ref = (refs && i < refs.length && refs[i] != null) ? String(refs[i]).trim() : '';
+            out.push(neowxResolveColorRef(ref, active, fallback, chartName));
+        }
+        return out;
+    }
+    // --- end neowxChartColors -----------------------------------------------
+
     ## Ordinals conversion for W0CHP's custom WindDir Charts:
     function getOrdinalDirection(degrees) {
         var sectors = [

--- a/skins/neowx-material/month-%Y-%m.html.tmpl
+++ b/skins/neowx-material/month-%Y-%m.html.tmpl
@@ -730,7 +730,7 @@
                         ## Build cc_field_map without a generator (avoids Python 3 / Cheetah scope issue)
                         #set $cc_field_map = {}
                         #for $fk, $fv in $cc_page.items()
-                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format') and isinstance($fv, (str, list))
+                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style') and isinstance($fv, (str, list))
                                 #silent $cc_field_map[$fk] = $fv
                             #end if
                         #end for
@@ -799,6 +799,7 @@
                         #set global $cc_scope = 'month'
                         #include "chart_date_format.inc"
                         #include "chart_tick_setup.inc"
+                        #include "chart_colors_setup.inc"
 
                         ## Render chart JS
                         #if len($cc_series_pairs) > 0 and $x in $Extras.Appearance.charts_order
@@ -894,6 +895,8 @@
                                         ],
                                     #end if
                                     series: [
+                                        #set $cc_color_list = []
+                                        #set $cc_pos = 0
                                         #for $val, $cols in $cc_series_pairs
                                             #if $getVar('month.' + val + '.has_data')
                                                 #if len($cols) == 1
@@ -901,17 +904,31 @@
                                                         name: "$getVar('obs.label.' + val)",
                                                         data: [ $getChartData(val, cols[0]) ]
                                                     },
+                                                    #silent $cc_color_list.append($cc_color_refs[$cc_pos] if $cc_pos < len($cc_color_refs) else 'default')
+                                                    #set $cc_pos = $cc_pos + 1
                                                 #else
                                                     #for $col in $cols
                                                         {
                                                             name: "$getVar('obs.label.' + val) $gettext($col)",
                                                             data: [ $getChartData(val, col) ]
                                                         },
+                                                        #silent $cc_color_list.append($cc_color_refs[$cc_pos] if $cc_pos < len($cc_color_refs) else 'default')
+                                                        #set $cc_pos = $cc_pos + 1
                                                     #end for
                                                 #end if
+                                            #else
+                                                #set $cc_pos = $cc_pos + len($cols)
                                             #end if
                                         #end for
-                                    ]
+                                    ],
+                                    #if len($cc_color_refs) > 0 and len($cc_color_list) > 0
+                                        #set $cc_color_count = len($cc_color_list)
+                                        colors: neowxChartColors([
+                                        #for $cref in $cc_color_list
+                                            "$cref",
+                                        #end for
+                                        ], $cc_color_count, "$x"),
+                                    #end if
                                 }).render()
                             }
                         #end if

--- a/skins/neowx-material/month-%Y-%m.html.tmpl
+++ b/skins/neowx-material/month-%Y-%m.html.tmpl
@@ -462,12 +462,38 @@
 
             #if $name in $Extras.Appearance.charts_order
 
+                #set global $cc_name  = $name
+                #set global $cc_scope = ''
+                #include "chart_colors_setup.inc"
+
                 #if $name == "outTemp"
 
                     var chartElement = document.querySelector('#$id');
                     if (chartElement) {
                         new ApexCharts(chartElement, {
                             ...graph_${type}_config,
+                            ## Per-series colors aligned to emitted series: outTemp renders min + max,
+                            ## so series1 takes slots 0 and 1; series2-8 each advance a slot, appending
+                            ## a color only when the series has data.
+                            #set $sc_color_list = []
+                            #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
+                            #silent $sc_color_list.append($cc_color_refs[1] if len($cc_color_refs) > 1 else 'default')
+                            #set $sc_pos = 2
+                            #for $sname in [$series2, $series3, $series4, $series5, $series6, $series7, $series8]
+                                #if $sname != ""
+                                    #if $getVar('month.' + $sname + '.has_data')
+                                        #silent $sc_color_list.append($cc_color_refs[$sc_pos] if $sc_pos < len($cc_color_refs) else 'default')
+                                    #end if
+                                    #set $sc_pos = $sc_pos + 1
+                                #end if
+                            #end for
+                            #if len($cc_color_refs) > 0 and len($sc_color_list) > 0
+                            colors: neowxChartColors([
+                                #for $cref in $sc_color_list
+                                "$cref",
+                                #end for
+                            ], len($sc_color_list), "$name"),
+                            #end if
                             #if $pg_align_mid and $type != 'radar'
                                 xaxis: {
                                     ...graph_${type}_config.xaxis,
@@ -521,6 +547,26 @@
                     if (chartElement) {
                         new ApexCharts(chartElement, {
                             ...graph_${type}_config,
+                            ## Per-series colors aligned to emitted series: series1 = slot 0; series2-8
+                            ## each advance a slot, appending a color only when the series has data.
+                            #set $sc_color_list = []
+                            #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
+                            #set $sc_pos = 1
+                            #for $sname in [$series2, $series3, $series4, $series5, $series6, $series7, $series8]
+                                #if $sname != ""
+                                    #if $getVar('month.' + $sname + '.has_data')
+                                        #silent $sc_color_list.append($cc_color_refs[$sc_pos] if $sc_pos < len($cc_color_refs) else 'default')
+                                    #end if
+                                    #set $sc_pos = $sc_pos + 1
+                                #end if
+                            #end for
+                            #if len($cc_color_refs) > 0 and len($sc_color_list) > 0
+                            colors: neowxChartColors([
+                                #for $cref in $sc_color_list
+                                "$cref",
+                                #end for
+                            ], len($sc_color_list), "$name"),
+                            #end if
                             #if $pg_align_mid and $type != 'radar'
                                 xaxis: {
                                     ...graph_${type}_config.xaxis,

--- a/skins/neowx-material/month-%Y-%m.html.tmpl
+++ b/skins/neowx-material/month-%Y-%m.html.tmpl
@@ -952,6 +952,11 @@
                                             #end for
                                         ],
                                     #end if
+                                    #if len($axes_list) > 1
+                                    ## Multi-axis assigns each series an axis group, which makes ApexCharts
+                                    ## cluster the legend by axis (out of series order). Keep series order.
+                                    legend: { ...graph_${cc_type}_config.legend, clusterGroupedSeries: false },
+                                    #end if
                                     series: [
                                         #set $cc_color_list = []
                                         #set $cc_pos = 0

--- a/skins/neowx-material/month-%Y-%m.html.tmpl
+++ b/skins/neowx-material/month-%Y-%m.html.tmpl
@@ -492,7 +492,7 @@
                                 #for $cref in $sc_color_list
                                 "$cref",
                                 #end for
-                            ], len($sc_color_list), "$name"),
+                            ], $len($sc_color_list), "$name"),
                             #end if
                             #if $pg_align_mid and $type != 'radar'
                                 xaxis: {
@@ -565,7 +565,7 @@
                                 #for $cref in $sc_color_list
                                 "$cref",
                                 #end for
-                            ], len($sc_color_list), "$name"),
+                            ], $len($sc_color_list), "$name"),
                             #end if
                             #if $pg_align_mid and $type != 'radar'
                                 xaxis: {

--- a/skins/neowx-material/month-%Y-%m.html.tmpl
+++ b/skins/neowx-material/month-%Y-%m.html.tmpl
@@ -839,6 +839,27 @@
                                         },
                                     #else
                                         ## Multiple axes configuration
+                                        ## Build per-axis lists of the emitted series names so seriesName can be
+                                        ## an ARRAY. An array seriesName makes ApexCharts use its array-style axis
+                                        ## mapping, which avoids a crash in setSeriesYAxisMappings when a series'
+                                        ## index exceeds the y-axis count (e.g. >1 field on an axis, or >2 series).
+                                        #set $axis_series_names = {}
+                                        #for $asn_axis_id in $axes_list
+                                            #silent $axis_series_names[$asn_axis_id] = []
+                                        #end for
+                                        #for $asn_val, $asn_cols in $cc_series_pairs
+                                            #set $asn_axis = $axis_map.get($asn_val, $axes_list[0])
+                                            #if $asn_axis not in $axis_series_names
+                                                #set $asn_axis = $axes_list[0]
+                                            #end if
+                                            #if len($asn_cols) == 1
+                                                #silent $axis_series_names[$asn_axis].append($getVar('obs.label.' + $asn_val))
+                                            #else
+                                                #for $asn_col in $asn_cols
+                                                    #silent $axis_series_names[$asn_axis].append($getVar('obs.label.' + $asn_val) + ' ' + $gettext($asn_col))
+                                                #end for
+                                            #end if
+                                        #end for
                                         yaxis: [
                                             #for $axis_entry in enumerate($axes_list)
                                                 #set $idx = $axis_entry[0]
@@ -865,7 +886,15 @@
                                                 #set $axis_min = $axis_cfg.get('min', None)
                                                 #set $axis_max = $axis_cfg.get('max', None)
                                             {
-                                                seriesName: "$getVar('obs.label.' + $first_field)",
+                                                #set $asn_list = $axis_series_names.get($axis_id, [])
+                                                #if not $asn_list
+                                                    #set $asn_list = [$getVar('obs.label.' + $first_field)]
+                                                #end if
+                                                seriesName: [
+                                                    #for $asn in $asn_list
+                                                        "$asn",
+                                                    #end for
+                                                ],
                                                 #if $axis_title
                                                 title: {
                                                     text: "$axis_title",

--- a/skins/neowx-material/month-%Y-%m.html.tmpl
+++ b/skins/neowx-material/month-%Y-%m.html.tmpl
@@ -822,10 +822,39 @@
                                         #end if
                                     },
                                     #end if
-                                    #if $cc_tooltip_fmt
+                                    #if $cc_tooltip_fmt or len($axes_list) > 1
                                     tooltip: {
                                         ...graph_${cc_type}_config.tooltip,
-                                        x: { ...graph_${cc_type}_config.tooltip.x, formatter: neowxDateFormatter("$cc_tooltip_fmt") }
+                                        #if $cc_tooltip_fmt
+                                        x: { ...graph_${cc_type}_config.tooltip.x, formatter: neowxDateFormatter("$cc_tooltip_fmt") },
+                                        #end if
+                                        #if len($axes_list) > 1
+                                        ## Per-series tooltip unit formatter. ApexCharts picks the y-axis label
+                                        ## formatter by series index, which mismatches units on multi-axis charts
+                                        ## (e.g. >1 series per axis). Key the unit off the series name instead.
+                                        #set $series_field_by_name = {}
+                                        #for $ttf_val, $ttf_cols in $cc_series_pairs
+                                            #if len($ttf_cols) == 1
+                                                #silent $series_field_by_name[$getVar('obs.label.' + $ttf_val)] = $ttf_val
+                                            #else
+                                                #for $ttf_col in $ttf_cols
+                                                    #silent $series_field_by_name[$getVar('obs.label.' + $ttf_val) + ' ' + $gettext($ttf_col)] = $ttf_val
+                                                #end for
+                                            #end if
+                                        #end for
+                                        y: {
+                                            formatter: function (val, opts) {
+                                                var u = {
+                                                    #for $ttn, $ttf in $series_field_by_name.items()
+                                                    "$ttn": ["$getVar('unit.format.' + $ttf)", "$getVar('unit.label.' + $ttf)"],
+                                                    #end for
+                                                };
+                                                var s = opts.w.config.series[opts.seriesIndex];
+                                                var p = s ? u[s.name] : null;
+                                                return p ? (formatNumber(val, p[0]) + p[1]) : val;
+                                            }
+                                        },
+                                        #end if
                                     },
                                     #end if
                                     #if len($axes_list) <= 1

--- a/skins/neowx-material/month-%Y-%m.html.tmpl
+++ b/skins/neowx-material/month-%Y-%m.html.tmpl
@@ -712,10 +712,23 @@
                 avg_values.push(vector_data[item]['amt'] > 0 ? vector_data[item]['sum'] / vector_data[item]['amt'] : 0);
                 max_values.push(vector_data[item]['max']);
             });
+            #set global $cc_name  = 'windvec'
+            #set global $cc_scope = ''
+            #include "chart_colors_setup.inc"
+            #set $sc_color_list = []
+            #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
+            #silent $sc_color_list.append($cc_color_refs[1] if len($cc_color_refs) > 1 else 'default')
             var windvecchart = document.querySelector('#windvecchart');
             if (windvecchart) {
                 new ApexCharts(windvecchart, {
                     ...graph_radar_config,
+                    #if len($cc_color_refs) > 0
+                    colors: neowxChartColors([
+                        #for $cref in $sc_color_list
+                        "$cref",
+                        #end for
+                    ], $len($sc_color_list), "windvec"),
+                    #end if
                     yaxis: { labels: { formatter: function (val) { return formatNumber(val, "$unit.format.windSpeed") + "$unit.label.windSpeed"; } } },
                     series: [
                         { name: "$obs.label.windSpeed", data: avg_values },

--- a/skins/neowx-material/month.html.tmpl
+++ b/skins/neowx-material/month.html.tmpl
@@ -1069,6 +1069,11 @@
                                             #end for
                                         ],
                                     #end if
+                                    #if len($axes_list) > 1
+                                    ## Multi-axis assigns each series an axis group, which makes ApexCharts
+                                    ## cluster the legend by axis (out of series order). Keep series order.
+                                    legend: { ...graph_${cc_type}_config.legend, clusterGroupedSeries: false },
+                                    #end if
                                     series: [
                                         #set $cc_color_list = []
                                         #set $cc_pos = 0

--- a/skins/neowx-material/month.html.tmpl
+++ b/skins/neowx-material/month.html.tmpl
@@ -847,7 +847,7 @@
                         ## Build cc_field_map without a generator (avoids Python 3 / Cheetah scope issue)
                         #set $cc_field_map = {}
                         #for $fk, $fv in $cc_page.items()
-                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format') and isinstance($fv, (str, list))
+                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style') and isinstance($fv, (str, list))
                                 #silent $cc_field_map[$fk] = $fv
                             #end if
                         #end for
@@ -916,6 +916,7 @@
                         #set global $cc_scope = 'month'
                         #include "chart_date_format.inc"
                         #include "chart_tick_setup.inc"
+                        #include "chart_colors_setup.inc"
 
                         ## Render chart JS
                         #if len($cc_series_pairs) > 0 and $x in $Extras.Appearance.charts_order
@@ -1011,6 +1012,8 @@
                                         ],
                                     #end if
                                     series: [
+                                        #set $cc_color_list = []
+                                        #set $cc_pos = 0
                                         #for $val, $cols in $cc_series_pairs
                                             #if $getVar('month.' + val + '.has_data')
                                                 #if len($cols) == 1
@@ -1018,17 +1021,31 @@
                                                         name: "$getVar('obs.label.' + val)",
                                                         data: [ $getChartData(val, cols[0]) ]
                                                     },
+                                                    #silent $cc_color_list.append($cc_color_refs[$cc_pos] if $cc_pos < len($cc_color_refs) else 'default')
+                                                    #set $cc_pos = $cc_pos + 1
                                                 #else
                                                     #for $col in $cols
                                                         {
                                                             name: "$getVar('obs.label.' + val) $gettext($col)",
                                                             data: [ $getChartData(val, col) ]
                                                         },
+                                                        #silent $cc_color_list.append($cc_color_refs[$cc_pos] if $cc_pos < len($cc_color_refs) else 'default')
+                                                        #set $cc_pos = $cc_pos + 1
                                                     #end for
                                                 #end if
+                                            #else
+                                                #set $cc_pos = $cc_pos + len($cols)
                                             #end if
                                         #end for
-                                    ]
+                                    ],
+                                    #if len($cc_color_refs) > 0 and len($cc_color_list) > 0
+                                        #set $cc_color_count = len($cc_color_list)
+                                        colors: neowxChartColors([
+                                        #for $cref in $cc_color_list
+                                            "$cref",
+                                        #end for
+                                        ], $cc_color_count, "$x"),
+                                    #end if
                                 }).render()
                             }
                         #end if

--- a/skins/neowx-material/month.html.tmpl
+++ b/skins/neowx-material/month.html.tmpl
@@ -956,6 +956,27 @@
                                         },
                                     #else
                                         ## Multiple axes configuration
+                                        ## Build per-axis lists of the emitted series names so seriesName can be
+                                        ## an ARRAY. An array seriesName makes ApexCharts use its array-style axis
+                                        ## mapping, which avoids a crash in setSeriesYAxisMappings when a series'
+                                        ## index exceeds the y-axis count (e.g. >1 field on an axis, or >2 series).
+                                        #set $axis_series_names = {}
+                                        #for $asn_axis_id in $axes_list
+                                            #silent $axis_series_names[$asn_axis_id] = []
+                                        #end for
+                                        #for $asn_val, $asn_cols in $cc_series_pairs
+                                            #set $asn_axis = $axis_map.get($asn_val, $axes_list[0])
+                                            #if $asn_axis not in $axis_series_names
+                                                #set $asn_axis = $axes_list[0]
+                                            #end if
+                                            #if len($asn_cols) == 1
+                                                #silent $axis_series_names[$asn_axis].append($getVar('obs.label.' + $asn_val))
+                                            #else
+                                                #for $asn_col in $asn_cols
+                                                    #silent $axis_series_names[$asn_axis].append($getVar('obs.label.' + $asn_val) + ' ' + $gettext($asn_col))
+                                                #end for
+                                            #end if
+                                        #end for
                                         yaxis: [
                                             #for $axis_entry in enumerate($axes_list)
                                                 #set $idx = $axis_entry[0]
@@ -982,7 +1003,15 @@
                                                 #set $axis_min = $axis_cfg.get('min', None)
                                                 #set $axis_max = $axis_cfg.get('max', None)
                                             {
-                                                seriesName: "$getVar('obs.label.' + $first_field)",
+                                                #set $asn_list = $axis_series_names.get($axis_id, [])
+                                                #if not $asn_list
+                                                    #set $asn_list = [$getVar('obs.label.' + $first_field)]
+                                                #end if
+                                                seriesName: [
+                                                    #for $asn in $asn_list
+                                                        "$asn",
+                                                    #end for
+                                                ],
                                                 #if $axis_title
                                                 title: {
                                                     text: "$axis_title",

--- a/skins/neowx-material/month.html.tmpl
+++ b/skins/neowx-material/month.html.tmpl
@@ -939,10 +939,39 @@
                                         #end if
                                     },
                                     #end if
-                                    #if $cc_tooltip_fmt
+                                    #if $cc_tooltip_fmt or len($axes_list) > 1
                                     tooltip: {
                                         ...graph_${cc_type}_config.tooltip,
-                                        x: { ...graph_${cc_type}_config.tooltip.x, formatter: neowxDateFormatter("$cc_tooltip_fmt") }
+                                        #if $cc_tooltip_fmt
+                                        x: { ...graph_${cc_type}_config.tooltip.x, formatter: neowxDateFormatter("$cc_tooltip_fmt") },
+                                        #end if
+                                        #if len($axes_list) > 1
+                                        ## Per-series tooltip unit formatter. ApexCharts picks the y-axis label
+                                        ## formatter by series index, which mismatches units on multi-axis charts
+                                        ## (e.g. >1 series per axis). Key the unit off the series name instead.
+                                        #set $series_field_by_name = {}
+                                        #for $ttf_val, $ttf_cols in $cc_series_pairs
+                                            #if len($ttf_cols) == 1
+                                                #silent $series_field_by_name[$getVar('obs.label.' + $ttf_val)] = $ttf_val
+                                            #else
+                                                #for $ttf_col in $ttf_cols
+                                                    #silent $series_field_by_name[$getVar('obs.label.' + $ttf_val) + ' ' + $gettext($ttf_col)] = $ttf_val
+                                                #end for
+                                            #end if
+                                        #end for
+                                        y: {
+                                            formatter: function (val, opts) {
+                                                var u = {
+                                                    #for $ttn, $ttf in $series_field_by_name.items()
+                                                    "$ttn": ["$getVar('unit.format.' + $ttf)", "$getVar('unit.label.' + $ttf)"],
+                                                    #end for
+                                                };
+                                                var s = opts.w.config.series[opts.seriesIndex];
+                                                var p = s ? u[s.name] : null;
+                                                return p ? (formatNumber(val, p[0]) + p[1]) : val;
+                                            }
+                                        },
+                                        #end if
                                     },
                                     #end if
                                     #if len($axes_list) <= 1

--- a/skins/neowx-material/month.html.tmpl
+++ b/skins/neowx-material/month.html.tmpl
@@ -819,10 +819,23 @@
                 max_values.push(vector_data[item]['max'])
             });
 
+            #set global $cc_name  = 'windvec'
+            #set global $cc_scope = ''
+            #include "chart_colors_setup.inc"
+            #set $sc_color_list = []
+            #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
+            #silent $sc_color_list.append($cc_color_refs[1] if len($cc_color_refs) > 1 else 'default')
             var windvecchart = document.querySelector('#windvecchart');
             if (windvecchart) {
                 new ApexCharts(windvecchart, {
                     ...graph_radar_config,
+                    #if len($cc_color_refs) > 0
+                    colors: neowxChartColors([
+                        #for $cref in $sc_color_list
+                        "$cref",
+                        #end for
+                    ], $len($sc_color_list), "windvec"),
+                    #end if
                     yaxis: {
                         labels: {
                             formatter: function (val) {

--- a/skins/neowx-material/month.html.tmpl
+++ b/skins/neowx-material/month.html.tmpl
@@ -527,7 +527,7 @@
                                 #for $cref in $sc_color_list
                                 "$cref",
                                 #end for
-                            ], len($sc_color_list), "$name"),
+                            ], $len($sc_color_list), "$name"),
                             #end if
                             #if $pg_align_mid and $type != 'radar'
                                 xaxis: {
@@ -621,7 +621,7 @@
                                 #for $cref in $sc_color_list
                                 "$cref",
                                 #end for
-                            ], len($sc_color_list), "$name"),
+                            ], $len($sc_color_list), "$name"),
                             #end if
                             #if $pg_align_mid and $type != 'radar'
                                 xaxis: {

--- a/skins/neowx-material/month.html.tmpl
+++ b/skins/neowx-material/month.html.tmpl
@@ -495,6 +495,10 @@
             ## Only add JS chart code if in array
             #if $name in $Extras.Appearance.charts_order
 
+                #set global $cc_name  = $name
+                #set global $cc_scope = ''
+                #include "chart_colors_setup.inc"
+
                 #if $name == "outTemp"
 
                     ## Special diagram for outside temp
@@ -503,6 +507,28 @@
                     if (chartElement) {
                         new ApexCharts(chartElement, {
                             ...graph_${type}_config,
+                            ## Per-series colors aligned to emitted series: outTemp renders min + max,
+                            ## so series1 takes slots 0 and 1; series2-8 each advance a slot, appending
+                            ## a color only when the series has data.
+                            #set $sc_color_list = []
+                            #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
+                            #silent $sc_color_list.append($cc_color_refs[1] if len($cc_color_refs) > 1 else 'default')
+                            #set $sc_pos = 2
+                            #for $sname in [$series2, $series3, $series4, $series5, $series6, $series7, $series8]
+                                #if $sname != ""
+                                    #if $getVar('month.' + $sname + '.has_data')
+                                        #silent $sc_color_list.append($cc_color_refs[$sc_pos] if $sc_pos < len($cc_color_refs) else 'default')
+                                    #end if
+                                    #set $sc_pos = $sc_pos + 1
+                                #end if
+                            #end for
+                            #if len($cc_color_refs) > 0 and len($sc_color_list) > 0
+                            colors: neowxChartColors([
+                                #for $cref in $sc_color_list
+                                "$cref",
+                                #end for
+                            ], len($sc_color_list), "$name"),
+                            #end if
                             #if $pg_align_mid and $type != 'radar'
                                 xaxis: {
                                     ...graph_${type}_config.xaxis,
@@ -577,6 +603,26 @@
                     if (chartElement) {
                         new ApexCharts(chartElement, {
                             ...graph_${type}_config,
+                            ## Per-series colors aligned to emitted series: series1 = slot 0; series2-8
+                            ## each advance a slot, appending a color only when the series has data.
+                            #set $sc_color_list = []
+                            #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
+                            #set $sc_pos = 1
+                            #for $sname in [$series2, $series3, $series4, $series5, $series6, $series7, $series8]
+                                #if $sname != ""
+                                    #if $getVar('month.' + $sname + '.has_data')
+                                        #silent $sc_color_list.append($cc_color_refs[$sc_pos] if $sc_pos < len($cc_color_refs) else 'default')
+                                    #end if
+                                    #set $sc_pos = $sc_pos + 1
+                                #end if
+                            #end for
+                            #if len($cc_color_refs) > 0 and len($sc_color_list) > 0
+                            colors: neowxChartColors([
+                                #for $cref in $sc_color_list
+                                "$cref",
+                                #end for
+                            ], len($sc_color_list), "$name"),
+                            #end if
                             #if $pg_align_mid and $type != 'radar'
                                 xaxis: {
                                     ...graph_${type}_config.xaxis,

--- a/skins/neowx-material/package-lock.json
+++ b/skins/neowx-material/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neowx-material",
-  "version": "1.65.0",
+  "version": "1.66.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neowx-material",
-      "version": "1.65.0",
+      "version": "1.66.0",
       "license": "MIT",
       "dependencies": {
         "sass": "1.100.0"

--- a/skins/neowx-material/package.json
+++ b/skins/neowx-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neowx-material",
-  "version": "1.65.0",
+  "version": "1.66.0",
   "description": "The most versatile and modern weewx skin",
   "main": "index.js",
   "repository": "https://github.com/neoground/neowx-material",

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -18,7 +18,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
 
-    version = 1.65.0
+    version = 1.66.0
 
     # Language
     # -------------------------------------------------------------------------

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -513,6 +513,22 @@
         #   to override the chart-level list (useful when a page plots a
         #   different number of lines, e.g. outTemp = min, max).
         #
+        # Built-in charts (outTemp, rain, windSpeed, etc.) can be colored the
+        # same way: add a block named after the chart with a colors key. Same
+        # value forms as custom-chart colors above (bare palette slot number,
+        # paletteN:M, a literal "#hex"/CSS name, or default).
+        #
+        #   [[[outTemp]]]
+        #       colors = palette4:1
+        #   [[[windSpeed]]]
+        #       colors = 1, 4          # windSpeed line, windGust line
+        #
+        # Most built-in charts have one line, so they take one color. windSpeed
+        # has two (speed, gust). On the month and year pages outTemp is drawn as
+        # a min and a max line, so there it uses two colors (1st = min, 2nd =
+        # max); the day and week pages show a single averaged outTemp line and
+        # use only the first color.
+        #
         # Per-page overrides
         # -------------------------------------------------------------------------
         # By default the top-level "values" and "column" apply to every page.

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -529,6 +529,10 @@
         # max); the day and week pages show a single averaged outTemp line and
         # use only the first color.
         #
+        # The wind vector chart takes two colors too:
+        #   [[[windvec]]]
+        #       colors = 2, 3      # 1st = wind speed ring, 2nd = wind gust ring
+        #
         # Per-page overrides
         # -------------------------------------------------------------------------
         # By default the top-level "values" and "column" apply to every page.

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -543,16 +543,15 @@
         #     tick_style = align             # x-axis ticks for this chart, every page
         #     values    = outTemp, dewpoint   # default (current + pages without a subsection)
         #     column    = avg                 # default
+        #     colors    = 2, 1                # active-palette slots, all pages (must come
+        #                                     # before the page subsections)
         #     [[[[week]]]]
         #         tick_style = align:8       # ...but ask for ~8 ticks on the week page only
         #         outTemp  = min, max         # outTemp → "Outside Temperature Min" + "… Max"
         #         dewpoint = avg              # dewpoint → "Dew Point"  (no suffix for single col)
+        #         colors   = palette2:1, palette2:2, "#FD5D5D"   # one per line: min, max, dewpoint
         #     [[[[year]]]]
         #         outTemp  = min, avg, max
-        #     colors    = 2, 1                 # active-palette slots, all pages
-        #     [[[[week]]]]
-        #         outTemp  = min, max
-        #         colors   = palette2:1, palette2:2, "#FD5D5D"
         [[[customChartOutTemp]]]
             title = Outdoor Temperature
             charttype = area

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -500,6 +500,18 @@
         #   Series labelled "<obs label> <column label>" when more than one column
         #   is used for a field; otherwise just "<obs label>".
         # values: comma-separated list of WeeWX field names
+        # colors: optional comma-separated list assigning a color to each line,
+        #   in the order the lines appear in the chart legend. Each entry is:
+        #     2             - 2nd color of the ACTIVE palette ([[Charts]] palette)
+        #     paletteN:M    - Mth color of built-in palette N (N=1-10, M=1-5,
+        #                     see apexcharts.com/docs/options/theme/#palette)
+        #     "#FD5D5D"     - a literal color (hex needs quotes, CSS names don't)
+        #     default       - keep the theme default for this slot
+        #   Fewer entries than lines: remaining lines keep the theme defaults.
+        #   Unrecognized entries fall back to the default and log a browser
+        #   console warning. colors can also be set inside a per-page subsection
+        #   to override the chart-level list (useful when a page plots a
+        #   different number of lines, e.g. outTemp = min, max).
         #
         # Per-page overrides
         # -------------------------------------------------------------------------
@@ -537,6 +549,10 @@
         #         dewpoint = avg              # dewpoint → "Dew Point"  (no suffix for single col)
         #     [[[[year]]]]
         #         outTemp  = min, avg, max
+        #     colors    = 2, 1                 # active-palette slots, all pages
+        #     [[[[week]]]]
+        #         outTemp  = min, max
+        #         colors   = palette2:1, palette2:2, "#FD5D5D"
         [[[customChartOutTemp]]]
             title = Outdoor Temperature
             charttype = area
@@ -740,9 +756,16 @@
             # chart_interval can also be set directly inside [[[BatteryFields]]] per field.
             # Priority: FieldConfiguration > BatteryFields > default (300 seconds)
             #
+            # colors can set the chart line color for a field. Same forms as
+            # the custom chart colors option in [[Appearance]]: a bare number
+            # (active-palette slot), paletteN:M, a literal color, or default.
+            # Telemetry charts have a single line, so only the first entry of
+            # a list is used.
+            #
             # Example:
             #[[[[outTempBatteryStatus]]]]
             #    chart_interval = 300
+            #    colors = palette1:3
 
     # Charts
     # -------------------------------------------------------------------------

--- a/skins/neowx-material/telemetry.html.tmpl
+++ b/skins/neowx-material/telemetry.html.tmpl
@@ -645,6 +645,21 @@
                     #pass
                 #end try
 
+                ## Per-field chart line color: Extras.Telemetry.FieldConfiguration.<field>.colors
+                #set $tc_color_ref = ''
+                #try
+                    #set $_fc_colors = $getVar('Extras.Telemetry.FieldConfiguration.' + $name + '.colors', None)
+                    #if $_fc_colors is not None
+                        #if isinstance($_fc_colors, list)
+                            #set $tc_color_ref = str($_fc_colors[0]).strip().replace('"', '').replace('\\', '') if len($_fc_colors) > 0 else ''
+                        #else
+                            #set $tc_color_ref = str($_fc_colors).strip().replace('"', '').replace('\\', '')
+                        #end if
+                    #end if
+                #except
+                    #set $tc_color_ref = ''
+                #end try
+
                 // currentvalue: --> $chart_interval <--
 
                 new ApexCharts(document.querySelector('#$name-chart'), {
@@ -722,6 +737,9 @@
                             }
                         #end if
                     },
+                    #if $tc_color_ref
+                    colors: neowxChartColors(["$tc_color_ref"], 1, "$name"),
+                    #end if
                     series: [
                         {
                             name: "$getVar('obs.label.' + series)",

--- a/skins/neowx-material/week.html.tmpl
+++ b/skins/neowx-material/week.html.tmpl
@@ -738,10 +738,23 @@
 
             // Display wind vector chart
 
+            #set global $cc_name  = 'windvec'
+            #set global $cc_scope = ''
+            #include "chart_colors_setup.inc"
+            #set $sc_color_list = []
+            #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
+            #silent $sc_color_list.append($cc_color_refs[1] if len($cc_color_refs) > 1 else 'default')
             var windvecchart = document.querySelector('#windvecchart');
             if (windvecchart) {
                 new ApexCharts(windvecchart, {
                     ...graph_radar_config,
+                    #if len($cc_color_refs) > 0
+                    colors: neowxChartColors([
+                        #for $cref in $sc_color_list
+                        "$cref",
+                        #end for
+                    ], $len($sc_color_list), "windvec"),
+                    #end if
                     yaxis: {
                         labels: {
                             formatter: function (val) {

--- a/skins/neowx-material/week.html.tmpl
+++ b/skins/neowx-material/week.html.tmpl
@@ -808,7 +808,7 @@
                         ## Build cc_field_map without a generator (avoids Python 3 / Cheetah scope issue)
                         #set $cc_field_map = {}
                         #for $fk, $fv in $cc_page.items()
-                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format') and isinstance($fv, (str, list))
+                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style') and isinstance($fv, (str, list))
                                 #silent $cc_field_map[$fk] = $fv
                             #end if
                         #end for
@@ -879,6 +879,7 @@
                         #set global $cc_scope = 'week'
                         #include "chart_date_format.inc"
                         #include "chart_tick_setup.inc"
+                        #include "chart_colors_setup.inc"
 
                         ##
                         ## Render the chart JS
@@ -976,6 +977,8 @@
                                         ],
                                     #end if
                                     series: [
+                                        #set $cc_color_list = []
+                                        #set $cc_pos = 0
                                         #for $val, $cols in $cc_series_pairs
                                             #if $getVar('week.' + val + '.has_data')
                                                 #if len($cols) == 1
@@ -984,6 +987,8 @@
                                                         name: "$getVar('obs.label.' + val)",
                                                         data: [ $getChartData(val, cols[0]) ]
                                                     },
+                                                    #silent $cc_color_list.append($cc_color_refs[$cc_pos] if $cc_pos < len($cc_color_refs) else 'default')
+                                                    #set $cc_pos = $cc_pos + 1
                                                 #else
                                                     ## Multiple columns → append column label to series name
                                                     #for $col in $cols
@@ -991,11 +996,23 @@
                                                             name: "$getVar('obs.label.' + val) $gettext($col)",
                                                             data: [ $getChartData(val, col) ]
                                                         },
+                                                        #silent $cc_color_list.append($cc_color_refs[$cc_pos] if $cc_pos < len($cc_color_refs) else 'default')
+                                                        #set $cc_pos = $cc_pos + 1
                                                     #end for
                                                 #end if
+                                            #else
+                                                #set $cc_pos = $cc_pos + len($cols)
                                             #end if
                                         #end for
-                                    ]
+                                    ],
+                                    #if len($cc_color_refs) > 0 and len($cc_color_list) > 0
+                                        #set $cc_color_count = len($cc_color_list)
+                                        colors: neowxChartColors([
+                                        #for $cref in $cc_color_list
+                                            "$cref",
+                                        #end for
+                                        ], $cc_color_count, "$x"),
+                                    #end if
                                 }).render()
                             }
                         #end if

--- a/skins/neowx-material/week.html.tmpl
+++ b/skins/neowx-material/week.html.tmpl
@@ -1034,6 +1034,11 @@
                                             #end for
                                         ],
                                     #end if
+                                    #if len($axes_list) > 1
+                                    ## Multi-axis assigns each series an axis group, which makes ApexCharts
+                                    ## cluster the legend by axis (out of series order). Keep series order.
+                                    legend: { ...graph_${cc_type}_config.legend, clusterGroupedSeries: false },
+                                    #end if
                                     series: [
                                         #set $cc_color_list = []
                                         #set $cc_pos = 0

--- a/skins/neowx-material/week.html.tmpl
+++ b/skins/neowx-material/week.html.tmpl
@@ -519,7 +519,7 @@
                             #for $cref in $sc_color_list
                             "$cref",
                             #end for
-                        ], len($sc_color_list), "$name"),
+                        ], $len($sc_color_list), "$name"),
                         #end if
                         #if $pg_align_mid and $type != 'radar'
                             xaxis: {

--- a/skins/neowx-material/week.html.tmpl
+++ b/skins/neowx-material/week.html.tmpl
@@ -921,6 +921,27 @@
                                         },
                                     #else
                                         ## Multiple axes configuration
+                                        ## Build per-axis lists of the emitted series names so seriesName can be
+                                        ## an ARRAY. An array seriesName makes ApexCharts use its array-style axis
+                                        ## mapping, which avoids a crash in setSeriesYAxisMappings when a series'
+                                        ## index exceeds the y-axis count (e.g. >1 field on an axis, or >2 series).
+                                        #set $axis_series_names = {}
+                                        #for $asn_axis_id in $axes_list
+                                            #silent $axis_series_names[$asn_axis_id] = []
+                                        #end for
+                                        #for $asn_val, $asn_cols in $cc_series_pairs
+                                            #set $asn_axis = $axis_map.get($asn_val, $axes_list[0])
+                                            #if $asn_axis not in $axis_series_names
+                                                #set $asn_axis = $axes_list[0]
+                                            #end if
+                                            #if len($asn_cols) == 1
+                                                #silent $axis_series_names[$asn_axis].append($getVar('obs.label.' + $asn_val))
+                                            #else
+                                                #for $asn_col in $asn_cols
+                                                    #silent $axis_series_names[$asn_axis].append($getVar('obs.label.' + $asn_val) + ' ' + $gettext($asn_col))
+                                                #end for
+                                            #end if
+                                        #end for
                                         yaxis: [
                                             #for $axis_entry in enumerate($axes_list)
                                                 #set $idx = $axis_entry[0]
@@ -947,7 +968,15 @@
                                                 #set $axis_min = $axis_cfg.get('min', None)
                                                 #set $axis_max = $axis_cfg.get('max', None)
                                             {
-                                                seriesName: "$getVar('obs.label.' + $first_field)",
+                                                #set $asn_list = $axis_series_names.get($axis_id, [])
+                                                #if not $asn_list
+                                                    #set $asn_list = [$getVar('obs.label.' + $first_field)]
+                                                #end if
+                                                seriesName: [
+                                                    #for $asn in $asn_list
+                                                        "$asn",
+                                                    #end for
+                                                ],
                                                 #if $axis_title
                                                 title: {
                                                     text: "$axis_title",

--- a/skins/neowx-material/week.html.tmpl
+++ b/skins/neowx-material/week.html.tmpl
@@ -904,10 +904,39 @@
                                         #end if
                                     },
                                     #end if
-                                    #if $cc_tooltip_fmt
+                                    #if $cc_tooltip_fmt or len($axes_list) > 1
                                     tooltip: {
                                         ...graph_${cc_type}_config.tooltip,
-                                        x: { ...graph_${cc_type}_config.tooltip.x, formatter: neowxDateFormatter("$cc_tooltip_fmt") }
+                                        #if $cc_tooltip_fmt
+                                        x: { ...graph_${cc_type}_config.tooltip.x, formatter: neowxDateFormatter("$cc_tooltip_fmt") },
+                                        #end if
+                                        #if len($axes_list) > 1
+                                        ## Per-series tooltip unit formatter. ApexCharts picks the y-axis label
+                                        ## formatter by series index, which mismatches units on multi-axis charts
+                                        ## (e.g. >1 series per axis). Key the unit off the series name instead.
+                                        #set $series_field_by_name = {}
+                                        #for $ttf_val, $ttf_cols in $cc_series_pairs
+                                            #if len($ttf_cols) == 1
+                                                #silent $series_field_by_name[$getVar('obs.label.' + $ttf_val)] = $ttf_val
+                                            #else
+                                                #for $ttf_col in $ttf_cols
+                                                    #silent $series_field_by_name[$getVar('obs.label.' + $ttf_val) + ' ' + $gettext($ttf_col)] = $ttf_val
+                                                #end for
+                                            #end if
+                                        #end for
+                                        y: {
+                                            formatter: function (val, opts) {
+                                                var u = {
+                                                    #for $ttn, $ttf in $series_field_by_name.items()
+                                                    "$ttn": ["$getVar('unit.format.' + $ttf)", "$getVar('unit.label.' + $ttf)"],
+                                                    #end for
+                                                };
+                                                var s = opts.w.config.series[opts.seriesIndex];
+                                                var p = s ? u[s.name] : null;
+                                                return p ? (formatNumber(val, p[0]) + p[1]) : val;
+                                            }
+                                        },
+                                        #end if
                                     },
                                     #end if
                                     #if len($axes_list) <= 1

--- a/skins/neowx-material/week.html.tmpl
+++ b/skins/neowx-material/week.html.tmpl
@@ -493,11 +493,34 @@
 
             ## Only add JS chart code if in array
             #if $name in $Extras.Appearance.charts_order
+                #set global $cc_name  = $name
+                #set global $cc_scope = ''
+                #include "chart_colors_setup.inc"
 
                 var chartElement = document.querySelector('#$id');
                 if (chartElement) {
                     new ApexCharts(chartElement, {
                         ...graph_${type}_config,
+                        ## Per-series colors aligned to emitted series: series1 = slot 0; series2-8
+                        ## each advance a slot, appending a color only when the series has data.
+                        #set $sc_color_list = []
+                        #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
+                        #set $sc_pos = 1
+                        #for $sname in [$series2, $series3, $series4, $series5, $series6, $series7, $series8]
+                            #if $sname != ""
+                                #if $getVar('week.' + $sname + '.has_data')
+                                    #silent $sc_color_list.append($cc_color_refs[$sc_pos] if $sc_pos < len($cc_color_refs) else 'default')
+                                #end if
+                                #set $sc_pos = $sc_pos + 1
+                            #end if
+                        #end for
+                        #if len($cc_color_refs) > 0 and len($sc_color_list) > 0
+                        colors: neowxChartColors([
+                            #for $cref in $sc_color_list
+                            "$cref",
+                            #end for
+                        ], len($sc_color_list), "$name"),
+                        #end if
                         #if $pg_align_mid and $type != 'radar'
                             xaxis: {
                                 ...graph_${type}_config.xaxis,

--- a/skins/neowx-material/year-%Y.html.tmpl
+++ b/skins/neowx-material/year-%Y.html.tmpl
@@ -775,7 +775,7 @@
                 ## Build cc_series_pairs from field-name keys or values+column fallback
                 #set $cc_field_map = {}
                 #for $fk, $fv in $cc_page.items()
-                    #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format') and isinstance($fv, (str, list))
+                    #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style') and isinstance($fv, (str, list))
                         #silent $cc_field_map[$fk] = $fv
                     #end if
                 #end for
@@ -844,6 +844,7 @@
                 #set global $cc_scope = 'year'
                 #include "chart_date_format.inc"
                 #include "chart_tick_setup.inc"
+                #include "chart_colors_setup.inc"
 
                 ## Render chart JS
                 #if len($cc_series_pairs) > 0 and $x in $Extras.Appearance.charts_order
@@ -939,6 +940,8 @@
                                 ],
                             #end if
                             series: [
+                                #set $cc_color_list = []
+                                #set $cc_pos = 0
                                 #for $val, $cols in $cc_series_pairs
                                     #if $getVar('year.' + val + '.has_data')
                                         #if len($cols) == 1
@@ -946,17 +949,31 @@
                                                 name: "$getVar('obs.label.' + val)",
                                                 data: [ $getChartData(val, cols[0]) ]
                                             },
+                                            #silent $cc_color_list.append($cc_color_refs[$cc_pos] if $cc_pos < len($cc_color_refs) else 'default')
+                                            #set $cc_pos = $cc_pos + 1
                                         #else
                                             #for $col in $cols
                                                 {
                                                     name: "$getVar('obs.label.' + val) $gettext($col)",
                                                     data: [ $getChartData(val, col) ]
                                                 },
+                                                #silent $cc_color_list.append($cc_color_refs[$cc_pos] if $cc_pos < len($cc_color_refs) else 'default')
+                                                #set $cc_pos = $cc_pos + 1
                                             #end for
                                         #end if
+                                    #else
+                                        #set $cc_pos = $cc_pos + len($cols)
                                     #end if
                                 #end for
-                            ]
+                            ],
+                            #if len($cc_color_refs) > 0 and len($cc_color_list) > 0
+                                #set $cc_color_count = len($cc_color_list)
+                                colors: neowxChartColors([
+                                #for $cref in $cc_color_list
+                                    "$cref",
+                                #end for
+                                ], $cc_color_count, "$x"),
+                            #end if
                         }).render()
                     }
                 #end if

--- a/skins/neowx-material/year-%Y.html.tmpl
+++ b/skins/neowx-material/year-%Y.html.tmpl
@@ -867,10 +867,39 @@
                                 #end if
                             },
                             #end if
-                            #if $cc_tooltip_fmt
+                            #if $cc_tooltip_fmt or len($axes_list) > 1
                             tooltip: {
                                 ...graph_${cc_type}_config.tooltip,
-                                x: { ...graph_${cc_type}_config.tooltip.x, formatter: neowxDateFormatter("$cc_tooltip_fmt") }
+                                #if $cc_tooltip_fmt
+                                x: { ...graph_${cc_type}_config.tooltip.x, formatter: neowxDateFormatter("$cc_tooltip_fmt") },
+                                #end if
+                                #if len($axes_list) > 1
+                                ## Per-series tooltip unit formatter. ApexCharts picks the y-axis label
+                                ## formatter by series index, which mismatches units on multi-axis charts
+                                ## (e.g. >1 series per axis). Key the unit off the series name instead.
+                                #set $series_field_by_name = {}
+                                #for $ttf_val, $ttf_cols in $cc_series_pairs
+                                    #if len($ttf_cols) == 1
+                                        #silent $series_field_by_name[$getVar('obs.label.' + $ttf_val)] = $ttf_val
+                                    #else
+                                        #for $ttf_col in $ttf_cols
+                                            #silent $series_field_by_name[$getVar('obs.label.' + $ttf_val) + ' ' + $gettext($ttf_col)] = $ttf_val
+                                        #end for
+                                    #end if
+                                #end for
+                                y: {
+                                    formatter: function (val, opts) {
+                                        var u = {
+                                            #for $ttn, $ttf in $series_field_by_name.items()
+                                            "$ttn": ["$getVar('unit.format.' + $ttf)", "$getVar('unit.label.' + $ttf)"],
+                                            #end for
+                                        };
+                                        var s = opts.w.config.series[opts.seriesIndex];
+                                        var p = s ? u[s.name] : null;
+                                        return p ? (formatNumber(val, p[0]) + p[1]) : val;
+                                    }
+                                },
+                                #end if
                             },
                             #end if
                             #if len($axes_list) <= 1

--- a/skins/neowx-material/year-%Y.html.tmpl
+++ b/skins/neowx-material/year-%Y.html.tmpl
@@ -757,10 +757,23 @@
         avg_values.push(vector_data[item]['amt'] > 0 ? vector_data[item]['sum'] / vector_data[item]['amt'] : 0);
         max_values.push(vector_data[item]['max']);
     });
+    #set global $cc_name  = 'windvec'
+    #set global $cc_scope = ''
+    #include "chart_colors_setup.inc"
+    #set $sc_color_list = []
+    #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
+    #silent $sc_color_list.append($cc_color_refs[1] if len($cc_color_refs) > 1 else 'default')
     var windvecchart = document.querySelector('#windvecchart');
     if (windvecchart) {
         new ApexCharts(windvecchart, {
             ...graph_radar_config,
+            #if len($cc_color_refs) > 0
+            colors: neowxChartColors([
+                #for $cref in $sc_color_list
+                "$cref",
+                #end for
+            ], $len($sc_color_list), "windvec"),
+            #end if
             yaxis: { labels: { formatter: function (val) { return formatNumber(val, "$unit.format.windSpeed") + "$unit.label.windSpeed"; } } },
             series: [
                 { name: "$obs.label.windSpeed", data: avg_values },

--- a/skins/neowx-material/year-%Y.html.tmpl
+++ b/skins/neowx-material/year-%Y.html.tmpl
@@ -997,6 +997,11 @@
                                     #end for
                                 ],
                             #end if
+                            #if len($axes_list) > 1
+                            ## Multi-axis assigns each series an axis group, which makes ApexCharts
+                            ## cluster the legend by axis (out of series order). Keep series order.
+                            legend: { ...graph_${cc_type}_config.legend, clusterGroupedSeries: false },
+                            #end if
                             series: [
                                 #set $cc_color_list = []
                                 #set $cc_pos = 0

--- a/skins/neowx-material/year-%Y.html.tmpl
+++ b/skins/neowx-material/year-%Y.html.tmpl
@@ -539,7 +539,7 @@
                         #for $cref in $sc_color_list
                         "$cref",
                         #end for
-                    ], len($sc_color_list), "$name"),
+                    ], $len($sc_color_list), "$name"),
                     #end if
                     #if $pg_align_mid and $type != 'radar'
                         xaxis: {
@@ -612,7 +612,7 @@
                         #for $cref in $sc_color_list
                         "$cref",
                         #end for
-                    ], len($sc_color_list), "$name"),
+                    ], $len($sc_color_list), "$name"),
                     #end if
                     #if $pg_align_mid and $type != 'radar'
                         xaxis: {

--- a/skins/neowx-material/year-%Y.html.tmpl
+++ b/skins/neowx-material/year-%Y.html.tmpl
@@ -509,6 +509,9 @@
 #def getChartJsCode($name, $id, $type, $series1, $series2 = "", $column = "avg", $series3 = "", $series4 = "", $series5 = "", $series6 = "", $series7 = "", $series8 = "")
 
     #if $name in $Extras.Appearance.charts_order
+        #set global $cc_name  = $name
+        #set global $cc_scope = ''
+        #include "chart_colors_setup.inc"
 
         #if $name == "outTemp"
 
@@ -516,6 +519,28 @@
             if (chartElement) {
                 new ApexCharts(chartElement, {
                     ...graph_${type}_config,
+                    ## Per-series colors aligned to emitted series: outTemp renders min + max,
+                    ## so series1 takes slots 0 and 1; series2-8 each advance a slot, appending
+                    ## a color only when the series has data.
+                    #set $sc_color_list = []
+                    #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
+                    #silent $sc_color_list.append($cc_color_refs[1] if len($cc_color_refs) > 1 else 'default')
+                    #set $sc_pos = 2
+                    #for $sname in [$series2, $series3, $series4, $series5, $series6, $series7, $series8]
+                        #if $sname != ""
+                            #if $getVar('year.' + $sname + '.has_data')
+                                #silent $sc_color_list.append($cc_color_refs[$sc_pos] if $sc_pos < len($cc_color_refs) else 'default')
+                            #end if
+                            #set $sc_pos = $sc_pos + 1
+                        #end if
+                    #end for
+                    #if len($cc_color_refs) > 0 and len($sc_color_list) > 0
+                    colors: neowxChartColors([
+                        #for $cref in $sc_color_list
+                        "$cref",
+                        #end for
+                    ], len($sc_color_list), "$name"),
+                    #end if
                     #if $pg_align_mid and $type != 'radar'
                         xaxis: {
                             ...graph_${type}_config.xaxis,
@@ -569,6 +594,26 @@
             if (chartElement) {
                 new ApexCharts(chartElement, {
                     ...graph_${type}_config,
+                    ## Per-series colors aligned to emitted series: series1 = slot 0; series2-8
+                    ## each advance a slot, appending a color only when the series has data.
+                    #set $sc_color_list = []
+                    #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
+                    #set $sc_pos = 1
+                    #for $sname in [$series2, $series3, $series4, $series5, $series6, $series7, $series8]
+                        #if $sname != ""
+                            #if $getVar('year.' + $sname + '.has_data')
+                                #silent $sc_color_list.append($cc_color_refs[$sc_pos] if $sc_pos < len($cc_color_refs) else 'default')
+                            #end if
+                            #set $sc_pos = $sc_pos + 1
+                        #end if
+                    #end for
+                    #if len($cc_color_refs) > 0 and len($sc_color_list) > 0
+                    colors: neowxChartColors([
+                        #for $cref in $sc_color_list
+                        "$cref",
+                        #end for
+                    ], len($sc_color_list), "$name"),
+                    #end if
                     #if $pg_align_mid and $type != 'radar'
                         xaxis: {
                             ...graph_${type}_config.xaxis,

--- a/skins/neowx-material/year-%Y.html.tmpl
+++ b/skins/neowx-material/year-%Y.html.tmpl
@@ -884,6 +884,27 @@
                                 },
                             #else
                                 ## Multiple axes configuration
+                                ## Build per-axis lists of the emitted series names so seriesName can be
+                                ## an ARRAY. An array seriesName makes ApexCharts use its array-style axis
+                                ## mapping, which avoids a crash in setSeriesYAxisMappings when a series'
+                                ## index exceeds the y-axis count (e.g. >1 field on an axis, or >2 series).
+                                #set $axis_series_names = {}
+                                #for $asn_axis_id in $axes_list
+                                    #silent $axis_series_names[$asn_axis_id] = []
+                                #end for
+                                #for $asn_val, $asn_cols in $cc_series_pairs
+                                    #set $asn_axis = $axis_map.get($asn_val, $axes_list[0])
+                                    #if $asn_axis not in $axis_series_names
+                                        #set $asn_axis = $axes_list[0]
+                                    #end if
+                                    #if len($asn_cols) == 1
+                                        #silent $axis_series_names[$asn_axis].append($getVar('obs.label.' + $asn_val))
+                                    #else
+                                        #for $asn_col in $asn_cols
+                                            #silent $axis_series_names[$asn_axis].append($getVar('obs.label.' + $asn_val) + ' ' + $gettext($asn_col))
+                                        #end for
+                                    #end if
+                                #end for
                                 yaxis: [
                                     #for $axis_entry in enumerate($axes_list)
                                         #set $idx = $axis_entry[0]
@@ -910,7 +931,15 @@
                                         #set $axis_min = $axis_cfg.get('min', None)
                                         #set $axis_max = $axis_cfg.get('max', None)
                                     {
-                                        seriesName: "$getVar('obs.label.' + $first_field)",
+                                        #set $asn_list = $axis_series_names.get($axis_id, [])
+                                        #if not $asn_list
+                                            #set $asn_list = [$getVar('obs.label.' + $first_field)]
+                                        #end if
+                                        seriesName: [
+                                            #for $asn in $asn_list
+                                                "$asn",
+                                            #end for
+                                        ],
                                         #if $axis_title
                                         title: {
                                             text: "$axis_title",

--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -730,7 +730,7 @@
                         ## Build cc_field_map without a generator (avoids Python 3 / Cheetah scope issue)
                         #set $cc_field_map = {}
                         #for $fk, $fv in $cc_page.items()
-                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format') and isinstance($fv, (str, list))
+                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style') and isinstance($fv, (str, list))
                                 #silent $cc_field_map[$fk] = $fv
                             #end if
                         #end for
@@ -801,6 +801,7 @@
                         #set global $cc_scope = 'year'
                         #include "chart_date_format.inc"
                         #include "chart_tick_setup.inc"
+                        #include "chart_colors_setup.inc"
 
                         ##
                         ## Render the chart JS
@@ -898,6 +899,8 @@
                                         ],
                                     #end if
                                     series: [
+                                        #set $cc_color_list = []
+                                        #set $cc_pos = 0
                                         #for $val, $cols in $cc_series_pairs
                                             #if $getVar('year.' + val + '.has_data')
                                                 #if len($cols) == 1
@@ -906,6 +909,8 @@
                                                         name: "$getVar('obs.label.' + val)",
                                                         data: [ $getChartData(val, cols[0]) ]
                                                     },
+                                                    #silent $cc_color_list.append($cc_color_refs[$cc_pos] if $cc_pos < len($cc_color_refs) else 'default')
+                                                    #set $cc_pos = $cc_pos + 1
                                                 #else
                                                     ## Multiple columns → append column label to series name
                                                     #for $col in $cols
@@ -913,11 +918,23 @@
                                                             name: "$getVar('obs.label.' + val) $gettext($col)",
                                                             data: [ $getChartData(val, col) ]
                                                         },
+                                                        #silent $cc_color_list.append($cc_color_refs[$cc_pos] if $cc_pos < len($cc_color_refs) else 'default')
+                                                        #set $cc_pos = $cc_pos + 1
                                                     #end for
                                                 #end if
+                                            #else
+                                                #set $cc_pos = $cc_pos + len($cols)
                                             #end if
                                         #end for
-                                    ]
+                                    ],
+                                    #if len($cc_color_refs) > 0 and len($cc_color_list) > 0
+                                        #set $cc_color_count = len($cc_color_list)
+                                        colors: neowxChartColors([
+                                        #for $cref in $cc_color_list
+                                            "$cref",
+                                        #end for
+                                        ], $cc_color_count, "$x"),
+                                    #end if
                                 }).render()
                             }
                         #end if

--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -497,7 +497,7 @@
                                 #for $cref in $sc_color_list
                                 "$cref",
                                 #end for
-                            ], len($sc_color_list), "$name"),
+                            ], $len($sc_color_list), "$name"),
                             #end if
                             #if $pg_align_mid and $type != 'radar'
                                 xaxis: {
@@ -570,7 +570,7 @@
                                 #for $cref in $sc_color_list
                                 "$cref",
                                 #end for
-                            ], len($sc_color_list), "$name"),
+                            ], $len($sc_color_list), "$name"),
                             #end if
                             #if $pg_align_mid and $type != 'radar'
                                 xaxis: {

--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -956,6 +956,11 @@
                                             #end for
                                         ],
                                     #end if
+                                    #if len($axes_list) > 1
+                                    ## Multi-axis assigns each series an axis group, which makes ApexCharts
+                                    ## cluster the legend by axis (out of series order). Keep series order.
+                                    legend: { ...graph_${cc_type}_config.legend, clusterGroupedSeries: false },
+                                    #end if
                                     series: [
                                         #set $cc_color_list = []
                                         #set $cc_pos = 0

--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -708,10 +708,23 @@
                 avg_values.push(vector_data[item]['amt'] > 0 ? vector_data[item]['sum'] / vector_data[item]['amt'] : 0);
                 max_values.push(vector_data[item]['max']);
             });
+            #set global $cc_name  = 'windvec'
+            #set global $cc_scope = ''
+            #include "chart_colors_setup.inc"
+            #set $sc_color_list = []
+            #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
+            #silent $sc_color_list.append($cc_color_refs[1] if len($cc_color_refs) > 1 else 'default')
             var windvecchart = document.querySelector('#windvecchart');
             if (windvecchart) {
                 new ApexCharts(windvecchart, {
                     ...graph_radar_config,
+                    #if len($cc_color_refs) > 0
+                    colors: neowxChartColors([
+                        #for $cref in $sc_color_list
+                        "$cref",
+                        #end for
+                    ], $len($sc_color_list), "windvec"),
+                    #end if
                     yaxis: { labels: { formatter: function (val) { return formatNumber(val, "$unit.format.windSpeed") + "$unit.label.windSpeed"; } } },
                     series: [
                         { name: "$obs.label.windSpeed", data: avg_values },

--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -467,6 +467,9 @@
         #def getChartJsCode($name, $id, $type, $series1, $series2 = "", $column = "avg", $series3 = "", $series4 = "", $series5 = "", $series6 = "", $series7 = "", $series8 = "")
 
             #if $name in $Extras.Appearance.charts_order
+                #set global $cc_name  = $name
+                #set global $cc_scope = ''
+                #include "chart_colors_setup.inc"
 
                 #if $name == "outTemp"
 
@@ -474,6 +477,28 @@
                     if (chartElement) {
                         new ApexCharts(chartElement, {
                             ...graph_${type}_config,
+                            ## Per-series colors aligned to emitted series: outTemp renders min + max,
+                            ## so series1 takes slots 0 and 1; series2-8 each advance a slot, appending
+                            ## a color only when the series has data.
+                            #set $sc_color_list = []
+                            #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
+                            #silent $sc_color_list.append($cc_color_refs[1] if len($cc_color_refs) > 1 else 'default')
+                            #set $sc_pos = 2
+                            #for $sname in [$series2, $series3, $series4, $series5, $series6, $series7, $series8]
+                                #if $sname != ""
+                                    #if $getVar('year.' + $sname + '.has_data')
+                                        #silent $sc_color_list.append($cc_color_refs[$sc_pos] if $sc_pos < len($cc_color_refs) else 'default')
+                                    #end if
+                                    #set $sc_pos = $sc_pos + 1
+                                #end if
+                            #end for
+                            #if len($cc_color_refs) > 0 and len($sc_color_list) > 0
+                            colors: neowxChartColors([
+                                #for $cref in $sc_color_list
+                                "$cref",
+                                #end for
+                            ], len($sc_color_list), "$name"),
+                            #end if
                             #if $pg_align_mid and $type != 'radar'
                                 xaxis: {
                                     ...graph_${type}_config.xaxis,
@@ -527,6 +552,26 @@
                     if (chartElement) {
                         new ApexCharts(chartElement, {
                             ...graph_${type}_config,
+                            ## Per-series colors aligned to emitted series: series1 = slot 0; series2-8
+                            ## each advance a slot, appending a color only when the series has data.
+                            #set $sc_color_list = []
+                            #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
+                            #set $sc_pos = 1
+                            #for $sname in [$series2, $series3, $series4, $series5, $series6, $series7, $series8]
+                                #if $sname != ""
+                                    #if $getVar('year.' + $sname + '.has_data')
+                                        #silent $sc_color_list.append($cc_color_refs[$sc_pos] if $sc_pos < len($cc_color_refs) else 'default')
+                                    #end if
+                                    #set $sc_pos = $sc_pos + 1
+                                #end if
+                            #end for
+                            #if len($cc_color_refs) > 0 and len($sc_color_list) > 0
+                            colors: neowxChartColors([
+                                #for $cref in $sc_color_list
+                                "$cref",
+                                #end for
+                            ], len($sc_color_list), "$name"),
+                            #end if
                             #if $pg_align_mid and $type != 'radar'
                                 xaxis: {
                                     ...graph_${type}_config.xaxis,

--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -843,6 +843,27 @@
                                         },
                                     #else
                                         ## Multiple axes configuration
+                                        ## Build per-axis lists of the emitted series names so seriesName can be
+                                        ## an ARRAY. An array seriesName makes ApexCharts use its array-style axis
+                                        ## mapping, which avoids a crash in setSeriesYAxisMappings when a series'
+                                        ## index exceeds the y-axis count (e.g. >1 field on an axis, or >2 series).
+                                        #set $axis_series_names = {}
+                                        #for $asn_axis_id in $axes_list
+                                            #silent $axis_series_names[$asn_axis_id] = []
+                                        #end for
+                                        #for $asn_val, $asn_cols in $cc_series_pairs
+                                            #set $asn_axis = $axis_map.get($asn_val, $axes_list[0])
+                                            #if $asn_axis not in $axis_series_names
+                                                #set $asn_axis = $axes_list[0]
+                                            #end if
+                                            #if len($asn_cols) == 1
+                                                #silent $axis_series_names[$asn_axis].append($getVar('obs.label.' + $asn_val))
+                                            #else
+                                                #for $asn_col in $asn_cols
+                                                    #silent $axis_series_names[$asn_axis].append($getVar('obs.label.' + $asn_val) + ' ' + $gettext($asn_col))
+                                                #end for
+                                            #end if
+                                        #end for
                                         yaxis: [
                                             #for $axis_entry in enumerate($axes_list)
                                                 #set $idx = $axis_entry[0]
@@ -869,7 +890,15 @@
                                                 #set $axis_min = $axis_cfg.get('min', None)
                                                 #set $axis_max = $axis_cfg.get('max', None)
                                             {
-                                                seriesName: "$getVar('obs.label.' + $first_field)",
+                                                #set $asn_list = $axis_series_names.get($axis_id, [])
+                                                #if not $asn_list
+                                                    #set $asn_list = [$getVar('obs.label.' + $first_field)]
+                                                #end if
+                                                seriesName: [
+                                                    #for $asn in $asn_list
+                                                        "$asn",
+                                                    #end for
+                                                ],
                                                 #if $axis_title
                                                 title: {
                                                     text: "$axis_title",

--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -826,10 +826,39 @@
                                         #end if
                                     },
                                     #end if
-                                    #if $cc_tooltip_fmt
+                                    #if $cc_tooltip_fmt or len($axes_list) > 1
                                     tooltip: {
                                         ...graph_${cc_type}_config.tooltip,
-                                        x: { ...graph_${cc_type}_config.tooltip.x, formatter: neowxDateFormatter("$cc_tooltip_fmt") }
+                                        #if $cc_tooltip_fmt
+                                        x: { ...graph_${cc_type}_config.tooltip.x, formatter: neowxDateFormatter("$cc_tooltip_fmt") },
+                                        #end if
+                                        #if len($axes_list) > 1
+                                        ## Per-series tooltip unit formatter. ApexCharts picks the y-axis label
+                                        ## formatter by series index, which mismatches units on multi-axis charts
+                                        ## (e.g. >1 series per axis). Key the unit off the series name instead.
+                                        #set $series_field_by_name = {}
+                                        #for $ttf_val, $ttf_cols in $cc_series_pairs
+                                            #if len($ttf_cols) == 1
+                                                #silent $series_field_by_name[$getVar('obs.label.' + $ttf_val)] = $ttf_val
+                                            #else
+                                                #for $ttf_col in $ttf_cols
+                                                    #silent $series_field_by_name[$getVar('obs.label.' + $ttf_val) + ' ' + $gettext($ttf_col)] = $ttf_val
+                                                #end for
+                                            #end if
+                                        #end for
+                                        y: {
+                                            formatter: function (val, opts) {
+                                                var u = {
+                                                    #for $ttn, $ttf in $series_field_by_name.items()
+                                                    "$ttn": ["$getVar('unit.format.' + $ttf)", "$getVar('unit.label.' + $ttf)"],
+                                                    #end for
+                                                };
+                                                var s = opts.w.config.series[opts.seriesIndex];
+                                                var p = s ? u[s.name] : null;
+                                                return p ? (formatNumber(val, p[0]) + p[1]) : val;
+                                            }
+                                        },
+                                        #end if
                                     },
                                     #end if
                                     #if len($axes_list) <= 1

--- a/skins/neowx-material/yesterday.html.tmpl
+++ b/skins/neowx-material/yesterday.html.tmpl
@@ -945,10 +945,39 @@
                                         #end if
                                     },
                                     #end if
-                                    #if $cc_tooltip_fmt
+                                    #if $cc_tooltip_fmt or len($axes_list) > 1
                                     tooltip: {
                                         ...graph_${cc_type}_config.tooltip,
-                                        x: { ...graph_${cc_type}_config.tooltip.x, formatter: neowxDateFormatter("$cc_tooltip_fmt") }
+                                        #if $cc_tooltip_fmt
+                                        x: { ...graph_${cc_type}_config.tooltip.x, formatter: neowxDateFormatter("$cc_tooltip_fmt") },
+                                        #end if
+                                        #if len($axes_list) > 1
+                                        ## Per-series tooltip unit formatter. ApexCharts picks the y-axis label
+                                        ## formatter by series index, which mismatches units on multi-axis charts
+                                        ## (e.g. >1 series per axis). Key the unit off the series name instead.
+                                        #set $series_field_by_name = {}
+                                        #for $ttf_val, $ttf_cols in $cc_series_pairs
+                                            #if len($ttf_cols) == 1
+                                                #silent $series_field_by_name[$getVar('obs.label.' + $ttf_val)] = $ttf_val
+                                            #else
+                                                #for $ttf_col in $ttf_cols
+                                                    #silent $series_field_by_name[$getVar('obs.label.' + $ttf_val) + ' ' + $gettext($ttf_col)] = $ttf_val
+                                                #end for
+                                            #end if
+                                        #end for
+                                        y: {
+                                            formatter: function (val, opts) {
+                                                var u = {
+                                                    #for $ttn, $ttf in $series_field_by_name.items()
+                                                    "$ttn": ["$getVar('unit.format.' + $ttf)", "$getVar('unit.label.' + $ttf)"],
+                                                    #end for
+                                                };
+                                                var s = opts.w.config.series[opts.seriesIndex];
+                                                var p = s ? u[s.name] : null;
+                                                return p ? (formatNumber(val, p[0]) + p[1]) : val;
+                                            }
+                                        },
+                                        #end if
                                     },
                                     #end if
                                     #if len($axes_list) <= 1

--- a/skins/neowx-material/yesterday.html.tmpl
+++ b/skins/neowx-material/yesterday.html.tmpl
@@ -556,7 +556,7 @@
                             #for $cref in $sc_color_list
                             "$cref",
                             #end for
-                        ], len($sc_color_list), "$name"),
+                        ], $len($sc_color_list), "$name"),
                         #end if
                         #if $pg_align_mid and $type != 'radar'
                             xaxis: {

--- a/skins/neowx-material/yesterday.html.tmpl
+++ b/skins/neowx-material/yesterday.html.tmpl
@@ -858,7 +858,7 @@
                         ## Build cc_field_map without a generator (avoids Python 3 / Cheetah scope issue)
                         #set $cc_field_map = {}
                         #for $fk, $fv in $cc_page.items()
-                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format') and isinstance($fv, (str, list))
+                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style') and isinstance($fv, (str, list))
                                 #silent $cc_field_map[$fk] = $fv
                             #end if
                         #end for
@@ -927,6 +927,7 @@
                         #set global $cc_scope = 'yesterday'
                         #include "chart_date_format.inc"
                         #include "chart_tick_setup.inc"
+                        #include "chart_colors_setup.inc"
 
                         ## Render chart JS
                         #if len($cc_series_pairs) > 0 and $x in $Extras.Appearance.charts_order
@@ -1017,6 +1018,8 @@
                                         ],
                                     #end if
                                     series: [
+                                        #set $cc_color_list = []
+                                        #set $cc_pos = 0
                                         #for $val, $cols in $cc_series_pairs
                                             #if $getVar('yesterday.' + val + '.has_data')
                                                 #if len($cols) == 1
@@ -1024,17 +1027,31 @@
                                                         name: "$getVar('obs.label.' + val)",
                                                         data: [ $getChartData(val, cols[0]) ].slice(0, $number_of_records)
                                                     },
+                                                    #silent $cc_color_list.append($cc_color_refs[$cc_pos] if $cc_pos < len($cc_color_refs) else 'default')
+                                                    #set $cc_pos = $cc_pos + 1
                                                 #else
                                                     #for $col in $cols
                                                         {
                                                             name: "$getVar('obs.label.' + val) $gettext($col)",
                                                             data: [ $getChartData(val, col) ].slice(0, $number_of_records)
                                                         },
+                                                        #silent $cc_color_list.append($cc_color_refs[$cc_pos] if $cc_pos < len($cc_color_refs) else 'default')
+                                                        #set $cc_pos = $cc_pos + 1
                                                     #end for
                                                 #end if
+                                            #else
+                                                #set $cc_pos = $cc_pos + len($cols)
                                             #end if
                                         #end for
-                                    ]
+                                    ],
+                                    #if len($cc_color_refs) > 0 and len($cc_color_list) > 0
+                                        #set $cc_color_count = len($cc_color_list)
+                                        colors: neowxChartColors([
+                                        #for $cref in $cc_color_list
+                                            "$cref",
+                                        #end for
+                                        ], $cc_color_count, "$x"),
+                                    #end if
                                 }).render()
                             }
                         #end if

--- a/skins/neowx-material/yesterday.html.tmpl
+++ b/skins/neowx-material/yesterday.html.tmpl
@@ -802,10 +802,23 @@
 
             // Display wind vector chart
 
+            #set global $cc_name  = 'windvec'
+            #set global $cc_scope = ''
+            #include "chart_colors_setup.inc"
+            #set $sc_color_list = []
+            #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
+            #silent $sc_color_list.append($cc_color_refs[1] if len($cc_color_refs) > 1 else 'default')
             var windvecchart = document.querySelector('#windvecchart');
             if (windvecchart) {
                 new ApexCharts(windvecchart, {
                     ...graph_radar_config,
+                    #if len($cc_color_refs) > 0
+                    colors: neowxChartColors([
+                        #for $cref in $sc_color_list
+                        "$cref",
+                        #end for
+                    ], $len($sc_color_list), "windvec"),
+                    #end if
                     yaxis: {
                         labels: {
                             formatter: function (val) {

--- a/skins/neowx-material/yesterday.html.tmpl
+++ b/skins/neowx-material/yesterday.html.tmpl
@@ -1075,6 +1075,11 @@
                                             #end for
                                         ],
                                     #end if
+                                    #if len($axes_list) > 1
+                                    ## Multi-axis assigns each series an axis group, which makes ApexCharts
+                                    ## cluster the legend by axis (out of series order). Keep series order.
+                                    legend: { ...graph_${cc_type}_config.legend, clusterGroupedSeries: false },
+                                    #end if
                                     series: [
                                         #set $cc_color_list = []
                                         #set $cc_pos = 0

--- a/skins/neowx-material/yesterday.html.tmpl
+++ b/skins/neowx-material/yesterday.html.tmpl
@@ -962,6 +962,27 @@
                                         },
                                     #else
                                         ## Multiple axes configuration
+                                        ## Build per-axis lists of the emitted series names so seriesName can be
+                                        ## an ARRAY. An array seriesName makes ApexCharts use its array-style axis
+                                        ## mapping, which avoids a crash in setSeriesYAxisMappings when a series'
+                                        ## index exceeds the y-axis count (e.g. >1 field on an axis, or >2 series).
+                                        #set $axis_series_names = {}
+                                        #for $asn_axis_id in $axes_list
+                                            #silent $axis_series_names[$asn_axis_id] = []
+                                        #end for
+                                        #for $asn_val, $asn_cols in $cc_series_pairs
+                                            #set $asn_axis = $axis_map.get($asn_val, $axes_list[0])
+                                            #if $asn_axis not in $axis_series_names
+                                                #set $asn_axis = $axes_list[0]
+                                            #end if
+                                            #if len($asn_cols) == 1
+                                                #silent $axis_series_names[$asn_axis].append($getVar('obs.label.' + $asn_val))
+                                            #else
+                                                #for $asn_col in $asn_cols
+                                                    #silent $axis_series_names[$asn_axis].append($getVar('obs.label.' + $asn_val) + ' ' + $gettext($asn_col))
+                                                #end for
+                                            #end if
+                                        #end for
                                         yaxis: [
                                             #for $axis_entry in enumerate($axes_list)
                                                 #set $idx = $axis_entry[0]
@@ -988,7 +1009,15 @@
                                                 #set $axis_min = $axis_cfg.get('min', None)
                                                 #set $axis_max = $axis_cfg.get('max', None)
                                             {
-                                                seriesName: "$getVar('obs.label.' + $first_field)",
+                                                #set $asn_list = $axis_series_names.get($axis_id, [])
+                                                #if not $asn_list
+                                                    #set $asn_list = [$getVar('obs.label.' + $first_field)]
+                                                #end if
+                                                seriesName: [
+                                                    #for $asn in $asn_list
+                                                        "$asn",
+                                                    #end for
+                                                ],
                                                 #if $axis_title
                                                 title: {
                                                     text: "$axis_title",

--- a/skins/neowx-material/yesterday.html.tmpl
+++ b/skins/neowx-material/yesterday.html.tmpl
@@ -490,6 +490,9 @@
 
             ## Only add JS chart code if in array
             #if $name in $Extras.Appearance.charts_order
+                #set global $cc_name  = $name
+                #set global $cc_scope = ''
+                #include "chart_colors_setup.inc"
 
                 ## Get chart data and slice it (only first half of last 48 hours)
 
@@ -535,6 +538,26 @@
                 if (chartElement) {
                     new ApexCharts(chartElement, {
                         ...graph_${type}_config,
+                        ## Per-series colors aligned to emitted series: series1 = slot 0; series2-8
+                        ## each advance a slot, appending a color only when the series has data.
+                        #set $sc_color_list = []
+                        #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
+                        #set $sc_pos = 1
+                        #for $sname in [$series2, $series3, $series4, $series5, $series6, $series7, $series8]
+                            #if $sname != ""
+                                #if $getVar('yesterday.' + $sname + '.has_data')
+                                    #silent $sc_color_list.append($cc_color_refs[$sc_pos] if $sc_pos < len($cc_color_refs) else 'default')
+                                #end if
+                                #set $sc_pos = $sc_pos + 1
+                            #end if
+                        #end for
+                        #if len($cc_color_refs) > 0 and len($sc_color_list) > 0
+                        colors: neowxChartColors([
+                            #for $cref in $sc_color_list
+                            "$cref",
+                            #end for
+                        ], len($sc_color_list), "$name"),
+                        #end if
                         #if $pg_align_mid and $type != 'radar'
                             xaxis: {
                                 ...graph_${type}_config.xaxis,


### PR DESCRIPTION
This started as "let me set a custom color on a chart line" and grew a bit from there — it now lets you color the lines on basically every chart in the skin, and along the way it fixes a few multi-axis bugs that were already lurking.

## Setting colors

Add a `colors` key wherever you configure a chart. Each value can be:

- a palette slot number like `2` (the Nth color of whatever `[[Charts]] palette` you're using),
- an explicit `paletteN:M` if you want a specific built-in palette color,
- a literal color — `"#f08080"` (quote the hex, or the `#` starts a comment) or a CSS name like `steelblue`,
- or `default` to leave that line on the theme color.

You can mix those in one list, and the colors line up with the chart's lines in legend order. Give fewer colors than there are lines and the rest just stay default; typo a value and that line falls back to default and logs a warning in the browser console. If you don't set `colors` at all, nothing changes — the chart renders exactly like it does today.

This works for:

- **Custom charts** — `colors` on a `customChart*` block, and you can override it per page (`[[[[week]]]]`, etc.). Missing-data series are handled, so if a sensor drops out the remaining lines keep their colors instead of shifting.
- **Built-in charts** — just add a block named after the chart, e.g. `[[[outTemp]]]` or `[[[windSpeed]]]`. `outTemp` is drawn as a min/max pair on the month/year pages, so it takes two colors there and one on the day/week pages.
- **Telemetry charts** — a single color per field under `[[Telemetry]] [[[FieldConfiguration]]]`.
- **The wind vector chart** — `[[[windvec]]] colors = speed, gust`.

## Multi-axis fixes

Testing colors on a two-axis custom chart turned up three pre-existing problems with the multi-axis path, all fixed here:

- Multi-axis charts could render completely blank — ApexCharts throws in `setSeriesYAxisMappings` when a series sits at an index past the axis count. Emitting `seriesName` as an array avoids it.
- Tooltips showed the wrong units (e.g. a temperature reading labelled `%`) because ApexCharts picks the tooltip formatter by series index rather than by axis. Now each series gets its own `tooltip.y` formatter keyed by name.
- The legend came out in a scrambled order once series were grouped by axis; `clusterGroupedSeries: false` keeps it in series order.

## Under the hood

Color references are resolved in the browser by a small `neowxChartColors` helper in js.inc, and the config-reading is shared through `chart_colors_setup.inc` (registered in install.py). I also documented the per-axis `min`/`max`/`decimals` options in `[[[[yaxis_config]]]]` — those already worked but weren't written down anywhere.

## Worth checking before merge

Regenerate the reports and spot-check that colors take effect on each chart type across the day/week/month/year pages, that an un-configured chart looks unchanged, and that the multi-axis charts come up with correct tooltips and legend order (and no `ReferenceError` in the console).

🤖 Generated with [Claude Code](https://claude.com/claude-code)