### PR TITLE
Add translated strings for trends.

### DIFF
--- a/docs/TREND-INDICATORS.md
+++ b/docs/TREND-INDICATORS.md
@@ -33,7 +33,7 @@ Two settings under `[[Appearance]]` in `skin.conf` control everything:
 
 **Result:** each observation listed in `show_trend_on` shows a ↗ / → / ↘ arrow (and,
 for the barometer in `multi`/`davis`, a graded tendency) with a tooltip such as
-`Slowly Rising: +0.009 inHg (over 3 h)`.
+`Rising Slowly: +0.009 inHg (over 3 h)`.
 
 ## How a trend is calculated
 
@@ -72,7 +72,7 @@ up / steady / down arrow in every style.
 
 In the tables below, **Δ** is the pressure change over the window. The ranges are
 half-open so every value maps to exactly one tier (a value exactly on a boundary falls
-into the *faster* tier — e.g. Δ = +2.0 hPa is "Rising", not "Slowly Rising").
+into the *faster* tier — e.g. Δ = +2.0 hPa is "Rising", not "Rising Slowly").
 
 ### `multi` (default) — WMO/NWS-style multi-tier
 
@@ -80,13 +80,13 @@ The barometer arrow steepens as the change grows, and doubles for the rapid tier
 
 | Change (Δ) | inHg equiv. | Arrow | Tooltip word |
 |---|---|---|---|
-| Δ ≥ +5.0 hPa | ≥ +0.148 | ↑↑ | Rapidly Rising |
+| Δ ≥ +5.0 hPa | ≥ +0.148 | ↑↑ | Rising Rapidly |
 | +2.0 ≤ Δ < +5.0 hPa | +0.059 … +0.148 | ↑ | Rising |
-| +0.7 ≤ Δ < +2.0 hPa | +0.021 … +0.059 | ↗ | Slowly Rising |
+| +0.7 ≤ Δ < +2.0 hPa | +0.021 … +0.059 | ↗ | Rising Slowly |
 | −0.7 < Δ < +0.7 hPa | within ±0.021 | → | Steady |
-| −2.0 < Δ ≤ −0.7 hPa | −0.021 … −0.059 | ↘ | Slowly Falling |
+| −2.0 < Δ ≤ −0.7 hPa | −0.021 … −0.059 | ↘ | Falling Slowly |
 | −5.0 < Δ ≤ −2.0 hPa | −0.059 … −0.148 | ↓ | Falling |
-| Δ ≤ −5.0 hPa | ≤ −0.148 | ↓↓ | Rapidly Falling |
+| Δ ≤ −5.0 hPa | ≤ −0.148 | ↓↓ | Falling Rapidly |
 
 ### `davis` — Davis Vantage thresholds
 
@@ -94,11 +94,11 @@ Mirrors the 3-level rate descriptions used by Davis Vantage consoles.
 
 | Change (Δ) | inHg equiv. | Arrow | Tooltip word |
 |---|---|---|---|
-| Δ ≥ +2.0 hPa | ≥ +0.059 | ↑ | Rising rapidly |
-| +0.7 ≤ Δ < +2.0 hPa | +0.021 … +0.059 | ↗ | Rising slowly |
+| Δ ≥ +2.0 hPa | ≥ +0.059 | ↑ | Rising Rapidly |
+| +0.7 ≤ Δ < +2.0 hPa | +0.021 … +0.059 | ↗ | Rising Slowly |
 | −0.7 < Δ < +0.7 hPa | within ±0.021 | → | Steady |
-| −2.0 < Δ ≤ −0.7 hPa | −0.021 … −0.059 | ↘ | Falling slowly |
-| Δ ≤ −2.0 hPa | ≤ −0.059 | ↓ | Falling rapidly |
+| −2.0 < Δ ≤ −0.7 hPa | −0.021 … −0.059 | ↘ | Falling Slowly |
+| Δ ≤ −2.0 hPa | ≤ −0.059 | ↓ | Falling Rapidly |
 
 These hPa cut-points reproduce Davis's published inHg table (≈ 0.02 inHg and 0.06 inHg).
 
@@ -146,8 +146,13 @@ threshold would treat °F and °C differently.
 ## Tooltips
 
 The tooltip names the category and shows the signed change in your display units over the
