### PR TITLE
Feature/chart hide initial values

### DIFF
--- a/install.py
+++ b/install.py
@@ -36,6 +36,7 @@ class BasicInstaller(ExtensionInstaller):
                         "skins/neowx-material/fonts/Rubik-Regular.woff2",
                         "skins/neowx-material/card_datetime.inc",
                         "skins/neowx-material/chart_date_format.inc",
+                        "skins/neowx-material/chart_hidden_series.inc",
                         "skins/neowx-material/chart_tick_axis.inc",
                         "skins/neowx-material/chart_colors_setup.inc",
                         "skins/neowx-material/chart_tick_setup.inc",

--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class BasicInstaller(ExtensionInstaller):
     def __init__(self):
         super(BasicInstaller, self).__init__(
-            version="1.66.1",
+            version="1.67.0",
             name="neowx-material",
             description="The most versatile and modern weewx skin",
             author="Neoweewx",

--- a/skins/neowx-material/chart_hidden_series.inc
+++ b/skins/neowx-material/chart_hidden_series.inc
@@ -22,6 +22,9 @@ chart: {
     events: {
         ...(graph_${_hs_type}_config.chart && graph_${_hs_type}_config.chart.events),
         mounted: function (chartContext) {
+            ## This per-chart mounted overrides the global window.Apex one, so call
+            ## the global handler (axis-alignment registration) ourselves first.
+            if (typeof neowxMountedHandler === 'function') { try { neowxMountedHandler(chartContext); } catch (e) {} }
             try {
                 #for $hn in $cc_hidden_names
                 chartContext.hideSeries("$hn");

--- a/skins/neowx-material/chart_hidden_series.inc
+++ b/skins/neowx-material/chart_hidden_series.inc
@@ -1,7 +1,7 @@
 #encoding UTF-8
 ## +-------------------------------------------------------------------------+
 ## | chart_hidden_series.inc   Collapse series named in $cc_hidden_names on  |
-## | initial render (the "hideinitialvalues" feature) and reveal the chart   |
+## | initial render (the "hidevalues" feature) and reveal the chart   |
 ## | container the caller hid with opacity:0 to avoid a load-in flash.       |
 ## |                                                                         |
 ## | Cheetah #include runs in a scope that only sees GLOBALS (not the        |

--- a/skins/neowx-material/chart_hidden_series.inc
+++ b/skins/neowx-material/chart_hidden_series.inc
@@ -1,0 +1,30 @@
+#encoding UTF-8
+## +-------------------------------------------------------------------------+
+## | chart_hidden_series.inc   Collapse series named in $cc_hidden_names on  |
+## | initial render (the "hideinitialvalues" feature) and reveal the chart   |
+## | container the caller hid with opacity:0 to avoid a load-in flash.       |
+## |                                                                         |
+## | Expects in scope: $cc_hidden_names (list of exact ApexCharts series     |
+## | names), $cc_type (graph config suffix), $cc_id (container element id).  |
+## | Emits a merged chart.events.mounted handler, or nothing when no series  |
+## | are hidden. Merge (not replace) so chart.type and any existing events   |
+## | from graph_${cc_type}_config survive.                                   |
+## +-------------------------------------------------------------------------+
+#if len($cc_hidden_names) > 0
+chart: {
+    ...graph_${cc_type}_config.chart,
+    events: {
+        ...(graph_${cc_type}_config.chart && graph_${cc_type}_config.chart.events),
+        mounted: function (chartContext) {
+            try {
+                #for $hn in $cc_hidden_names
+                chartContext.hideSeries("$hn");
+                #end for
+            } finally {
+                var _el = document.querySelector('#$cc_id');
+                if (_el) { _el.style.opacity = '1'; }
+            }
+        }
+    }
+},
+#end if

--- a/skins/neowx-material/chart_hidden_series.inc
+++ b/skins/neowx-material/chart_hidden_series.inc
@@ -4,24 +4,30 @@
 ## | initial render (the "hideinitialvalues" feature) and reveal the chart   |
 ## | container the caller hid with opacity:0 to avoid a load-in flash.       |
 ## |                                                                         |
-## | Expects in scope: $cc_hidden_names (list of exact ApexCharts series     |
-## | names), $cc_type (graph config suffix), $cc_id (container element id).  |
-## | Emits a merged chart.events.mounted handler, or nothing when no series  |
-## | are hidden. Merge (not replace) so chart.type and any existing events   |
-## | from graph_${cc_type}_config survive.                                   |
+## | Cheetah #include runs in a scope that only sees GLOBALS (not the        |
+## | caller's local #set vars), so the caller MUST set $cc_hidden_names with  |
+## | "#set global". The chart type and container id are derived here from     |
+## | the already-global $cc_name (the customChart* key) so callers don't      |
+## | have to globalize their local $cc_type / $cc_id too.                     |
+## |                                                                         |
+## | Emits a merged chart.events.mounted handler, or nothing when no series   |
+## | are hidden. Merge (not replace) so chart.type and any existing events    |
+## | from graph_<type>_config survive.                                        |
 ## +-------------------------------------------------------------------------+
 #if len($cc_hidden_names) > 0
+#set $_hs_type = $Extras.Appearance.get($cc_name, {}).get('charttype', 'area')
+#set $_hs_id   = $cc_name + 'chart'
 chart: {
-    ...graph_${cc_type}_config.chart,
+    ...graph_${_hs_type}_config.chart,
     events: {
-        ...(graph_${cc_type}_config.chart && graph_${cc_type}_config.chart.events),
+        ...(graph_${_hs_type}_config.chart && graph_${_hs_type}_config.chart.events),
         mounted: function (chartContext) {
             try {
                 #for $hn in $cc_hidden_names
                 chartContext.hideSeries("$hn");
                 #end for
             } finally {
-                var _el = document.querySelector('#$cc_id');
+                var _el = document.querySelector('#$_hs_id');
                 if (_el) { _el.style.opacity = '1'; }
             }
         }

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -1105,7 +1105,7 @@
                             #else
                                 #set $cc_hidden_obs = [v.strip() for v in str($cc_hidden_raw).split(',') if v.strip()]
                             #end if
-                            #set $cc_hidden_names = []
+                            #set global $cc_hidden_names = []
                             #for $val, $cols in $cc_series_pairs
                                 #if $val in $cc_hidden_obs and $chartHasData(val)
                                     #silent $cc_hidden_names.append($getVar('obs.label.' + val))

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -1019,7 +1019,7 @@
                         ## Build cc_field_map without a generator (avoids Python 3 / Cheetah scope issue)
                         #set $cc_field_map = {}
                         #for $fk, $fv in $cc_page.items()
-                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style') and isinstance($fv, (str, list))
+                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style', 'hideinitialvalues') and isinstance($fv, (str, list))
                                 #silent $cc_field_map[$fk] = $fv
                             #end if
                         #end for
@@ -1098,10 +1098,28 @@
                             #except
                                 #set $axes_list = ['y1']
                             #end try
+                            ## hideinitialvalues: series that start collapsed (page -> chart level).
+                            #set $cc_hidden_raw = $cc_page.get('hideinitialvalues', $cc.get('hideinitialvalues', ''))
+                            #if isinstance($cc_hidden_raw, list)
+                                #set $cc_hidden_obs = [v.strip() for v in $cc_hidden_raw if v.strip()]
+                            #else
+                                #set $cc_hidden_obs = [v.strip() for v in str($cc_hidden_raw).split(',') if v.strip()]
+                            #end if
+                            #set $cc_hidden_names = []
+                            #for $val, $cols in $cc_series_pairs
+                                #if $val in $cc_hidden_obs and $chartHasData(val)
+                                    #silent $cc_hidden_names.append($getVar('obs.label.' + val))
+                                #end if
+                            #end for
                             var chartElement = document.querySelector('#$cc_id');
                             if (chartElement) {
+                                #if len($cc_hidden_names) > 0
+                                chartElement.style.opacity = '0';
+                                setTimeout(function () { var _e = document.querySelector('#$cc_id'); if (_e) { _e.style.opacity = '1'; } }, 2000);
+                                #end if
                                 new ApexCharts(chartElement, {
                                     ...graph_${cc_type}_config,
+                                    #include "chart_hidden_series.inc"
                                     #if $cc_label_fmt or $pg_align_mid or $cc_tick_set
                                     xaxis: {
                                         ...graph_${cc_type}_config.xaxis,

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -1019,7 +1019,7 @@
                         ## Build cc_field_map without a generator (avoids Python 3 / Cheetah scope issue)
                         #set $cc_field_map = {}
                         #for $fk, $fv in $cc_page.items()
-                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style', 'hideinitialvalues') and isinstance($fv, (str, list))
+                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style', 'hidevalues') and isinstance($fv, (str, list))
                                 #silent $cc_field_map[$fk] = $fv
                             #end if
                         #end for
@@ -1098,8 +1098,8 @@
                             #except
                                 #set $axes_list = ['y1']
                             #end try
-                            ## hideinitialvalues: series that start collapsed (page -> chart level).
-                            #set $cc_hidden_raw = $cc_page.get('hideinitialvalues', $cc.get('hideinitialvalues', ''))
+                            ## hidevalues: series that start collapsed (page -> chart level).
+                            #set $cc_hidden_raw = $cc_page.get('hidevalues', $cc.get('hidevalues', ''))
                             #if isinstance($cc_hidden_raw, list)
                                 #set $cc_hidden_obs = [v.strip().replace(' ', '') for v in $cc_hidden_raw if v.strip()]
                             #else

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -213,9 +213,17 @@
 ## | Value-cards keep using $day on purpose: they show today's stats.         |
 ## +-------------------------------------------------------------------------+
 ## >>> chartHasData >>>
+## Memoized per render: chartHasData runs a custom-span aggregate query, and the
+## same obs is tested several times per chart (card visibility, hidevalues
+## pre-pass, series-emit loop). The span is constant ($custom_time_delta), so the
+## result only depends on $name - cache it for the report cycle.
+#set global $_chd_cache = {}
 #def chartHasData($name)
-    #set $_chd_obs = $getattr($span($time_delta=$custom_time_delta), $name)
-    #return $_chd_obs.has_data
+    #if $name not in $_chd_cache
+        #set $_chd_obs = $getattr($span($time_delta=$custom_time_delta), $name)
+        #silent $_chd_cache[$name] = $_chd_obs.has_data
+    #end if
+    #return $_chd_cache[$name]
 #end def
 ## <<< chartHasData <<<
 
@@ -1107,7 +1115,7 @@
                             #end if
                             #set global $cc_hidden_names = []
                             #for $val, $cols in $cc_series_pairs
-                                #if $chartHasData(val) and ($val in $cc_hidden_obs or ($val + ':' + $cols[0]) in $cc_hidden_obs)
+                                #if ($val in $cc_hidden_obs or ($val + ':' + $cols[0]) in $cc_hidden_obs) and $chartHasData(val)
                                     #silent $cc_hidden_names.append($getVar('obs.label.' + val))
                                 #end if
                             #end for

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -1101,13 +1101,13 @@
                             ## hideinitialvalues: series that start collapsed (page -> chart level).
                             #set $cc_hidden_raw = $cc_page.get('hideinitialvalues', $cc.get('hideinitialvalues', ''))
                             #if isinstance($cc_hidden_raw, list)
-                                #set $cc_hidden_obs = [v.strip() for v in $cc_hidden_raw if v.strip()]
+                                #set $cc_hidden_obs = [v.strip().replace(' ', '') for v in $cc_hidden_raw if v.strip()]
                             #else
-                                #set $cc_hidden_obs = [v.strip() for v in str($cc_hidden_raw).split(',') if v.strip()]
+                                #set $cc_hidden_obs = [v.strip().replace(' ', '') for v in str($cc_hidden_raw).split(',') if v.strip()]
                             #end if
                             #set global $cc_hidden_names = []
                             #for $val, $cols in $cc_series_pairs
-                                #if $val in $cc_hidden_obs and $chartHasData(val)
+                                #if $chartHasData(val) and ($val in $cc_hidden_obs or ($val + ':' + $cols[0]) in $cc_hidden_obs)
                                     #silent $cc_hidden_names.append($getVar('obs.label.' + val))
                                 #end if
                             #end for

--- a/skins/neowx-material/js/app.js
+++ b/skins/neowx-material/js/app.js
@@ -7,6 +7,12 @@ $(function () {
 // Number rounding based on weewx values
 // Example: Number: 34.5678 Format: %.2f Result: 34.57
 function formatNumber(no, format) {
+    // Guard non-numeric values (null/undefined for hidden series or null data
+    // gaps): calling .toFixed on them throws and aborts the whole tooltip
+    // render, so the tooltip vanishes after toggling a series off the legend.
+    if (typeof no !== 'number' || !isFinite(no)) {
+        return no;
+    }
     // Extract number of decimal places from format
     format = format.replace(/[^0-9]/g, '');
     return no.toFixed(format);

--- a/skins/neowx-material/month-%Y-%m.html.tmpl
+++ b/skins/neowx-material/month-%Y-%m.html.tmpl
@@ -789,7 +789,7 @@
                         ## Build cc_field_map without a generator (avoids Python 3 / Cheetah scope issue)
                         #set $cc_field_map = {}
                         #for $fk, $fv in $cc_page.items()
-                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style') and isinstance($fv, (str, list))
+                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style', 'hideinitialvalues') and isinstance($fv, (str, list))
                                 #silent $cc_field_map[$fk] = $fv
                             #end if
                         #end for
@@ -868,10 +868,34 @@
                             #except
                                 #set $axes_list = ['y1']
                             #end try
+                            ## hideinitialvalues: series that start collapsed (page -> chart level).
+                            #set $cc_hidden_raw = $cc_page.get('hideinitialvalues', $cc.get('hideinitialvalues', ''))
+                            #if isinstance($cc_hidden_raw, list)
+                                #set $cc_hidden_obs = [v.strip() for v in $cc_hidden_raw if v.strip()]
+                            #else
+                                #set $cc_hidden_obs = [v.strip() for v in str($cc_hidden_raw).split(',') if v.strip()]
+                            #end if
+                            #set $cc_hidden_names = []
+                            #for $val, $cols in $cc_series_pairs
+                                #if $val in $cc_hidden_obs and $getVar('month.' + val + '.has_data')
+                                    #if len($cols) == 1
+                                        #silent $cc_hidden_names.append($getVar('obs.label.' + val))
+                                    #else
+                                        #for $col in $cols
+                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                        #end for
+                                    #end if
+                                #end if
+                            #end for
                             var chartElement = document.querySelector('#$cc_id');
                             if (chartElement) {
+                                #if len($cc_hidden_names) > 0
+                                chartElement.style.opacity = '0';
+                                setTimeout(function () { var _e = document.querySelector('#$cc_id'); if (_e) { _e.style.opacity = '1'; } }, 2000);
+                                #end if
                                 new ApexCharts(chartElement, {
                                     ...graph_${cc_type}_config,
+                                    #include "chart_hidden_series.inc"
                                     #if $cc_label_fmt or $pg_align_mid or $cc_tick_set
                                     xaxis: {
                                         ...graph_${cc_type}_config.xaxis,

--- a/skins/neowx-material/month-%Y-%m.html.tmpl
+++ b/skins/neowx-material/month-%Y-%m.html.tmpl
@@ -875,7 +875,7 @@
                             #else
                                 #set $cc_hidden_obs = [v.strip() for v in str($cc_hidden_raw).split(',') if v.strip()]
                             #end if
-                            #set $cc_hidden_names = []
+                            #set global $cc_hidden_names = []
                             #for $val, $cols in $cc_series_pairs
                                 #if $val in $cc_hidden_obs and $getVar('month.' + val + '.has_data')
                                     #if len($cols) == 1

--- a/skins/neowx-material/month-%Y-%m.html.tmpl
+++ b/skins/neowx-material/month-%Y-%m.html.tmpl
@@ -877,18 +877,16 @@
                             #end if
                             #set global $cc_hidden_names = []
                             #for $val, $cols in $cc_series_pairs
-                                #if $getVar('month.' + val + '.has_data')
-                                    #if len($cols) == 1
-                                        #if $val in $cc_hidden_obs or ($val + ':' + $cols[0]) in $cc_hidden_obs
-                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val))
-                                        #end if
-                                    #else
-                                        #for $col in $cols
-                                            #if $val in $cc_hidden_obs or ($val + ':' + $col) in $cc_hidden_obs
-                                                #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
-                                            #end if
-                                        #end for
+                                #if len($cols) == 1
+                                    #if ($val in $cc_hidden_obs or ($val + ':' + $cols[0]) in $cc_hidden_obs) and $getVar('month.' + val + '.has_data')
+                                        #silent $cc_hidden_names.append($getVar('obs.label.' + val))
                                     #end if
+                                #else
+                                    #for $col in $cols
+                                        #if ($val in $cc_hidden_obs or ($val + ':' + $col) in $cc_hidden_obs) and $getVar('month.' + val + '.has_data')
+                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                        #end if
+                                    #end for
                                 #end if
                             #end for
                             var chartElement = document.querySelector('#$cc_id');

--- a/skins/neowx-material/month-%Y-%m.html.tmpl
+++ b/skins/neowx-material/month-%Y-%m.html.tmpl
@@ -871,18 +871,22 @@
                             ## hideinitialvalues: series that start collapsed (page -> chart level).
                             #set $cc_hidden_raw = $cc_page.get('hideinitialvalues', $cc.get('hideinitialvalues', ''))
                             #if isinstance($cc_hidden_raw, list)
-                                #set $cc_hidden_obs = [v.strip() for v in $cc_hidden_raw if v.strip()]
+                                #set $cc_hidden_obs = [v.strip().replace(' ', '') for v in $cc_hidden_raw if v.strip()]
                             #else
-                                #set $cc_hidden_obs = [v.strip() for v in str($cc_hidden_raw).split(',') if v.strip()]
+                                #set $cc_hidden_obs = [v.strip().replace(' ', '') for v in str($cc_hidden_raw).split(',') if v.strip()]
                             #end if
                             #set global $cc_hidden_names = []
                             #for $val, $cols in $cc_series_pairs
-                                #if $val in $cc_hidden_obs and $getVar('month.' + val + '.has_data')
+                                #if $getVar('month.' + val + '.has_data')
                                     #if len($cols) == 1
-                                        #silent $cc_hidden_names.append($getVar('obs.label.' + val))
+                                        #if $val in $cc_hidden_obs or ($val + ':' + $cols[0]) in $cc_hidden_obs
+                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val))
+                                        #end if
                                     #else
                                         #for $col in $cols
-                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                            #if $val in $cc_hidden_obs or ($val + ':' + $col) in $cc_hidden_obs
+                                                #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                            #end if
                                         #end for
                                     #end if
                                 #end if

--- a/skins/neowx-material/month-%Y-%m.html.tmpl
+++ b/skins/neowx-material/month-%Y-%m.html.tmpl
@@ -789,7 +789,7 @@
                         ## Build cc_field_map without a generator (avoids Python 3 / Cheetah scope issue)
                         #set $cc_field_map = {}
                         #for $fk, $fv in $cc_page.items()
-                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style', 'hideinitialvalues') and isinstance($fv, (str, list))
+                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style', 'hidevalues') and isinstance($fv, (str, list))
                                 #silent $cc_field_map[$fk] = $fv
                             #end if
                         #end for
@@ -868,8 +868,8 @@
                             #except
                                 #set $axes_list = ['y1']
                             #end try
-                            ## hideinitialvalues: series that start collapsed (page -> chart level).
-                            #set $cc_hidden_raw = $cc_page.get('hideinitialvalues', $cc.get('hideinitialvalues', ''))
+                            ## hidevalues: series that start collapsed (page -> chart level).
+                            #set $cc_hidden_raw = $cc_page.get('hidevalues', $cc.get('hidevalues', ''))
                             #if isinstance($cc_hidden_raw, list)
                                 #set $cc_hidden_obs = [v.strip().replace(' ', '') for v in $cc_hidden_raw if v.strip()]
                             #else

--- a/skins/neowx-material/month.html.tmpl
+++ b/skins/neowx-material/month.html.tmpl
@@ -988,18 +988,22 @@
                             ## hideinitialvalues: series that start collapsed (page -> chart level).
                             #set $cc_hidden_raw = $cc_page.get('hideinitialvalues', $cc.get('hideinitialvalues', ''))
                             #if isinstance($cc_hidden_raw, list)
-                                #set $cc_hidden_obs = [v.strip() for v in $cc_hidden_raw if v.strip()]
+                                #set $cc_hidden_obs = [v.strip().replace(' ', '') for v in $cc_hidden_raw if v.strip()]
                             #else
-                                #set $cc_hidden_obs = [v.strip() for v in str($cc_hidden_raw).split(',') if v.strip()]
+                                #set $cc_hidden_obs = [v.strip().replace(' ', '') for v in str($cc_hidden_raw).split(',') if v.strip()]
                             #end if
                             #set global $cc_hidden_names = []
                             #for $val, $cols in $cc_series_pairs
-                                #if $val in $cc_hidden_obs and $getVar('month.' + val + '.has_data')
+                                #if $getVar('month.' + val + '.has_data')
                                     #if len($cols) == 1
-                                        #silent $cc_hidden_names.append($getVar('obs.label.' + val))
+                                        #if $val in $cc_hidden_obs or ($val + ':' + $cols[0]) in $cc_hidden_obs
+                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val))
+                                        #end if
                                     #else
                                         #for $col in $cols
-                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                            #if $val in $cc_hidden_obs or ($val + ':' + $col) in $cc_hidden_obs
+                                                #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                            #end if
                                         #end for
                                     #end if
                                 #end if

--- a/skins/neowx-material/month.html.tmpl
+++ b/skins/neowx-material/month.html.tmpl
@@ -994,18 +994,16 @@
                             #end if
                             #set global $cc_hidden_names = []
                             #for $val, $cols in $cc_series_pairs
-                                #if $getVar('month.' + val + '.has_data')
-                                    #if len($cols) == 1
-                                        #if $val in $cc_hidden_obs or ($val + ':' + $cols[0]) in $cc_hidden_obs
-                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val))
-                                        #end if
-                                    #else
-                                        #for $col in $cols
-                                            #if $val in $cc_hidden_obs or ($val + ':' + $col) in $cc_hidden_obs
-                                                #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
-                                            #end if
-                                        #end for
+                                #if len($cols) == 1
+                                    #if ($val in $cc_hidden_obs or ($val + ':' + $cols[0]) in $cc_hidden_obs) and $getVar('month.' + val + '.has_data')
+                                        #silent $cc_hidden_names.append($getVar('obs.label.' + val))
                                     #end if
+                                #else
+                                    #for $col in $cols
+                                        #if ($val in $cc_hidden_obs or ($val + ':' + $col) in $cc_hidden_obs) and $getVar('month.' + val + '.has_data')
+                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                        #end if
+                                    #end for
                                 #end if
                             #end for
                             var chartElement = document.querySelector('#$cc_id');

--- a/skins/neowx-material/month.html.tmpl
+++ b/skins/neowx-material/month.html.tmpl
@@ -906,7 +906,7 @@
                         ## Build cc_field_map without a generator (avoids Python 3 / Cheetah scope issue)
                         #set $cc_field_map = {}
                         #for $fk, $fv in $cc_page.items()
-                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style') and isinstance($fv, (str, list))
+                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style', 'hideinitialvalues') and isinstance($fv, (str, list))
                                 #silent $cc_field_map[$fk] = $fv
                             #end if
                         #end for
@@ -985,10 +985,34 @@
                             #except
                                 #set $axes_list = ['y1']
                             #end try
+                            ## hideinitialvalues: series that start collapsed (page -> chart level).
+                            #set $cc_hidden_raw = $cc_page.get('hideinitialvalues', $cc.get('hideinitialvalues', ''))
+                            #if isinstance($cc_hidden_raw, list)
+                                #set $cc_hidden_obs = [v.strip() for v in $cc_hidden_raw if v.strip()]
+                            #else
+                                #set $cc_hidden_obs = [v.strip() for v in str($cc_hidden_raw).split(',') if v.strip()]
+                            #end if
+                            #set $cc_hidden_names = []
+                            #for $val, $cols in $cc_series_pairs
+                                #if $val in $cc_hidden_obs and $getVar('month.' + val + '.has_data')
+                                    #if len($cols) == 1
+                                        #silent $cc_hidden_names.append($getVar('obs.label.' + val))
+                                    #else
+                                        #for $col in $cols
+                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                        #end for
+                                    #end if
+                                #end if
+                            #end for
                             var chartElement = document.querySelector('#$cc_id');
                             if (chartElement) {
+                                #if len($cc_hidden_names) > 0
+                                chartElement.style.opacity = '0';
+                                setTimeout(function () { var _e = document.querySelector('#$cc_id'); if (_e) { _e.style.opacity = '1'; } }, 2000);
+                                #end if
                                 new ApexCharts(chartElement, {
                                     ...graph_${cc_type}_config,
+                                    #include "chart_hidden_series.inc"
                                     #if $cc_label_fmt or $pg_align_mid or $cc_tick_set
                                     xaxis: {
                                         ...graph_${cc_type}_config.xaxis,

--- a/skins/neowx-material/month.html.tmpl
+++ b/skins/neowx-material/month.html.tmpl
@@ -992,7 +992,7 @@
                             #else
                                 #set $cc_hidden_obs = [v.strip() for v in str($cc_hidden_raw).split(',') if v.strip()]
                             #end if
-                            #set $cc_hidden_names = []
+                            #set global $cc_hidden_names = []
                             #for $val, $cols in $cc_series_pairs
                                 #if $val in $cc_hidden_obs and $getVar('month.' + val + '.has_data')
                                     #if len($cols) == 1

--- a/skins/neowx-material/month.html.tmpl
+++ b/skins/neowx-material/month.html.tmpl
@@ -906,7 +906,7 @@
                         ## Build cc_field_map without a generator (avoids Python 3 / Cheetah scope issue)
                         #set $cc_field_map = {}
                         #for $fk, $fv in $cc_page.items()
-                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style', 'hideinitialvalues') and isinstance($fv, (str, list))
+                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style', 'hidevalues') and isinstance($fv, (str, list))
                                 #silent $cc_field_map[$fk] = $fv
                             #end if
                         #end for
@@ -985,8 +985,8 @@
                             #except
                                 #set $axes_list = ['y1']
                             #end try
-                            ## hideinitialvalues: series that start collapsed (page -> chart level).
-                            #set $cc_hidden_raw = $cc_page.get('hideinitialvalues', $cc.get('hideinitialvalues', ''))
+                            ## hidevalues: series that start collapsed (page -> chart level).
+                            #set $cc_hidden_raw = $cc_page.get('hidevalues', $cc.get('hidevalues', ''))
                             #if isinstance($cc_hidden_raw, list)
                                 #set $cc_hidden_obs = [v.strip().replace(' ', '') for v in $cc_hidden_raw if v.strip()]
                             #else

--- a/skins/neowx-material/package-lock.json
+++ b/skins/neowx-material/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neowx-material",
-  "version": "1.66.1",
+  "version": "1.67.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neowx-material",
-      "version": "1.66.1",
+      "version": "1.67.0",
       "license": "MIT",
       "dependencies": {
         "sass": "1.100.0"

--- a/skins/neowx-material/package.json
+++ b/skins/neowx-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neowx-material",
-  "version": "1.66.1",
+  "version": "1.67.0",
   "description": "The most versatile and modern weewx skin",
   "main": "index.js",
   "repository": "https://github.com/neoground/neowx-material",

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -18,7 +18,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
 
-    version = 1.66.1
+    version = 1.67.0
 
     # Language
     # -------------------------------------------------------------------------

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -562,7 +562,7 @@
         #     charttype = area
         #     tick_style = align             # x-axis ticks for this chart, every page
         #     values    = outTemp, dewpoint   # default (current + pages without a subsection)
-        #     hideinitialvalues = dewpoint    # series that load collapsed in the
+        #     hidevalues = dewpoint    # series that load collapsed in the
         #                                     # legend; the viewer clicks the legend
         #                                     # entry to show them. Every name here
         #                                     # must also be in "values"; names not
@@ -584,7 +584,7 @@
         #         outTemp  = min, max         # outTemp → "Outside Temperature Min" + "… Max"
         #         dewpoint = avg              # dewpoint → "Dew Point"  (no suffix for single col)
         #         colors   = palette2:1, palette2:2, "#FD5D5D"   # one per line: min, max, dewpoint
-        #         hideinitialvalues = outTemp:max   # only the max line starts collapsed (week only)
+        #         hidevalues = outTemp:max   # only the max line starts collapsed (week only)
         #     [[[[year]]]]
         #         outTemp  = min, avg, max
         [[[customChartOutTemp]]]
@@ -644,7 +644,7 @@
             charttype = area
             column = avg
             values = inTemp, outTemp, inDewpoint, dewpoint
-            hideinitialvalues = inDewpoint, dewpoint
+            hidevalues = inDewpoint, dewpoint
 
 
 

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -562,6 +562,15 @@
         #     charttype = area
         #     tick_style = align             # x-axis ticks for this chart, every page
         #     values    = outTemp, dewpoint   # default (current + pages without a subsection)
+        #     hideinitialvalues = dewpoint    # series that load collapsed in the
+        #                                     # legend; the viewer clicks the legend
+        #                                     # entry to show them. Every name here
+        #                                     # must also be in "values"; names not
+        #                                     # plotted (absent from values, unknown,
+        #                                     # or no data) are ignored. Can be set
+        #                                     # inside a per-page subsection to override
+        #                                     # the chart-level list. For a field that
+        #                                     # plots min+max, both lines start hidden.
         #     column    = avg                 # default
         #     colors    = 2, 1                # active-palette slots, all pages (must come
         #                                     # before the page subsections)
@@ -629,6 +638,7 @@
             charttype = area
             column = avg
             values = inTemp, outTemp, inDewpoint, dewpoint
+            hideinitialvalues = inDewpoint, dewpoint
 
 
 

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -569,8 +569,13 @@
         #                                     # plotted (absent from values, unknown,
         #                                     # or no data) are ignored. Can be set
         #                                     # inside a per-page subsection to override
-        #                                     # the chart-level list. For a field that
-        #                                     # plots min+max, both lines start hidden.
+        #                                     # the chart-level list.
+        #                                     #   obs        -> hides every line of that
+        #                                     #                 observation (e.g. for a
+        #                                     #                 min+max field, both lines)
+        #                                     #   obs:column -> hides only that column's
+        #                                     #                 line, e.g. outTemp:max
+        #                                     # Combine forms in the list, comma-separated.
         #     column    = avg                 # default
         #     colors    = 2, 1                # active-palette slots, all pages (must come
         #                                     # before the page subsections)
@@ -579,6 +584,7 @@
         #         outTemp  = min, max         # outTemp → "Outside Temperature Min" + "… Max"
         #         dewpoint = avg              # dewpoint → "Dew Point"  (no suffix for single col)
         #         colors   = palette2:1, palette2:2, "#FD5D5D"   # one per line: min, max, dewpoint
+        #         hideinitialvalues = outTemp:max   # only the max line starts collapsed (week only)
         #     [[[[year]]]]
         #         outTemp  = min, avg, max
         [[[customChartOutTemp]]]

--- a/skins/neowx-material/week.html.tmpl
+++ b/skins/neowx-material/week.html.tmpl
@@ -844,7 +844,7 @@
                         ## Build cc_field_map without a generator (avoids Python 3 / Cheetah scope issue)
                         #set $cc_field_map = {}
                         #for $fk, $fv in $cc_page.items()
-                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style', 'hideinitialvalues') and isinstance($fv, (str, list))
+                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style', 'hidevalues') and isinstance($fv, (str, list))
                                 #silent $cc_field_map[$fk] = $fv
                             #end if
                         #end for
@@ -927,8 +927,8 @@
                             #except
                                 #set $axes_list = ['y1']
                             #end try
-                            ## hideinitialvalues: series that start collapsed (page -> chart level).
-                            #set $cc_hidden_raw = $cc_page.get('hideinitialvalues', $cc.get('hideinitialvalues', ''))
+                            ## hidevalues: series that start collapsed (page -> chart level).
+                            #set $cc_hidden_raw = $cc_page.get('hidevalues', $cc.get('hidevalues', ''))
                             #if isinstance($cc_hidden_raw, list)
                                 #set $cc_hidden_obs = [v.strip().replace(' ', '') for v in $cc_hidden_raw if v.strip()]
                             #else

--- a/skins/neowx-material/week.html.tmpl
+++ b/skins/neowx-material/week.html.tmpl
@@ -930,18 +930,22 @@
                             ## hideinitialvalues: series that start collapsed (page -> chart level).
                             #set $cc_hidden_raw = $cc_page.get('hideinitialvalues', $cc.get('hideinitialvalues', ''))
                             #if isinstance($cc_hidden_raw, list)
-                                #set $cc_hidden_obs = [v.strip() for v in $cc_hidden_raw if v.strip()]
+                                #set $cc_hidden_obs = [v.strip().replace(' ', '') for v in $cc_hidden_raw if v.strip()]
                             #else
-                                #set $cc_hidden_obs = [v.strip() for v in str($cc_hidden_raw).split(',') if v.strip()]
+                                #set $cc_hidden_obs = [v.strip().replace(' ', '') for v in str($cc_hidden_raw).split(',') if v.strip()]
                             #end if
                             #set global $cc_hidden_names = []
                             #for $val, $cols in $cc_series_pairs
-                                #if $val in $cc_hidden_obs and $getVar('week.' + val + '.has_data')
+                                #if $getVar('week.' + val + '.has_data')
                                     #if len($cols) == 1
-                                        #silent $cc_hidden_names.append($getVar('obs.label.' + val))
+                                        #if $val in $cc_hidden_obs or ($val + ':' + $cols[0]) in $cc_hidden_obs
+                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val))
+                                        #end if
                                     #else
                                         #for $col in $cols
-                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                            #if $val in $cc_hidden_obs or ($val + ':' + $col) in $cc_hidden_obs
+                                                #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                            #end if
                                         #end for
                                     #end if
                                 #end if

--- a/skins/neowx-material/week.html.tmpl
+++ b/skins/neowx-material/week.html.tmpl
@@ -936,18 +936,16 @@
                             #end if
                             #set global $cc_hidden_names = []
                             #for $val, $cols in $cc_series_pairs
-                                #if $getVar('week.' + val + '.has_data')
-                                    #if len($cols) == 1
-                                        #if $val in $cc_hidden_obs or ($val + ':' + $cols[0]) in $cc_hidden_obs
-                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val))
-                                        #end if
-                                    #else
-                                        #for $col in $cols
-                                            #if $val in $cc_hidden_obs or ($val + ':' + $col) in $cc_hidden_obs
-                                                #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
-                                            #end if
-                                        #end for
+                                #if len($cols) == 1
+                                    #if ($val in $cc_hidden_obs or ($val + ':' + $cols[0]) in $cc_hidden_obs) and $getVar('week.' + val + '.has_data')
+                                        #silent $cc_hidden_names.append($getVar('obs.label.' + val))
                                     #end if
+                                #else
+                                    #for $col in $cols
+                                        #if ($val in $cc_hidden_obs or ($val + ':' + $col) in $cc_hidden_obs) and $getVar('week.' + val + '.has_data')
+                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                        #end if
+                                    #end for
                                 #end if
                             #end for
                             var chartElement = document.querySelector('#$cc_id');

--- a/skins/neowx-material/week.html.tmpl
+++ b/skins/neowx-material/week.html.tmpl
@@ -934,7 +934,7 @@
                             #else
                                 #set $cc_hidden_obs = [v.strip() for v in str($cc_hidden_raw).split(',') if v.strip()]
                             #end if
-                            #set $cc_hidden_names = []
+                            #set global $cc_hidden_names = []
                             #for $val, $cols in $cc_series_pairs
                                 #if $val in $cc_hidden_obs and $getVar('week.' + val + '.has_data')
                                     #if len($cols) == 1

--- a/skins/neowx-material/week.html.tmpl
+++ b/skins/neowx-material/week.html.tmpl
@@ -844,7 +844,7 @@
                         ## Build cc_field_map without a generator (avoids Python 3 / Cheetah scope issue)
                         #set $cc_field_map = {}
                         #for $fk, $fv in $cc_page.items()
-                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style') and isinstance($fv, (str, list))
+                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style', 'hideinitialvalues') and isinstance($fv, (str, list))
                                 #silent $cc_field_map[$fk] = $fv
                             #end if
                         #end for
@@ -927,10 +927,34 @@
                             #except
                                 #set $axes_list = ['y1']
                             #end try
+                            ## hideinitialvalues: series that start collapsed (page -> chart level).
+                            #set $cc_hidden_raw = $cc_page.get('hideinitialvalues', $cc.get('hideinitialvalues', ''))
+                            #if isinstance($cc_hidden_raw, list)
+                                #set $cc_hidden_obs = [v.strip() for v in $cc_hidden_raw if v.strip()]
+                            #else
+                                #set $cc_hidden_obs = [v.strip() for v in str($cc_hidden_raw).split(',') if v.strip()]
+                            #end if
+                            #set $cc_hidden_names = []
+                            #for $val, $cols in $cc_series_pairs
+                                #if $val in $cc_hidden_obs and $getVar('week.' + val + '.has_data')
+                                    #if len($cols) == 1
+                                        #silent $cc_hidden_names.append($getVar('obs.label.' + val))
+                                    #else
+                                        #for $col in $cols
+                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                        #end for
+                                    #end if
+                                #end if
+                            #end for
                             var chartElement = document.querySelector('#$cc_id');
                             if (chartElement) {
+                                #if len($cc_hidden_names) > 0
+                                chartElement.style.opacity = '0';
+                                setTimeout(function () { var _e = document.querySelector('#$cc_id'); if (_e) { _e.style.opacity = '1'; } }, 2000);
+                                #end if
                                 new ApexCharts(chartElement, {
                                     ...graph_${cc_type}_config,
+                                    #include "chart_hidden_series.inc"
                                     #if $cc_label_fmt or $pg_align_mid or $cc_tick_set
                                     xaxis: {
                                         ...graph_${cc_type}_config.xaxis,

--- a/skins/neowx-material/year-%Y.html.tmpl
+++ b/skins/neowx-material/year-%Y.html.tmpl
@@ -833,7 +833,7 @@
                 ## Build cc_series_pairs from field-name keys or values+column fallback
                 #set $cc_field_map = {}
                 #for $fk, $fv in $cc_page.items()
-                    #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style') and isinstance($fv, (str, list))
+                    #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style', 'hideinitialvalues') and isinstance($fv, (str, list))
                         #silent $cc_field_map[$fk] = $fv
                     #end if
                 #end for
@@ -912,10 +912,34 @@
                     #except
                         #set $axes_list = ['y1']
                     #end try
+                    ## hideinitialvalues: series that start collapsed (page -> chart level).
+                    #set $cc_hidden_raw = $cc_page.get('hideinitialvalues', $cc.get('hideinitialvalues', ''))
+                    #if isinstance($cc_hidden_raw, list)
+                        #set $cc_hidden_obs = [v.strip() for v in $cc_hidden_raw if v.strip()]
+                    #else
+                        #set $cc_hidden_obs = [v.strip() for v in str($cc_hidden_raw).split(',') if v.strip()]
+                    #end if
+                    #set $cc_hidden_names = []
+                    #for $val, $cols in $cc_series_pairs
+                        #if $val in $cc_hidden_obs and $getVar('year.' + val + '.has_data')
+                            #if len($cols) == 1
+                                #silent $cc_hidden_names.append($getVar('obs.label.' + val))
+                            #else
+                                #for $col in $cols
+                                    #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                #end for
+                            #end if
+                        #end if
+                    #end for
                     var chartElement = document.querySelector('#$cc_id');
                     if (chartElement) {
+                        #if len($cc_hidden_names) > 0
+                        chartElement.style.opacity = '0';
+                        setTimeout(function () { var _e = document.querySelector('#$cc_id'); if (_e) { _e.style.opacity = '1'; } }, 2000);
+                        #end if
                         new ApexCharts(chartElement, {
                             ...graph_${cc_type}_config,
+                            #include "chart_hidden_series.inc"
                             #if $cc_label_fmt or $pg_align_mid or $cc_tick_set
                             xaxis: {
                                 ...graph_${cc_type}_config.xaxis,

--- a/skins/neowx-material/year-%Y.html.tmpl
+++ b/skins/neowx-material/year-%Y.html.tmpl
@@ -833,7 +833,7 @@
                 ## Build cc_series_pairs from field-name keys or values+column fallback
                 #set $cc_field_map = {}
                 #for $fk, $fv in $cc_page.items()
-                    #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style', 'hideinitialvalues') and isinstance($fv, (str, list))
+                    #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style', 'hidevalues') and isinstance($fv, (str, list))
                         #silent $cc_field_map[$fk] = $fv
                     #end if
                 #end for
@@ -912,8 +912,8 @@
                     #except
                         #set $axes_list = ['y1']
                     #end try
-                    ## hideinitialvalues: series that start collapsed (page -> chart level).
-                    #set $cc_hidden_raw = $cc_page.get('hideinitialvalues', $cc.get('hideinitialvalues', ''))
+                    ## hidevalues: series that start collapsed (page -> chart level).
+                    #set $cc_hidden_raw = $cc_page.get('hidevalues', $cc.get('hidevalues', ''))
                     #if isinstance($cc_hidden_raw, list)
                         #set $cc_hidden_obs = [v.strip().replace(' ', '') for v in $cc_hidden_raw if v.strip()]
                     #else

--- a/skins/neowx-material/year-%Y.html.tmpl
+++ b/skins/neowx-material/year-%Y.html.tmpl
@@ -915,18 +915,22 @@
                     ## hideinitialvalues: series that start collapsed (page -> chart level).
                     #set $cc_hidden_raw = $cc_page.get('hideinitialvalues', $cc.get('hideinitialvalues', ''))
                     #if isinstance($cc_hidden_raw, list)
-                        #set $cc_hidden_obs = [v.strip() for v in $cc_hidden_raw if v.strip()]
+                        #set $cc_hidden_obs = [v.strip().replace(' ', '') for v in $cc_hidden_raw if v.strip()]
                     #else
-                        #set $cc_hidden_obs = [v.strip() for v in str($cc_hidden_raw).split(',') if v.strip()]
+                        #set $cc_hidden_obs = [v.strip().replace(' ', '') for v in str($cc_hidden_raw).split(',') if v.strip()]
                     #end if
                     #set global $cc_hidden_names = []
                     #for $val, $cols in $cc_series_pairs
-                        #if $val in $cc_hidden_obs and $getVar('year.' + val + '.has_data')
+                        #if $getVar('year.' + val + '.has_data')
                             #if len($cols) == 1
-                                #silent $cc_hidden_names.append($getVar('obs.label.' + val))
+                                #if $val in $cc_hidden_obs or ($val + ':' + $cols[0]) in $cc_hidden_obs
+                                    #silent $cc_hidden_names.append($getVar('obs.label.' + val))
+                                #end if
                             #else
                                 #for $col in $cols
-                                    #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                    #if $val in $cc_hidden_obs or ($val + ':' + $col) in $cc_hidden_obs
+                                        #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                    #end if
                                 #end for
                             #end if
                         #end if

--- a/skins/neowx-material/year-%Y.html.tmpl
+++ b/skins/neowx-material/year-%Y.html.tmpl
@@ -919,7 +919,7 @@
                     #else
                         #set $cc_hidden_obs = [v.strip() for v in str($cc_hidden_raw).split(',') if v.strip()]
                     #end if
-                    #set $cc_hidden_names = []
+                    #set global $cc_hidden_names = []
                     #for $val, $cols in $cc_series_pairs
                         #if $val in $cc_hidden_obs and $getVar('year.' + val + '.has_data')
                             #if len($cols) == 1

--- a/skins/neowx-material/year-%Y.html.tmpl
+++ b/skins/neowx-material/year-%Y.html.tmpl
@@ -921,18 +921,16 @@
                     #end if
                     #set global $cc_hidden_names = []
                     #for $val, $cols in $cc_series_pairs
-                        #if $getVar('year.' + val + '.has_data')
-                            #if len($cols) == 1
-                                #if $val in $cc_hidden_obs or ($val + ':' + $cols[0]) in $cc_hidden_obs
-                                    #silent $cc_hidden_names.append($getVar('obs.label.' + val))
-                                #end if
-                            #else
-                                #for $col in $cols
-                                    #if $val in $cc_hidden_obs or ($val + ':' + $col) in $cc_hidden_obs
-                                        #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
-                                    #end if
-                                #end for
+                        #if len($cols) == 1
+                            #if ($val in $cc_hidden_obs or ($val + ':' + $cols[0]) in $cc_hidden_obs) and $getVar('year.' + val + '.has_data')
+                                #silent $cc_hidden_names.append($getVar('obs.label.' + val))
                             #end if
+                        #else
+                            #for $col in $cols
+                                #if ($val in $cc_hidden_obs or ($val + ':' + $col) in $cc_hidden_obs) and $getVar('year.' + val + '.has_data')
+                                    #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                #end if
+                            #end for
                         #end if
                     #end for
                     var chartElement = document.querySelector('#$cc_id');

--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -880,18 +880,16 @@
                             #end if
                             #set global $cc_hidden_names = []
                             #for $val, $cols in $cc_series_pairs
-                                #if $getVar('year.' + val + '.has_data')
-                                    #if len($cols) == 1
-                                        #if $val in $cc_hidden_obs or ($val + ':' + $cols[0]) in $cc_hidden_obs
-                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val))
-                                        #end if
-                                    #else
-                                        #for $col in $cols
-                                            #if $val in $cc_hidden_obs or ($val + ':' + $col) in $cc_hidden_obs
-                                                #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
-                                            #end if
-                                        #end for
+                                #if len($cols) == 1
+                                    #if ($val in $cc_hidden_obs or ($val + ':' + $cols[0]) in $cc_hidden_obs) and $getVar('year.' + val + '.has_data')
+                                        #silent $cc_hidden_names.append($getVar('obs.label.' + val))
                                     #end if
+                                #else
+                                    #for $col in $cols
+                                        #if ($val in $cc_hidden_obs or ($val + ':' + $col) in $cc_hidden_obs) and $getVar('year.' + val + '.has_data')
+                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                        #end if
+                                    #end for
                                 #end if
                             #end for
                             var chartElement = document.querySelector('#$cc_id');

--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -788,7 +788,7 @@
                         ## Build cc_field_map without a generator (avoids Python 3 / Cheetah scope issue)
                         #set $cc_field_map = {}
                         #for $fk, $fv in $cc_page.items()
-                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style') and isinstance($fv, (str, list))
+                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style', 'hideinitialvalues') and isinstance($fv, (str, list))
                                 #silent $cc_field_map[$fk] = $fv
                             #end if
                         #end for
@@ -871,10 +871,34 @@
                             #except
                                 #set $axes_list = ['y1']
                             #end try
+                            ## hideinitialvalues: series that start collapsed (page -> chart level).
+                            #set $cc_hidden_raw = $cc_page.get('hideinitialvalues', $cc.get('hideinitialvalues', ''))
+                            #if isinstance($cc_hidden_raw, list)
+                                #set $cc_hidden_obs = [v.strip() for v in $cc_hidden_raw if v.strip()]
+                            #else
+                                #set $cc_hidden_obs = [v.strip() for v in str($cc_hidden_raw).split(',') if v.strip()]
+                            #end if
+                            #set $cc_hidden_names = []
+                            #for $val, $cols in $cc_series_pairs
+                                #if $val in $cc_hidden_obs and $getVar('year.' + val + '.has_data')
+                                    #if len($cols) == 1
+                                        #silent $cc_hidden_names.append($getVar('obs.label.' + val))
+                                    #else
+                                        #for $col in $cols
+                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                        #end for
+                                    #end if
+                                #end if
+                            #end for
                             var chartElement = document.querySelector('#$cc_id');
                             if (chartElement) {
+                                #if len($cc_hidden_names) > 0
+                                chartElement.style.opacity = '0';
+                                setTimeout(function () { var _e = document.querySelector('#$cc_id'); if (_e) { _e.style.opacity = '1'; } }, 2000);
+                                #end if
                                 new ApexCharts(chartElement, {
                                     ...graph_${cc_type}_config,
+                                    #include "chart_hidden_series.inc"
                                     #if $cc_label_fmt or $pg_align_mid or $cc_tick_set
                                     xaxis: {
                                         ...graph_${cc_type}_config.xaxis,

--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -788,7 +788,7 @@
                         ## Build cc_field_map without a generator (avoids Python 3 / Cheetah scope issue)
                         #set $cc_field_map = {}
                         #for $fk, $fv in $cc_page.items()
-                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style', 'hideinitialvalues') and isinstance($fv, (str, list))
+                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style', 'hidevalues') and isinstance($fv, (str, list))
                                 #silent $cc_field_map[$fk] = $fv
                             #end if
                         #end for
@@ -871,8 +871,8 @@
                             #except
                                 #set $axes_list = ['y1']
                             #end try
-                            ## hideinitialvalues: series that start collapsed (page -> chart level).
-                            #set $cc_hidden_raw = $cc_page.get('hideinitialvalues', $cc.get('hideinitialvalues', ''))
+                            ## hidevalues: series that start collapsed (page -> chart level).
+                            #set $cc_hidden_raw = $cc_page.get('hidevalues', $cc.get('hidevalues', ''))
                             #if isinstance($cc_hidden_raw, list)
                                 #set $cc_hidden_obs = [v.strip().replace(' ', '') for v in $cc_hidden_raw if v.strip()]
                             #else

--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -874,18 +874,22 @@
                             ## hideinitialvalues: series that start collapsed (page -> chart level).
                             #set $cc_hidden_raw = $cc_page.get('hideinitialvalues', $cc.get('hideinitialvalues', ''))
                             #if isinstance($cc_hidden_raw, list)
-                                #set $cc_hidden_obs = [v.strip() for v in $cc_hidden_raw if v.strip()]
+                                #set $cc_hidden_obs = [v.strip().replace(' ', '') for v in $cc_hidden_raw if v.strip()]
                             #else
-                                #set $cc_hidden_obs = [v.strip() for v in str($cc_hidden_raw).split(',') if v.strip()]
+                                #set $cc_hidden_obs = [v.strip().replace(' ', '') for v in str($cc_hidden_raw).split(',') if v.strip()]
                             #end if
                             #set global $cc_hidden_names = []
                             #for $val, $cols in $cc_series_pairs
-                                #if $val in $cc_hidden_obs and $getVar('year.' + val + '.has_data')
+                                #if $getVar('year.' + val + '.has_data')
                                     #if len($cols) == 1
-                                        #silent $cc_hidden_names.append($getVar('obs.label.' + val))
+                                        #if $val in $cc_hidden_obs or ($val + ':' + $cols[0]) in $cc_hidden_obs
+                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val))
+                                        #end if
                                     #else
                                         #for $col in $cols
-                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                            #if $val in $cc_hidden_obs or ($val + ':' + $col) in $cc_hidden_obs
+                                                #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                            #end if
                                         #end for
                                     #end if
                                 #end if

--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -878,7 +878,7 @@
                             #else
                                 #set $cc_hidden_obs = [v.strip() for v in str($cc_hidden_raw).split(',') if v.strip()]
                             #end if
-                            #set $cc_hidden_names = []
+                            #set global $cc_hidden_names = []
                             #for $val, $cols in $cc_series_pairs
                                 #if $val in $cc_hidden_obs and $getVar('year.' + val + '.has_data')
                                     #if len($cols) == 1

--- a/skins/neowx-material/yesterday.html.tmpl
+++ b/skins/neowx-material/yesterday.html.tmpl
@@ -975,7 +975,7 @@
                             #else
                                 #set $cc_hidden_obs = [v.strip() for v in str($cc_hidden_raw).split(',') if v.strip()]
                             #end if
-                            #set $cc_hidden_names = []
+                            #set global $cc_hidden_names = []
                             #for $val, $cols in $cc_series_pairs
                                 #if $val in $cc_hidden_obs and $getVar('yesterday.' + val + '.has_data')
                                     #if len($cols) == 1

--- a/skins/neowx-material/yesterday.html.tmpl
+++ b/skins/neowx-material/yesterday.html.tmpl
@@ -977,18 +977,16 @@
                             #end if
                             #set global $cc_hidden_names = []
                             #for $val, $cols in $cc_series_pairs
-                                #if $getVar('yesterday.' + val + '.has_data')
-                                    #if len($cols) == 1
-                                        #if $val in $cc_hidden_obs or ($val + ':' + $cols[0]) in $cc_hidden_obs
-                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val))
-                                        #end if
-                                    #else
-                                        #for $col in $cols
-                                            #if $val in $cc_hidden_obs or ($val + ':' + $col) in $cc_hidden_obs
-                                                #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
-                                            #end if
-                                        #end for
+                                #if len($cols) == 1
+                                    #if ($val in $cc_hidden_obs or ($val + ':' + $cols[0]) in $cc_hidden_obs) and $getVar('yesterday.' + val + '.has_data')
+                                        #silent $cc_hidden_names.append($getVar('obs.label.' + val))
                                     #end if
+                                #else
+                                    #for $col in $cols
+                                        #if ($val in $cc_hidden_obs or ($val + ':' + $col) in $cc_hidden_obs) and $getVar('yesterday.' + val + '.has_data')
+                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                        #end if
+                                    #end for
                                 #end if
                             #end for
                             var chartElement = document.querySelector('#$cc_id');

--- a/skins/neowx-material/yesterday.html.tmpl
+++ b/skins/neowx-material/yesterday.html.tmpl
@@ -894,7 +894,7 @@
                         ## Build cc_field_map without a generator (avoids Python 3 / Cheetah scope issue)
                         #set $cc_field_map = {}
                         #for $fk, $fv in $cc_page.items()
-                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style', 'hideinitialvalues') and isinstance($fv, (str, list))
+                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style', 'hidevalues') and isinstance($fv, (str, list))
                                 #silent $cc_field_map[$fk] = $fv
                             #end if
                         #end for
@@ -968,8 +968,8 @@
                         ## Render chart JS
                         #if len($cc_series_pairs) > 0 and $x in $Extras.Appearance.charts_order
                             #set $cc_id = $x + "chart"
-                            ## hideinitialvalues: series that start collapsed (page -> chart level).
-                            #set $cc_hidden_raw = $cc_page.get('hideinitialvalues', $cc.get('hideinitialvalues', ''))
+                            ## hidevalues: series that start collapsed (page -> chart level).
+                            #set $cc_hidden_raw = $cc_page.get('hidevalues', $cc.get('hidevalues', ''))
                             #if isinstance($cc_hidden_raw, list)
                                 #set $cc_hidden_obs = [v.strip().replace(' ', '') for v in $cc_hidden_raw if v.strip()]
                             #else

--- a/skins/neowx-material/yesterday.html.tmpl
+++ b/skins/neowx-material/yesterday.html.tmpl
@@ -894,7 +894,7 @@
                         ## Build cc_field_map without a generator (avoids Python 3 / Cheetah scope issue)
                         #set $cc_field_map = {}
                         #for $fk, $fv in $cc_page.items()
-                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style') and isinstance($fv, (str, list))
+                            #if $fk not in ('column', 'values', 'title', 'charttype', 'yaxis', 'yaxis_config', 'datetime_label_format', 'datetime_tooltip_format', 'colors', 'tick_style', 'hideinitialvalues') and isinstance($fv, (str, list))
                                 #silent $cc_field_map[$fk] = $fv
                             #end if
                         #end for
@@ -968,10 +968,34 @@
                         ## Render chart JS
                         #if len($cc_series_pairs) > 0 and $x in $Extras.Appearance.charts_order
                             #set $cc_id = $x + "chart"
+                            ## hideinitialvalues: series that start collapsed (page -> chart level).
+                            #set $cc_hidden_raw = $cc_page.get('hideinitialvalues', $cc.get('hideinitialvalues', ''))
+                            #if isinstance($cc_hidden_raw, list)
+                                #set $cc_hidden_obs = [v.strip() for v in $cc_hidden_raw if v.strip()]
+                            #else
+                                #set $cc_hidden_obs = [v.strip() for v in str($cc_hidden_raw).split(',') if v.strip()]
+                            #end if
+                            #set $cc_hidden_names = []
+                            #for $val, $cols in $cc_series_pairs
+                                #if $val in $cc_hidden_obs and $getVar('yesterday.' + val + '.has_data')
+                                    #if len($cols) == 1
+                                        #silent $cc_hidden_names.append($getVar('obs.label.' + val))
+                                    #else
+                                        #for $col in $cols
+                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                        #end for
+                                    #end if
+                                #end if
+                            #end for
                             var chartElement = document.querySelector('#$cc_id');
                             if (chartElement) {
+                                #if len($cc_hidden_names) > 0
+                                chartElement.style.opacity = '0';
+                                setTimeout(function () { var _e = document.querySelector('#$cc_id'); if (_e) { _e.style.opacity = '1'; } }, 2000);
+                                #end if
                                 new ApexCharts(chartElement, {
                                     ...graph_${cc_type}_config,
+                                    #include "chart_hidden_series.inc"
                                     #if $cc_label_fmt or $pg_align_mid or $cc_tick_set
                                     xaxis: {
                                         ...graph_${cc_type}_config.xaxis,

--- a/skins/neowx-material/yesterday.html.tmpl
+++ b/skins/neowx-material/yesterday.html.tmpl
@@ -971,18 +971,22 @@
                             ## hideinitialvalues: series that start collapsed (page -> chart level).
                             #set $cc_hidden_raw = $cc_page.get('hideinitialvalues', $cc.get('hideinitialvalues', ''))
                             #if isinstance($cc_hidden_raw, list)
-                                #set $cc_hidden_obs = [v.strip() for v in $cc_hidden_raw if v.strip()]
+                                #set $cc_hidden_obs = [v.strip().replace(' ', '') for v in $cc_hidden_raw if v.strip()]
                             #else
-                                #set $cc_hidden_obs = [v.strip() for v in str($cc_hidden_raw).split(',') if v.strip()]
+                                #set $cc_hidden_obs = [v.strip().replace(' ', '') for v in str($cc_hidden_raw).split(',') if v.strip()]
                             #end if
                             #set global $cc_hidden_names = []
                             #for $val, $cols in $cc_series_pairs
-                                #if $val in $cc_hidden_obs and $getVar('yesterday.' + val + '.has_data')
+                                #if $getVar('yesterday.' + val + '.has_data')
                                     #if len($cols) == 1
-                                        #silent $cc_hidden_names.append($getVar('obs.label.' + val))
+                                        #if $val in $cc_hidden_obs or ($val + ':' + $cols[0]) in $cc_hidden_obs
+                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val))
+                                        #end if
                                     #else
                                         #for $col in $cols
-                                            #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                            #if $val in $cc_hidden_obs or ($val + ':' + $col) in $cc_hidden_obs
+                                                #silent $cc_hidden_names.append($getVar('obs.label.' + val) + ' ' + $gettext($col))
+                                            #end if
                                         #end for
                                     #end if
                                 #end if


### PR DESCRIPTION
Add ```hidevalues =``` option to chart to hide a value.  hidevalues can be applied to chart:

```
[[[customChartHumidity]]]
    title = Humidity
    charttype = area
    column = avg
    values = outHumidity, inHumidity
    hidevalues = inHumidity
    colors = "#008c9e","#9acd32"
```

or to a specific page in a chart:
```
[[[customChartHumidity]]]
    title = Humidity
    charttype = area
    column = avg
    values = outHumidity, inHumidity
    colors = "#008c9e","#9acd32"
    
    [[[[week]]]]
        outHumidity = avg
        inHumidity = avg
        colors = "#5bced4","#5b91d4","#5bd45b","#eddc6f"
        hidevalues = outHumidity    
```        
If multiple measurements are specified for a value, you can use the colon to specify a specific one or the value itself to hide both. This will hide both the outHumidity min and max:

```
[[[customChartHumidity]]]
    title = Humidity
    charttype = area
    column = avg
    values = outHumidity, inHumidity
    colors = "#008c9e","#9acd32"
    
    [[[[week]]]]
        outHumidity = min, max
        inHumidity = min, max
        colors = "#5bced4","#5b91d4","#5bd45b","#eddc6f"
        hidevalues = outHumidity    
```        

This will hide only the max value for outHumidity:

```
[[[customChartHumidity]]]
    title = Humidity
    charttype = area
    column = avg
    values = outHumidity, inHumidity
    colors = "#008c9e","#9acd32"
    
    [[[[week]]]]
        outHumidity = min, max
        inHumidity = min, max
        colors = "#5bced4","#5b91d4","#5bd45b","#eddc6f"
        hidevalues = outHumidity:max    
```        

Notes:
- The ```hiddenvalues``` must be defined in ```values``` or they are ignored.
- Fixed an issue where if you turned off one of the values on the chart the tooltips would not appear or appear wrong.