-window actually covered by the data, e.g. `Rapidly Rising: +0.118 inHg (over 3 h)` (or
+window actually covered by the data, e.g. `Rising Rapidly: +0.118 inHg (over 3 h)` (or
 `(over 1.5 h)` shortly after a restart — see [How a trend is calculated](#how-a-trend-is-calculated)).
+
+> **Localization.** The category words (`Rising`, `Falling`, `Steady`, `Rising Slowly`,
+> `Rising Rapidly`, `Falling Slowly`, `Falling Rapidly`) and the word `over` are pulled
+> from the active language file via `[Texts] → [[Trend]]` in `skins/neowx-material/lang/*.conf`.
+> The `davis` style reuses the same phrase keys, so its tooltips read identically to `multi`.
 
 Pressure is rounded to a unit-appropriate precision so small changes remain visible:
 

--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class BasicInstaller(ExtensionInstaller):
     def __init__(self):
         super(BasicInstaller, self).__init__(
-            version="1.66.0",
+            version="1.66.1",
             name="neowx-material",
             description="The most versatile and modern weewx skin",
             author="Neoweewx",

--- a/skins/neowx-material/lang/ca.conf
+++ b/skins/neowx-material/lang/ca.conf
@@ -144,3 +144,14 @@
         95                 = Tempesta: Lleugera o moderada
         96                 = Tempesta amb calamarsa lleugera
         99                 = Tempesta amb calamarsa forta
+
+    [[Trend]]
+        # Trend phrases for the current-page observation/barometer indicator.
+        rising          = En ascens
+        falling         = En descens
+        steady          = Estable
+        rising_slowly   = En ascens lent
+        rising_rapidly  = En ascens ràpid
+        falling_slowly  = En descens lent
+        falling_rapidly = En descens ràpid
+        over            = en

--- a/skins/neowx-material/lang/da.conf
+++ b/skins/neowx-material/lang/da.conf
@@ -259,3 +259,14 @@
         86                 = Snebyger: Kraftige
         95                 = Tordenvejr: Let til moderat      
 		99                 = Tordenvejr med kraftigt hagl
+
+    [[Trend]]
+        # Trend phrases for the current-page observation/barometer indicator.
+        rising          = Stigende
+        falling         = Faldende
+        steady          = Uændret
+        rising_slowly   = Langsomt stigende
+        rising_rapidly  = Hurtigt stigende
+        falling_slowly  = Langsomt faldende
+        falling_rapidly = Hurtigt faldende
+        over            = over

--- a/skins/neowx-material/lang/de.conf
+++ b/skins/neowx-material/lang/de.conf
@@ -254,3 +254,14 @@
         95                 = Gewitter: Leicht oder moderat
         96                 = Gewitter mit leichtem Hagel
         99                 = Gewitter mit starkem Hagel
+
+    [[Trend]]
+        # Trend phrases for the current-page observation/barometer indicator.
+        rising          = Steigend
+        falling         = Fallend
+        steady          = Gleichbleibend
+        rising_slowly   = Langsam steigend
+        rising_rapidly  = Stark steigend
+        falling_slowly  = Langsam fallend
+        falling_rapidly = Stark fallend
+        over            = über

--- a/skins/neowx-material/lang/en.conf
+++ b/skins/neowx-material/lang/en.conf
@@ -146,3 +146,14 @@
         95                 = Thunderstorm: Slight or moderate
         96                 = Thunderstorm with slight hail
         99                 = Thunderstorm with heavy hail
+
+    [[Trend]]
+        # Trend phrases for the current-page observation/barometer indicator.
+        rising          = Rising
+        falling         = Falling
+        steady          = Steady
+        rising_slowly   = Rising Slowly
+        rising_rapidly  = Rising Rapidly
+        falling_slowly  = Falling Slowly
+        falling_rapidly = Falling Rapidly
+        over            = over

--- a/skins/neowx-material/lang/es.conf
+++ b/skins/neowx-material/lang/es.conf
@@ -255,3 +255,14 @@
         95                 = Tormenta: Ligera o moderada
         96                 = Tormenta con granizo leve
         99                 = Tormenta con granizo fuerte
+
+    [[Trend]]
+        # Trend phrases for the current-page observation/barometer indicator.
+        rising          = En ascenso
+        falling         = En descenso
+        steady          = Estable
+        rising_slowly   = En ascenso lento
+        rising_rapidly  = En ascenso rápido
+        falling_slowly  = En descenso lento
+        falling_rapidly = En descenso rápido
+        over            = en

--- a/skins/neowx-material/lang/fi.conf
+++ b/skins/neowx-material/lang/fi.conf
@@ -259,3 +259,14 @@
         95                 = Ukkosmyrsky: Kevyt tai kohtalainen
         96                 = Ukkosmyrsky ja kevyttä rakeita
         99                 = Ukkosmyrsky ja voimakkaita rakeita
+
+    [[Trend]]
+        # Trend phrases for the current-page observation/barometer indicator.
+        rising          = Nouseva
+        falling         = Laskeva
+        steady          = Vakaa
+        rising_slowly   = Hitaasti nouseva
+        rising_rapidly  = Nopeasti nouseva
+        falling_slowly  = Hitaasti laskeva
+        falling_rapidly = Nopeasti laskeva
+        over            = yli

--- a/skins/neowx-material/lang/fr.conf
+++ b/skins/neowx-material/lang/fr.conf
@@ -256,3 +256,14 @@
         96                 = Orage avec grêle légère
         99                 = Orage avec forte grêle
 
+    [[Trend]]
+        # Trend phrases for the current-page observation/barometer indicator.
+        rising          = En hausse
+        falling         = En baisse
+        steady          = Stable
+        rising_slowly   = En hausse lente
+        rising_rapidly  = En hausse rapide
+        falling_slowly  = En baisse lente
+        falling_rapidly = En baisse rapide
+        over            = sur
+

--- a/skins/neowx-material/lang/it.conf
+++ b/skins/neowx-material/lang/it.conf
@@ -257,3 +257,14 @@
         96                 = Temporale con grandine leggera
         99                 = Temporale con grandine forte
 
+    [[Trend]]
+        # Trend phrases for the current-page observation/barometer indicator.
+        rising          = In aumento
+        falling         = In diminuzione
+        steady          = Stabile
+        rising_slowly   = In lento aumento
+        rising_rapidly  = In rapido aumento
+        falling_slowly  = In lenta diminuzione
+        falling_rapidly = In rapida diminuzione
+        over            = in
+

--- a/skins/neowx-material/lang/nl.conf
+++ b/skins/neowx-material/lang/nl.conf
@@ -256,3 +256,14 @@
         95                 = Onweer: licht of matig
         96                 = Onweer met lichte hagel
         99                 = Onweer met zware hagel
+
+    [[Trend]]
+        # Trend phrases for the current-page observation/barometer indicator.
+        rising          = Stijgend
+        falling         = Dalend
+        steady          = Gelijkblijvend
+        rising_slowly   = Langzaam stijgend
+        rising_rapidly  = Snel stijgend
+        falling_slowly  = Langzaam dalend
+        falling_rapidly = Snel dalend
+        over            = in

--- a/skins/neowx-material/lang/pl.conf
+++ b/skins/neowx-material/lang/pl.conf
@@ -219,3 +219,14 @@
         95                 = Burza: Słaba lub umiarkowana
         96                 = Burza z gradem: Słaba
         99                 = Burza z gradem: Silna
+
+    [[Trend]]
+        # Trend phrases for the current-page observation/barometer indicator.
+        rising          = Rośnie
+        falling         = Spada
+        steady          = Stabilne
+        rising_slowly   = Powoli rośnie
+        rising_rapidly  = Szybko rośnie
+        falling_slowly  = Powoli spada
+        falling_rapidly = Szybko spada
+        over            = w ciągu

--- a/skins/neowx-material/lang/se.conf
+++ b/skins/neowx-material/lang/se.conf
@@ -260,3 +260,14 @@
         95                 = Åska: Lätt eller måttlig
         96                 = Åska med lätt hagel
         99                 = Åska med kraftigt hagel
+
+    [[Trend]]
+        # Trend phrases for the current-page observation/barometer indicator.
+        rising          = Stigande
+        falling         = Fallande
+        steady          = Oförändrat
+        rising_slowly   = Långsamt stigande
+        rising_rapidly  = Snabbt stigande
+        falling_slowly  = Långsamt fallande
+        falling_rapidly = Snabbt fallande
+        over            = över

--- a/skins/neowx-material/lang/sk.conf
+++ b/skins/neowx-material/lang/sk.conf
@@ -314,3 +314,14 @@
         95                 = Búrka: Slabá alebo stredná
         96                 = Búrka s ľahkým krupobitím
         99                 = Búrka so silným krupobitím
+
+    [[Trend]]
+        # Trend phrases for the current-page observation/barometer indicator.
+        rising          = Stúpajúci
+        falling         = Klesajúci
+        steady          = Stabilný
+        rising_slowly   = Pomaly stúpajúci
+        rising_rapidly  = Rýchlo stúpajúci
+        falling_slowly  = Pomaly klesajúci
+        falling_rapidly = Rýchlo klesajúci
+        over            = za

--- a/skins/neowx-material/package-lock.json
+++ b/skins/neowx-material/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neowx-material",
-  "version": "1.66.0",
+  "version": "1.66.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neowx-material",
-      "version": "1.66.0",
+      "version": "1.66.1",
       "license": "MIT",
       "dependencies": {
         "sass": "1.100.0"

--- a/skins/neowx-material/package.json
+++ b/skins/neowx-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neowx-material",
-  "version": "1.66.0",
+  "version": "1.66.1",
   "description": "The most versatile and modern weewx skin",
   "main": "index.js",
   "repository": "https://github.com/neoground/neowx-material",

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -18,7 +18,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
 
-    version = 1.66.0
+    version = 1.66.1
 
     # Language
     # -------------------------------------------------------------------------

--- a/skins/neowx-material/trend_indicator.inc
+++ b/skins/neowx-material/trend_indicator.inc
@@ -105,44 +105,43 @@
         #if $_mode == 'davis'
             ## Davis Vantage (3 h, hPa): steady <0.7, slowly 0.7-2.0, rapidly >=2.0
             #if $_mag < 0.7 * $_scale
-                <i class="wi wi-direction-right" title="Steady: $_disp_s$_lbl (over $_win)" data-toggle="tooltip" data-html="true"></i>
+                <i class="wi wi-direction-right" title="$pgettext("Trend", "steady"): $_disp_s$_lbl ($pgettext("Trend", "over") $_win)" data-toggle="tooltip" data-html="true"></i>
             #else
-                #set $_verb = 'Rising' if $_tv > 0 else 'Falling'
                 #if $_mag >= 2.0 * $_scale
                     #set $_wic  = 'wi-direction-' + $_ud
-                    #set $_word = $_verb + ' rapidly'
+                    #set $_word = $pgettext("Trend", "rising_rapidly") if $_tv > 0 else $pgettext("Trend", "falling_rapidly")
                 #else
                     #set $_wic  = 'wi-direction-' + $_ud + '-right'
-                    #set $_word = $_verb + ' slowly'
+                    #set $_word = $pgettext("Trend", "rising_slowly") if $_tv > 0 else $pgettext("Trend", "falling_slowly")
                 #end if
-                <i class="wi $_wic" title="$_word: $_disp_s$_lbl (over $_win)" data-toggle="tooltip" data-html="true"></i>
+                <i class="wi $_wic" title="$_word: $_disp_s$_lbl ($pgettext("Trend", "over") $_win)" data-toggle="tooltip" data-html="true"></i>
             #end if
         #else
             ## multi / WMO-style (3 h, hPa): steady <0.7, slowly 0.7-2.0,
             ## rising 2.0-5.0, rapidly >=5.0 (doubled arrow).
             #if $_mag < 0.7 * $_scale
-                <i class="wi wi-direction-right" title="Steady: $_disp_s$_lbl (over $_win)" data-toggle="tooltip" data-html="true"></i>
+                <i class="wi wi-direction-right" title="$pgettext("Trend", "steady"): $_disp_s$_lbl ($pgettext("Trend", "over") $_win)" data-toggle="tooltip" data-html="true"></i>
             #else
-                #set $_dir = 'Rising' if $_tv > 0 else 'Falling'
+                #set $_rising = $_tv > 0
                 #set $_double = False
                 #if $_mag >= 5.0 * $_scale
                     ## rapidly: two straight arrows
                     #set $_wic  = 'wi-direction-' + $_ud
                     #set $_double = True
-                    #set $_word = 'Rapidly ' + $_dir
+                    #set $_word = $pgettext("Trend", "rising_rapidly") if $_rising else $pgettext("Trend", "falling_rapidly")
                 #else if $_mag >= 2.0 * $_scale
                     ## rising: one straight arrow
                     #set $_wic  = 'wi-direction-' + $_ud
-                    #set $_word = $_dir
+                    #set $_word = $pgettext("Trend", "rising") if $_rising else $pgettext("Trend", "falling")
                 #else
                     ## slowly: one diagonal arrow
                     #set $_wic  = 'wi-direction-' + $_ud + '-right'
-                    #set $_word = 'Slowly ' + $_dir
+                    #set $_word = $pgettext("Trend", "rising_slowly") if $_rising else $pgettext("Trend", "falling_slowly")
                 #end if
                 #if $_double
-                    <span title="$_word: $_disp_s$_lbl (over $_win)" data-toggle="tooltip" data-html="true"><i class="wi $_wic"></i><i class="wi $_wic"></i></span>
+                    <span title="$_word: $_disp_s$_lbl ($pgettext("Trend", "over") $_win)" data-toggle="tooltip" data-html="true"><i class="wi $_wic"></i><i class="wi $_wic"></i></span>
                 #else
-                    <i class="wi $_wic" title="$_word: $_disp_s$_lbl (over $_win)" data-toggle="tooltip" data-html="true"></i>
+                    <i class="wi $_wic" title="$_word: $_disp_s$_lbl ($pgettext("Trend", "over") $_win)" data-toggle="tooltip" data-html="true"></i>
                 #end if
             #end if
         #end if
@@ -151,11 +150,11 @@
         ## non-pressure path for multi/davis. Canonical dead-band per family.
         #set $_simp = $_disp_s if $_pressure else $_disp_r
         #if $_tv > $_band
-            <i class="wi wi-direction-up-right" title="Rising: $_simp$_lbl (over $_win)" data-toggle="tooltip" data-html="true"></i>
+            <i class="wi wi-direction-up-right" title="$pgettext("Trend", "rising"): $_simp$_lbl ($pgettext("Trend", "over") $_win)" data-toggle="tooltip" data-html="true"></i>
         #else if $_tv < -$_band
-            <i class="wi wi-direction-down-right" title="Falling: $_simp$_lbl (over $_win)" data-toggle="tooltip" data-html="true"></i>
+            <i class="wi wi-direction-down-right" title="$pgettext("Trend", "falling"): $_simp$_lbl ($pgettext("Trend", "over") $_win)" data-toggle="tooltip" data-html="true"></i>
         #else
-            <i class="wi wi-direction-right" title="Steady: $_simp$_lbl (over $_win)" data-toggle="tooltip" data-html="true"></i>
+            <i class="wi wi-direction-right" title="$pgettext("Trend", "steady"): $_simp$_lbl ($pgettext("Trend", "over") $_win)" data-toggle="tooltip" data-html="true"></i>
         #end if
     #end if
 #end if


### PR DESCRIPTION
Add the "trends" test to the internationalization files.

When choosing translations, I tried to use the meteorological terms when I could find sources (see below), and when I could not find sources I relied on AI for initial translations so many may need modifications with some input.

[AEMET / Spanish barometric tendency ("en ascenso/descenso")](https://snowy.es/wikimeteo/categoria-presion)
[Meteocat — La pressió atmosfèrica ("en ascens/descens")](https://www.meteo.cat/wpweb/divulgacio/temps-al-temps/la-pressio-atmosferica-2/)
[DWD Glossar — Luftdrucktendenz ("stark steigend/fallend")](https://www.dwd.de/DE/service/lexikon/Functions/glossar.html?lv3=610008&lv2=101518)
[IMGW — tendencja ciśnienia ("rośnie/spada/stabilne")](https://cmm.imgw.pl/?p=22030)
[Slovak barometer terminology ("stúpajúci/klesajúci", "pomaly/rýchlo", "stabilný")](https://sk.eferrit.com/ako-citat-barometer/)