### PR TITLE
Allow a card or chart to appear once per section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 .vscode/
 .vs/
+__pycache__/
 /dist/skins/neowx-material/
 /dist/*.zip
 /skins/neowx-material/node_modules/

--- a/bin/user/panelorder.py
+++ b/bin/user/panelorder.py
@@ -45,7 +45,11 @@ items and, optionally, how to present them:
   content    card (default), chart, embedded, telemetry, telemetry_chart
 
 Sections render in declaration order within each content value.  Items are
-de-duplicated, first occurrence winning, separately per content value.
+de-duplicated within a section, first occurrence winning - the same item may
+appear in as many sections as you like and renders once in each.  'forecast' is
+the exception: one per page, wherever it is listed, later occurrences dropped.
+Each segment also carries a 'slug': the section name reduced to [A-Za-z0-9_-]
+and made unique across every section, which the templates emit as data-section.
 
 Registration is not optional.  Without this, the templates call names that were
 never added to the search list and the pages fail to generate:
@@ -70,7 +74,7 @@ from weewx.cheetahgenerator import SearchList
 
 log = logging.getLogger(__name__)
 
-VERSION = "2.0.2"
+VERSION = "2.1.0"
 
 # Segment types.  'type' is None for a section with no title, whose items
 # render loose rather than inside a panel.
@@ -143,6 +147,10 @@ _warned_problems = {}
 # id(appearance) -> {(content, enable_panels): segments}.
 _sections_cache = {}
 
+# parse_sections() memoises per (content, enable_panels); the slug map is
+# neither, so it gets its own key inside the same weakref-bounded bucket.
+_SLUG_KEY = ("__slugs__",)
+
 
 def _problem_seen(appearance, problem):
     bucket = _warned_problems.get(id(appearance))
@@ -191,6 +199,72 @@ def _as_list(value):
 
 def _appearance(skin_dict):
     return skin_dict.get("Extras", {}).get("Appearance", {})
+
+
+def _slug_char_ok(ch):
+    """ASCII-only test.  str.isalnum() passes 'e-acute' and other non-ASCII
+    letters, which would then appear raw in an attribute selector."""
+    return ("a" <= ch <= "z") or ("A" <= ch <= "Z") or ("0" <= ch <= "9") or ch in "_-"
+
+
+def _slugs(appearance, sections):
+    """Map every section id to a unique slug for use as an attribute value.
+
+    Computed over ALL sections, not per content region: one page renders the
+    card, chart and embedded regions into a single document, so two sections
+    with different content values can still collide there.
+
+    Case is preserved.  The slug goes verbatim into a CSS attribute selector,
+    which is case sensitive, so a user writing [data-section="soilCharts"]
+    must get back the name they wrote in skin.conf.
+    """
+    cached = _cache_get(appearance, _SLUG_KEY)
+    if cached is not None:
+        return cached
+
+    used = {}
+    result = {}
+    for idx, section_id in enumerate(
+            getattr(sections, "sections", list(sections.keys()))):
+        base = "".join(
+            c if _slug_char_ok(c) else "-" for c in str(section_id).strip())
+        while "--" in base:
+            base = base.replace("--", "-")
+        base = base.strip("-")
+        if not base:
+            base = "section-%d" % idx
+        slug = base
+        suffix = 2
+        while slug in used:
+            slug = "%s-%d" % (base, suffix)
+            suffix += 1
+        if slug != base:
+            log.warning(
+                "panelorder: sections '%s' and '%s' both reduce to the slug "
+                "'%s'; using '%s' for the second one. Rename one of them to "
+                "keep data-section values predictable.",
+                used[base], section_id, base, slug)
+        used[slug] = section_id
+        result[section_id] = slug
+
+    _cache_set(appearance, _SLUG_KEY, result)
+    return result
+
+
+def section_slug(skin_dict, section_id):
+    """The data-section value for one section, by its skin.conf name.
+
+    head.inc builds its items_title_align rules straight from
+    Extras.Appearance.sections rather than from parsed segments, and needs the
+    same slug the templates emit.  Exposed so that rule lives in exactly one
+    place: re-deriving it there would drop the collision suffix and the
+    empty-name fallback, and emit CSS that silently matches nothing.
+    """
+    appearance = _appearance(skin_dict)
+    sections = appearance.get("sections")
+    if not sections:
+        return ""
+    return _slugs(appearance, sections).get(str(section_id), "")
 
 
 def _report_unmigrated(appearance):
@@ -279,6 +353,8 @@ def parse_sections(skin_dict, content=CARD, enable_panels=True):
     if cached is not None:
         return cached
 
+    slugs = _slugs(appearance, sections)
+
     segments = []
     # Spans every section, unlike the per-section 'seen' below.
     claimed = set()
@@ -336,10 +412,16 @@ def parse_sections(skin_dict, content=CARD, enable_panels=True):
                     "type": _panel_type(appearance, section, section_id),
                     "title": title,
                     "items": items,
+                    "slug": slugs[section_id],
                 }
             )
         else:
-            segments.append({"type": None, "title": "", "items": items})
+            segments.append({
+                "type": None,
+                "title": "",
+                "items": items,
+                "slug": slugs[section_id],
+            })
 
     _cache_set(appearance, cache_key, segments)
     return segments
@@ -382,4 +464,11 @@ class PanelOrder(SearchList):
         def panel_items(content=CARD):
             return order_items(skin_dict, content)
 
-        return [{"panelSegments": panel_segments, "panelItems": panel_items}]
+        def panel_section_slug(section_id):
+            return section_slug(skin_dict, section_id)
+
+        return [{
+            "panelSegments": panel_segments,
+            "panelItems": panel_items,
+            "panelSectionSlug": panel_section_slug,
+        }]

--- a/bin/user/panelorder.py
+++ b/bin/user/panelorder.py
@@ -81,6 +81,13 @@ STATIC = "static"
 CARD = "card"
 CONTENTS = (CARD, "chart", "embedded", "telemetry", "telemetry_chart")
 
+# Items that render at most once per page however many sections list them.
+# The forecast is one large card with fixed inner element ids
+# (forecast-table, forecast_hour_icons) and its own #include-plus-#set global
+# handoff; a second copy would duplicate those ids and the two would fight
+# over the globals.  Everything else may now repeat once per section.
+SINGLETON_ITEMS = ("forecast",)
+
 # Keys a section may carry that are settings rather than typos.
 # items_title_align is read by head.inc, not here - it is listed so a panel
 # that sets it is not reported as carrying an unknown setting.
@@ -273,7 +280,8 @@ def parse_sections(skin_dict, content=CARD, enable_panels=True):
         return cached
 
     segments = []
-    seen = set()
+    # Spans every section, unlike the per-section 'seen' below.
+    claimed = set()
 
     for section_id in getattr(sections, "sections", list(sections.keys())):
         section = sections[section_id]
@@ -302,10 +310,16 @@ def parse_sections(skin_dict, content=CARD, enable_panels=True):
         _warn_unknown_keys(appearance, section, section_id)
 
         items = []
+        seen = set()
         for item in _as_list(section.get("items")):
-            if item not in seen:
-                seen.add(item)
-                items.append(item)
+            if item in seen:
+                continue
+            if item in SINGLETON_ITEMS:
+                if item in claimed:
+                    continue
+                claimed.add(item)
+            seen.add(item)
+            items.append(item)
         if not items:
             continue
 
@@ -335,13 +349,19 @@ def order_items(skin_dict, content=CARD):
     """Flat, de-duplicated item names for one content region.
 
     For loops that need the items themselves rather than the layout, such as
-    the chart JavaScript generation.
+    the chart JavaScript generation.  De-duplicates here rather than relying
+    on parse_sections, which now keeps a repeat that appears in a second
+    section - a chart's config and series data must still be emitted once
+    however many times the chart is displayed.
     """
-    return [
-        item
-        for segment in parse_sections(skin_dict, content, True)
-        for item in segment["items"]
-    ]
+    out = []
+    seen = set()
+    for segment in parse_sections(skin_dict, content, True):
+        for item in segment["items"]:
+            if item not in seen:
+                seen.add(item)
+                out.append(item)
+    return out
 
 
 class PanelOrder(SearchList):

--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class BasicInstaller(ExtensionInstaller):
     def __init__(self):
         super(BasicInstaller, self).__init__(
-            version="1.71.9",
+            version="1.72.0",
             name="neowx-material",
             description="The most versatile and modern weewx skin",
             author="Neoweewx",

--- a/skins/neowx-material/chart_hidden_series.inc
+++ b/skins/neowx-material/chart_hidden_series.inc
@@ -6,9 +6,11 @@
 ## |                                                                         |
 ## | Cheetah #include runs in a scope that only sees GLOBALS (not the        |
 ## | caller's local #set vars), so the caller MUST set $cc_hidden_names with  |
-## | "#set global". The chart type and container id are derived here from     |
-## | the already-global $cc_name (the customChart* key) so callers don't      |
-## | have to globalize their local $cc_type / $cc_id too.                     |
+## | "#set global". The chart type is derived here from the already-global    |
+## | $cc_name (the customChart* key) so callers don't have to globalize their |
+## | local $cc_type too. The mounted container is found via chartContext.el   |
+## | (the chart's own mount div), which is duplicate-safe since each          |
+## | instance's mounted handler gets its own chartContext.                    |
 ## |                                                                         |
 ## | Emits a merged chart.events.mounted handler, or nothing when no series   |
 ## | are hidden. Merge (not replace) so chart.type and any existing events    |
@@ -16,7 +18,6 @@
 ## +-------------------------------------------------------------------------+
 #if len($cc_hidden_names) > 0
 #set $_hs_type = $Extras.Appearance.get($cc_name, {}).get('charttype', 'area')
-#set $_hs_id   = $cc_name + 'chart'
 chart: {
     ...graph_${_hs_type}_config.chart,
     events: {
@@ -30,7 +31,7 @@ chart: {
                 chartContext.hideSeries("$hn");
                 #end for
             } finally {
-                var _el = document.querySelector('#$_hs_id');
+                var _el = chartContext && chartContext.el;
                 if (_el) { _el.style.opacity = '1'; }
             }
         }

--- a/skins/neowx-material/forecast.inc
+++ b/skins/neowx-material/forecast.inc
@@ -50,9 +50,15 @@
 ##
 ## The error branch further down needs none of this: its card is col-12, so it
 ## already breaks the row on both sides.
+##
+## $section is the enclosing [[[sections]]] slug, handed over the same way so
+## the forecast card wrapper can emit data-section - without it, head.inc's
+## section-scoped [data-section]/[data-name] CSS rules (e.g. items_title_align)
+## match nothing.
 #set $in_panel = $getVar('forecast_in_panel', False)
 #set $is_first = $getVar('forecast_is_first', True)
 #set $is_last  = $getVar('forecast_is_last', True)
+#set $section  = $getVar('forecast_section', '')
 
 ## $forecast is an autocalled SearchList method: every $forecast reference
 ## re-enters the Forecast SLE (rebuilding its params dict, json.dumps + md5
@@ -80,7 +86,7 @@
         #end if
         #for $i, $x in $enumerate($fcast.daily)
             <div class="col-12 col-md-6 col-xl-4 mb-4">
-                <div class="card card-forecast" data-name="forecast">
+                <div class="card card-forecast" data-name="forecast" data-section="$section">
                     <div class="card-body text-center pb-1">
                         <h3 class="h5-responsive $Extras.color-text">
                             #if $Extras.Forecast.show_today_tomorrow == "yes" and $i == 0
@@ -285,7 +291,7 @@
         #end if
 
         <div class="col-12 mb-4">
-            <div class="card card-forecast" data-name="forecast">
+            <div class="card card-forecast" data-name="forecast" data-section="$section">
                 <div class="card-body text-center pb-1">
                     <h3 class="h5-responsive $Extras.color-text">
                         $pgettext("Forecast","forecast") - Error

--- a/skins/neowx-material/head.inc
+++ b/skins/neowx-material/head.inc
@@ -439,10 +439,14 @@ href="img/splash/splash_1536x2048.png"
         #if isinstance($_items, str)
             #set $_items = $_items.split(',')
         #end if
+        ## Delegate to panelorder.py's parser rather than re-deriving the slug
+        ## sanitize rule here: it also handles the "-2" collision suffix and
+        ## the "section-<n>" fallback for a name with no usable characters.
+        #set $_sslug = $panelSectionSlug($_sid)
         #for $_item in $_items
             #set $_item = str($_item).strip()
             #if $_item != '' and all(c.isalnum() or c in '_.:-' for c in $_item)
-                #silent $_section_overrides.append(($_kinds, $_item, $_a))
+                #silent $_section_overrides.append(($_kinds, $_item, $_a, $_sslug))
             #end if
         #end for
     #end for
@@ -452,8 +456,13 @@ href="img/splash/splash_1536x2048.png"
 <style>
     ## The panel-wide rules first: same specificity as the per-card ones below,
     ## so anything named individually there overrides what its panel asked for.
-    #for $_kinds, $_item, $_align in $_section_overrides
-        #set $_sel = ', '.join([$_k + '[data-name="' + $_item + '"] > .card-body > .h5-responsive' for $_k in $_kinds])
+    #for $_kinds, $_item, $_align, $_sslug in $_section_overrides
+        ## :where() contributes zero specificity, which is load bearing here.
+        ## The comment above _CONTENT_CARD_KINDS records that section rules and
+        ## per-card rules must stay at EQUAL specificity, with emission order
+        ## deciding which wins. A bare second attribute selector would raise
+        ## these above the per-card rules below and silently invert that.
+        #set $_sel = ', '.join([$_k + ':where([data-section="' + $_sslug + '"])[data-name="' + $_item + '"] > .card-body > .h5-responsive' for $_k in $_kinds])
     $_sel {
         #if $_align == 'left'
         text-align: left;

--- a/skins/neowx-material/head.inc
+++ b/skins/neowx-material/head.inc
@@ -479,7 +479,12 @@ href="img/splash/splash_1536x2048.png"
         #end if
     }
         #for $_k in $_kinds
-    ${_k}[data-name="${_item}"] {
+            ## Same :where() reasoning as $_sel above: js/app.js reads this
+            ## custom property via getComputedStyle(card), and the per-card
+            ## counterpart below (.card[data-name="X"]) is also (0,2,0) - a
+            ## bare second attribute here would raise this rule to (0,3,0)
+            ## and make it always win regardless of emission order.
+    ${_k}:where([data-section="${_sslug}"])[data-name="${_item}"] {
         --nwm-item-title-align: $_align;
     }
         #end for

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -45,13 +45,13 @@
     #end if
 #end def
 
-#def iframeCard($name)
+#def iframeCard($name, $section = "")
     #set iframe_url = $getVar('Extras.Embedded.' + name + '.url', "")
     #set iframe_title = $getVar('Extras.Embedded.' + name + '.title', "")
     #set iframe_aspect = $getVar('Extras.Embedded.' + name + '.aspect_ratio', "4/3")
     #if iframe_url != ""
         <div class="col-12 col-md-6 col-xl-4 mb-4">
-            <div class="card overflow-hidden" data-name="$name">
+            <div class="card overflow-hidden" data-name="$name" data-section="$section">
                 $embedToolbar()
                 <div class="card-body text-center d-flex flex-column px-0 ${'pb-0' if iframe_title != '' else 'py-0'} overflow-hidden">
                     #if iframe_title != ""
@@ -68,7 +68,7 @@
     #end if
 #end def
 
-#def imageCard($name)
+#def imageCard($name, $section = "")
     #set image_url = $getVar('Extras.Embedded.' + name + '.url', "")
     ## by adding a timestamp parameter we prevent browser caching of the image
     #set $sep = '&' if '?' in $image_url else '?'
@@ -98,7 +98,7 @@
 
     #if image_url != ""
         <div class="col-12 col-md-6 col-xl-4 mb-4">
-            <div class="card overflow-hidden" data-name="$name">
+            <div class="card overflow-hidden" data-name="$name" data-section="$section">
                 $embedToolbar()
                 <div class="card-body text-center d-flex flex-column ${padding_x} ${padding_y} overflow-hidden">
                     #if image_title != ""
@@ -126,11 +126,11 @@
         #end if
     #end def
 
-    #def valuesCard($name)
+    #def valuesCard($name, $section = "")
         ## ET requires a valid positive sum to be shown
         #if $getVar('day.' + name + '.has_data') and ($name != 'ET' or ($day.ET.sum.raw is not None and $day.ET.sum.raw >= 0.0))
             <div class="col-12 col-md-6 col-xl-4 mb-4">
-                <div class="card card-value" id="${name}-value" data-name="$name">
+                <div class="card card-value" data-name="$name" data-section="$section">
                     <div class="card-body text-center">
                         <h3 class="h5-responsive $Extras.color-text">
                             $getVar('obs.label.' + name)
@@ -255,7 +255,7 @@
 ## | Chart values are defined in the JS section below                        |
 ## +-------------------------------------------------------------------------+
 
-#def chartCard($name, $name2 = "XX")
+#def chartCard($name, $name2 = "XX", $section = "")
     #if $name.startswith('customChart')
         ## Custom chart: read config from Extras.Appearance
         #set $cc = $Extras.Appearance.get($name, {})
@@ -271,10 +271,10 @@
             #set $cc_sensors_str = chr(44).join($cc_vals_list)
             #if len($cc_vals_list) > 0 and $cc_any_has_data
                 <div class="col-12 col-xl-6 mb-4">
-                    <div class="card card-chart" id="${name}-chart" data-name="$name" data-sensors="$cc_sensors_str">
+                    <div class="card card-chart" data-name="$name" data-section="$section" data-sensors="$cc_sensors_str">
                         <div class="card-body text-center">
                             <h5 class="h5-responsive $Extras.color-text">$cc_title</h5>
-                            <div id="${name}chart"></div>
+                            <div data-chart-mount="$name"></div>
                         </div>
                     </div>
                 </div>
@@ -282,7 +282,7 @@
         #end if
     #else if ($chartHasData($name) or $name == "windvec") and $name not in ["appTemp", "windrun"] and ($name != 'ET' or ($day.ET.sum.raw is not None and $day.ET.sum.raw >= 0.0))
         <div class="col-12 col-xl-6 mb-4">
-            <div class="card card-chart" id="${name}-chart" data-name="$name">
+            <div class="card card-chart" data-name="$name" data-section="$section">
                 <div class="card-body text-center">
                     <h5 class="h5-responsive $Extras.color-text">
                         #if $name2 != "XX"
@@ -292,7 +292,7 @@
                             $getVar('Extras.Charts.Titles.' + name, $getVar('obs.label.' + name))
                         #end if
                     </h5>
-                    <div id="${name}chart"></div>
+                    <div data-chart-mount="$name"></div>
                 </div>
             </div>
         </div>
@@ -303,7 +303,7 @@
 ## | Helper: render a single value-card item by name                         |
 ## +-------------------------------------------------------------------------+
 
-#def renderValueItem($x, $in_panel, $is_first, $is_last)
+#def renderValueItem($x, $in_panel, $is_first, $is_last, $section = "")
     ## 'forecast' renders via #include, which only sees the search list and
     ## #set global vars - so its placement flags are handed over as globals.
     ## is_first / is_last refer to the cards actually rendered in this segment,
@@ -314,7 +314,7 @@
         #set global $forecast_is_last  = $is_last
         #include "forecast.inc"
     #else
-        $valuesCard($x)
+        $valuesCard($x, $section)
     #end if
 #end def
 
@@ -352,7 +352,7 @@
     #if $seg['type'] is None
         ## No panel – render cards directly into the surrounding row
         #for $x in $seg['items']
-            $renderValueItem($x, False, $f_first, $f_last)
+            $renderValueItem($x, False, $f_first, $f_last, $seg['slug'])
         #end for
     #else
         ## Expansion panel
@@ -361,7 +361,7 @@
             #set $p_show  = ' show' if $p_exp else ''
             #set $p_id    = 'nwm-val-panel-' + str($panel_idx)
             <div class="col-12 mb-3">
-                <div class="card nwm-expansion-panel">
+                <div class="card nwm-expansion-panel" data-section="$seg['slug']">
                     #set global $panel_title = $seg['title']
                     #set global $panel_id    = $p_id
                     #set global $panel_type  = $seg['type']
@@ -370,7 +370,7 @@
                         <div class="nwm-panel-body">
                             <div class="row">
                                 #for $x in $seg['items']
-                                    $renderValueItem($x, True, $f_first, $f_last)
+                                    $renderValueItem($x, True, $f_first, $f_last, $seg['slug'])
                                 #end for
                             </div>
                         </div>
@@ -388,7 +388,7 @@
 #def renderChartSegment($seg, $panel_idx)
     #if $seg['type'] is None
         #for $x in $seg['items']
-            $chartCard($x)
+            $chartCard($x, section=$seg['slug'])
         #end for
     #else
         #set $any_has_data = False
@@ -416,7 +416,7 @@
             #set $p_show  = ' show' if $p_exp else ''
             #set $p_id    = 'nwm-chart-panel-' + str($panel_idx)
             <div class="col-12 mb-3">
-                <div class="card nwm-expansion-panel">
+                <div class="card nwm-expansion-panel" data-section="$seg['slug']">
                     #set global $panel_title = $seg['title']
                     #set global $panel_id    = $p_id
                     #set global $panel_type  = $seg['type']
@@ -425,7 +425,7 @@
                         <div class="nwm-panel-body">
                             <div class="row">
                                 #for $x in $seg['items']
-                                    $chartCard($x)
+                                    $chartCard($x, section=$seg['slug'])
                                 #end for
                             </div>
                         </div>
@@ -440,11 +440,11 @@
 ## | Helper: render items inside a panel (or directly) for embedded content   |
 ## +-------------------------------------------------------------------------+
 
-#def renderEmbItem($x)
+#def renderEmbItem($x, $section = "")
     #if $x.startswith("iFrame")
-        $iframeCard($x)
+        $iframeCard($x, $section)
     #else if $x.startswith("image")
-        $imageCard($x)
+        $imageCard($x, $section)
     #else
         $notFoundCard($x)
     #end if
@@ -453,7 +453,7 @@
 #def renderEmbSegment($seg, $panel_idx)
     #if $seg['type'] is None
         #for $x in $seg['items']
-            $renderEmbItem($x)
+            $renderEmbItem($x, $seg['slug'])
         #end for
     #else
         ## Embedded items are always rendered, so a group is never empty.
@@ -461,7 +461,7 @@
         #set $p_show  = ' show' if $p_exp else ''
         #set $p_id    = 'nwm-emb-panel-' + str($panel_idx)
         <div class="col-12 mb-3">
-            <div class="card nwm-expansion-panel">
+            <div class="card nwm-expansion-panel" data-section="$seg['slug']">
                 #set global $panel_title = $seg['title']
                 #set global $panel_id    = $p_id
                 #set global $panel_type  = $seg['type']
@@ -470,7 +470,7 @@
                     <div class="nwm-panel-body">
                         <div class="row">
                             #for $x in $seg['items']
-                                $renderEmbItem($x)
+                                $renderEmbItem($x, $seg['slug'])
                             #end for
                         </div>
                     </div>
@@ -715,8 +715,7 @@
                 #set global $cc_scope = ''
                 #include "chart_colors_setup.inc"
 
-                var chartElement = document.querySelector('#$id');
-                if (chartElement) {
+                document.querySelectorAll('[data-chart-mount="$name"]').forEach(function (chartElement) {
                     new ApexCharts(chartElement, {
                         ...graph_${type}_config,
                         ## Per-series colors aligned to emitted series: series1 = slot 0; series2-8
@@ -833,7 +832,7 @@
                             #end if
                         ]
                     }).render()
-                }
+                });
 
             #end if
 
@@ -962,8 +961,7 @@
             #set $sc_color_list = []
             #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
             #silent $sc_color_list.append($cc_color_refs[1] if len($cc_color_refs) > 1 else 'default')
-            var windvecchart = document.querySelector('#windvecchart');
-            if (windvecchart) {
+            document.querySelectorAll('[data-chart-mount="windvec"]').forEach(function (windvecchart) {
                 new ApexCharts(windvecchart, {
                     ...graph_radar_config,
                     #if len($cc_color_refs) > 0
@@ -991,7 +989,7 @@
                         },
                     ]
                 }).render()
-            }
+            });
             #silent $processed_charts.add("windvec")
 
             // --- Default single-series charts: loop over the chart sections ---
@@ -1140,11 +1138,10 @@
                                     #silent $cc_hidden_names.append($getVar('obs.label.' + val))
                                 #end if
                             #end for
-                            var chartElement = document.querySelector('#$cc_id');
-                            if (chartElement) {
+                            document.querySelectorAll('[data-chart-mount="$x"]').forEach(function (chartElement) {
                                 #if len($cc_hidden_names) > 0
                                 chartElement.style.opacity = '0';
-                                setTimeout(function () { var _e = document.querySelector('#$cc_id'); if (_e) { _e.style.opacity = '1'; } }, 2000);
+                                setTimeout(function () { chartElement.style.opacity = '1'; }, 2000);
                                 #end if
                                 new ApexCharts(chartElement, {
                                     ...graph_${cc_type}_config,
@@ -1304,7 +1301,7 @@
                                         ], $cc_color_count, "$x"),
                                     #end if
                                 }).render()
-                            }
+                            });
                         #end if
                     #end if
                 #end if

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -312,6 +312,7 @@
         #set global $forecast_in_panel = $in_panel
         #set global $forecast_is_first = $is_first
         #set global $forecast_is_last  = $is_last
+        #set global $forecast_section  = $section
         #include "forecast.inc"
     #else
         $valuesCard($x, $section)

--- a/skins/neowx-material/index.html.tmpl
+++ b/skins/neowx-material/index.html.tmpl
@@ -142,7 +142,7 @@
 
                 #else if $name == 'windSpeed'
 
-                    <i id="wind-icon" class="wi wi-wind from-$current.windDir.formatted-deg"
+                    <i class="wi wi-wind nwm-wind-icon from-$current.windDir.formatted-deg"
                     title="$current.windDir.formatted°" data-toggle="tooltip" data-html="true"></i>
 
                 #end if

--- a/skins/neowx-material/js/app.js
+++ b/skins/neowx-material/js/app.js
@@ -26,15 +26,54 @@ function debugLog(message) {
 }
 
 document.addEventListener('DOMContentLoaded', function () {
-    // Get all IDs of elements with class "card-value" and store in a variable
     const valueCards = document.querySelectorAll('.card-value');
-    const valueCardIds = Array.from(valueCards).map(card => card.id);
-    debugLog('Value Card IDs: ' + valueCardIds);
+    const valueCardNames = Array.from(valueCards).map(card => card.getAttribute('data-name'));
+    debugLog('Value cards: ' + valueCardNames);
 
-    // Get all IDs of elements with class "card-chart" and store in a variable
     const cardCharts = document.querySelectorAll('.card-chart');
-    const cardChartIds = Array.from(cardCharts).map(card => card.id);
-    debugLog('Card Chart IDs: ' + cardChartIds);
+    const cardChartNames = Array.from(cardCharts).map(card => card.getAttribute('data-name'));
+    debugLog('Chart cards: ' + cardChartNames);
+
+    // An item can appear in several sections, so a name matches several cards.
+    // Pick the one nearest the element clicked rather than the first in the
+    // document: clicking a card in a Temperature panel should reach the chart
+    // in that panel, not a copy at the top of the page.
+    //
+    // Scoping by data-section instead cannot work here - a value card is in a
+    // content = card section and its chart in a content = chart section, so
+    // their slugs never match.
+    function findJumpTarget(selector, from) {
+        var all = Array.from(document.querySelectorAll(selector));
+        var visible = all.filter(function (el) { return el.offsetParent !== null; });
+        if (!visible.length) return all[0] || null;
+        var y = from.getBoundingClientRect().top + window.pageYOffset;
+        return visible.reduce(function (best, el) {
+            var d = Math.abs(el.getBoundingClientRect().top + window.pageYOffset - y);
+            return d < best.d ? { el: el, d: d } : best;
+        }, { el: visible[0], d: Infinity }).el;
+    }
+
+    // A target inside a collapsed panel has display:none, so its bounding rect
+    // is all zeros and scrollToElement would scroll to (pageYOffset - 100):
+    // a ~100px twitch upward, with the highlight flashing on something
+    // invisible. Expand first, then scroll once layout has settled.
+    //
+    // Bootstrap 4.4.1, so this is the jQuery plugin - there is no
+    // bootstrap.Collapse.getOrCreateInstance() here.
+    function jumpTo(target) {
+        if (!target) return;
+        var body = target.closest('.collapse');
+        if (body && !body.classList.contains('show')) {
+            var header = body.parentNode.querySelector(':scope > .nwm-panel-header');
+            if (header) header.setAttribute('aria-expanded', 'true');
+            $(body).one('shown.bs.collapse', function () {
+                scrollToElement(target, true);
+            });
+            $(body).collapse('show');
+            return;
+        }
+        scrollToElement(target, true);
+    }
 
     // --- CLICK HANDLER 1: Value Cards -> Jump to Chart Cards ---
     valueCards.forEach(function(valueCard) {
@@ -46,11 +85,16 @@ document.addEventListener('DOMContentLoaded', function () {
                 return;
             }
 
-            // Special handling for wind icon - jump to wind vector image
+            // The wind icon jumps to the wind vector chart. This looked up
+            // 'embedded_imageWindVect' from 2021 until 2026 and never worked -
+            // no template has ever emitted that id - so the click fell through
+            // to the i.wi guard below and was swallowed.
+            //
+            // No imageWindVect fallback: that card does not exist and will not.
             if (sensorName === 'windSpeed' && e.target.closest('i.wi')) {
-                const vectorChart = document.getElementById('embedded_imageWindVect');
+                const vectorChart = findJumpTarget('.card-chart[data-name="windvec"]', valueCard);
                 if (vectorChart) {
-                    scrollToElement(vectorChart);
+                    jumpTo(vectorChart);
                     e.preventDefault();
                     e.stopPropagation();
                     return;
@@ -75,22 +119,26 @@ document.addEventListener('DOMContentLoaded', function () {
             }
 
             // Find the corresponding chart card by data-name (direct match first)
-            let chartCard = document.querySelector('.card-chart[data-name="' + chartSensorName + '"]');
+            let chartCard = findJumpTarget('.card-chart[data-name="' + chartSensorName + '"]', valueCard);
 
             // Fallback: search custom charts whose data-sensors attribute contains this sensor
             if (!chartCard) {
                 const customCharts = document.querySelectorAll('.card-chart[data-sensors]');
+                const matches = [];
                 for (const cc of customCharts) {
                     const sensors = cc.getAttribute('data-sensors').split(',').map(function(s) { return s.trim(); });
                     if (sensors.indexOf(chartSensorName) !== -1) {
-                        chartCard = cc;
-                        break;
+                        matches.push(cc);
                     }
+                }
+                if (matches.length) {
+                    chartCard = findJumpTarget('.card-chart[data-sensors]', valueCard);
+                    if (matches.indexOf(chartCard) === -1) chartCard = matches[0];
                 }
             }
 
             if (chartCard) {
-                scrollToElement(chartCard, true);
+                jumpTo(chartCard);
                 debugLog('✓ Jumped from value card "' + sensorName + '" to chart "' + chartCard.getAttribute('data-name') + '"');
             } else {
                 debugLog('⚠️ No chart card found for sensor: ' + chartSensorName);
@@ -122,7 +170,7 @@ document.addEventListener('DOMContentLoaded', function () {
             }
 
             // Find the corresponding value card by data-name (direct match first)
-            let valueCard = document.querySelector('.card-value[data-name="' + valueSensorName + '"]');
+            let valueCard = findJumpTarget('.card-value[data-name="' + valueSensorName + '"]', chartCard);
 
             // Fallback: if this is a custom chart, use data-sensors to find first existing value card
             if (!valueCard) {
@@ -130,7 +178,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 if (dataSensors) {
                     const sensors = dataSensors.split(',').map(function(s) { return s.trim(); });
                     for (const sensor of sensors) {
-                        const candidate = document.querySelector('.card-value[data-name="' + sensor + '"]');
+                        const candidate = findJumpTarget('.card-value[data-name="' + sensor + '"]', chartCard);
                         if (candidate) {
                             valueCard = candidate;
                             break;
@@ -140,7 +188,7 @@ document.addEventListener('DOMContentLoaded', function () {
             }
 
             if (valueCard) {
-                scrollToElement(valueCard, true);
+                jumpTo(valueCard);
                 debugLog('✓ Jumped from chart "' + sensorName + '" to value card "' + valueCard.getAttribute('data-name') + '"');
                 e.preventDefault();
             } else {

--- a/skins/neowx-material/js/weewx-mqtt.js
+++ b/skins/neowx-material/js/weewx-mqtt.js
@@ -431,8 +431,10 @@ function updatePayloadValues(payload) {
                 if (windDirValue !== undefined) {
                     formattedValue += ' ' + getCompass(windDirValue);
 
-                    // Update wind direction icon
-                    let windIcon = document.getElementById('wind-icon');
+                    // Update wind direction icon (class, not id - a windSpeed
+                    // card can render more than once per page under
+                    // per-section duplicates, so scope the lookup to this card)
+                    let windIcon = card.querySelector('.nwm-wind-icon');
                     if (windIcon && (currentText !== formattedValue)) {
                         let deg = Math.round(parseFloat(windDirValue));
                         // Remove existing direction class (wi-wind from-NNN-deg)

--- a/skins/neowx-material/month-%Y-%m.html.tmpl
+++ b/skins/neowx-material/month-%Y-%m.html.tmpl
@@ -152,7 +152,7 @@
 #def renderValueItem($x, $section = "")
     #if $x == "ET"
         #if $month.ET.has_data and $month.ET.sum.raw is not None and $month.ET.sum.raw > 0.0
-            $valuesCard('ET')
+            $valuesCard('ET', $section)
         #end if
     #else if $x == "temperatureThresholdDays"
         <div class="col-12 col-lg-6 mb-4">

--- a/skins/neowx-material/month-%Y-%m.html.tmpl
+++ b/skins/neowx-material/month-%Y-%m.html.tmpl
@@ -15,11 +15,11 @@
 #set global $TropicNight = ($table_dict.get('tropical_nights_threshold', 20.0),  $threshold_unit)
 #set global $ArcticDay = ($table_dict.get('arctic_days_threshold', 0.0),  $threshold_unit)
 
-#def valuesCard($name)
+#def valuesCard($name, $section = "")
     ## ET requires a valid positive sum to be shown
     #if $getVar('month.' + name + '.has_data') and ($name != 'ET' or ($month.ET.sum.raw is not None and $month.ET.sum.raw > 0.0))
         <div class="col-12 col-lg-6 mb-4">
-            <div class="card card-value" id="${name}-value" data-name="$name">
+            <div class="card card-value" data-name="$name" data-section="$section">
                 <div class="card-body text-center">
                     <h3 class="h5-responsive $Extras.color-text">
                         $getVar('obs.label.' + name)
@@ -101,7 +101,7 @@
     #end if
 #end def
 
-#def chartCard($name, $id, $name2 = "XX")
+#def chartCard($name, $id, $name2 = "XX", $section = "")
     #if $name.startswith('customChart')
         #set $cc = $Extras.Appearance.get($name, {})
         #if $cc
@@ -116,10 +116,10 @@
             #set $cc_sensors_str = chr(44).join($cc_vals_list)
             #if len($cc_vals_list) > 0 and $cc_any_has_data
                 <div class="col-12 col-xl-6 mb-4">
-                    <div class="card card-chart" id="${name}-chart" data-name="$name" data-sensors="$cc_sensors_str">
+                    <div class="card card-chart" data-name="$name" data-section="$section" data-sensors="$cc_sensors_str">
                         <div class="card-body text-center">
                             <h5 class="h5-responsive $Extras.color-text">$cc_title</h5>
-                            <div id="$id"></div>
+                            <div data-chart-mount="$name"></div>
                         </div>
                     </div>
                 </div>
@@ -127,7 +127,7 @@
         #end if
     #else if ($getVar('month.' + name + '.has_data') or $name == "windvec") and $name != "appTemp" and ($name != 'ET' or ($month.ET.sum.raw is not None and $month.ET.sum.raw > 0.0))
         <div class="col-12 col-xl-6 mb-4">
-            <div class="card card-chart" id="${name}-chart" data-name="$name">
+            <div class="card card-chart" data-name="$name" data-section="$section">
                 <div class="card-body text-center">
                     <h5 class="h5-responsive $Extras.color-text">
                         #if $name2 != "XX"
@@ -137,7 +137,7 @@
                             $getVar('Extras.Charts.Titles.' + name, $getVar('obs.label.' + name))
                         #end if
                     </h5>
-                    <div id="$id"></div>
+                    <div data-chart-mount="$name"></div>
                 </div>
             </div>
         </div>
@@ -149,7 +149,7 @@
 ## | (handles ET guard, temperatureThresholdDays, and all normal cards)      |
 ## +-------------------------------------------------------------------------+
 
-#def renderValueItem($x)
+#def renderValueItem($x, $section = "")
     #if $x == "ET"
         #if $month.ET.has_data and $month.ET.sum.raw is not None and $month.ET.sum.raw > 0.0
             $valuesCard('ET')
@@ -204,7 +204,7 @@
             </div>
         </div>
     #else
-        $valuesCard($x)
+        $valuesCard($x, $section)
     #end if
 #end def
 
@@ -216,7 +216,7 @@
     #if $seg['type'] is None
         ## No panel – render cards directly into the surrounding row
         #for $x in $seg['items']
-            $renderValueItem($x)
+            $renderValueItem($x, $seg['slug'])
         #end for
     #else
         ## Expansion panel
@@ -239,7 +239,7 @@
             #set $p_show  = ' show' if $p_exp else ''
             #set $p_id    = 'nwm-val-panel-' + str($panel_idx)
             <div class="col-12 mb-3">
-                <div class="card nwm-expansion-panel">
+                <div class="card nwm-expansion-panel" data-section="$seg['slug']">
                     #set global $panel_title = $seg['title']
                     #set global $panel_id    = $p_id
                     #set global $panel_type  = $seg['type']
@@ -248,7 +248,7 @@
                         <div class="nwm-panel-body">
                             <div class="row">
                                 #for $x in $seg['items']
-                                    $renderValueItem($x)
+                                    $renderValueItem($x, $seg['slug'])
                                 #end for
                             </div>
                         </div>
@@ -266,7 +266,7 @@
 #def renderChartSegment($seg, $panel_idx)
     #if $seg['type'] is None
         #for $x in $seg['items']
-            $chartCard($x, $x + 'chart')
+            $chartCard($x, $x + 'chart', section=$seg['slug'])
         #end for
     #else
         #set $any_has_data = False
@@ -294,7 +294,7 @@
             #set $p_show  = ' show' if $p_exp else ''
             #set $p_id    = 'nwm-chart-panel-' + str($panel_idx)
             <div class="col-12 mb-3">
-                <div class="card nwm-expansion-panel">
+                <div class="card nwm-expansion-panel" data-section="$seg['slug']">
                     #set global $panel_title = $seg['title']
                     #set global $panel_id    = $p_id
                     #set global $panel_type  = $seg['type']
@@ -303,7 +303,7 @@
                         <div class="nwm-panel-body">
                             <div class="row">
                                 #for $x in $seg['items']
-                                    $chartCard($x, $x + 'chart')
+                                    $chartCard($x, $x + 'chart', section=$seg['slug'])
                                 #end for
                             </div>
                         </div>
@@ -415,8 +415,7 @@
 
                 #if $name == "outTemp"
 
-                    var chartElement = document.querySelector('#$id');
-                    if (chartElement) {
+                    document.querySelectorAll('[data-chart-mount="$name"]').forEach(function (chartElement) {
                         new ApexCharts(chartElement, {
                             ...graph_${type}_config,
                             ## Per-series colors aligned to emitted series: outTemp renders min + max,
@@ -486,12 +485,11 @@
                                 #end if
                             ]
                         }).render()
-                    }
+                    });
 
                 #else
 
-                    var chartElement = document.querySelector('#$id');
-                    if (chartElement) {
+                    document.querySelectorAll('[data-chart-mount="$name"]').forEach(function (chartElement) {
                         new ApexCharts(chartElement, {
                             ...graph_${type}_config,
                             ## Per-series colors aligned to emitted series: series1 = slot 0; series2-8
@@ -573,7 +571,7 @@
                                 #end if
                             ]
                         }).render()
-                    }
+                    });
 
                 #end if
 
@@ -665,8 +663,7 @@
             #set $sc_color_list = []
             #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
             #silent $sc_color_list.append($cc_color_refs[1] if len($cc_color_refs) > 1 else 'default')
-            var windvecchart = document.querySelector('#windvecchart');
-            if (windvecchart) {
+            document.querySelectorAll('[data-chart-mount="windvec"]').forEach(function (windvecchart) {
                 new ApexCharts(windvecchart, {
                     ...graph_radar_config,
                     #if len($cc_color_refs) > 0
@@ -682,7 +679,7 @@
                         { name: "$obs.label.windGust",  data: max_values },
                     ]
                 }).render()
-            }
+            });
             #silent $processed_charts.add("windvec")
 
             // --- Default single-series charts: loop over the chart sections ---
@@ -835,11 +832,10 @@
                                     #end for
                                 #end if
                             #end for
-                            var chartElement = document.querySelector('#$cc_id');
-                            if (chartElement) {
+                            document.querySelectorAll('[data-chart-mount="$x"]').forEach(function (chartElement) {
                                 #if len($cc_hidden_names) > 0
                                 chartElement.style.opacity = '0';
-                                setTimeout(function () { var _e = document.querySelector('#$cc_id'); if (_e) { _e.style.opacity = '1'; } }, 2000);
+                                setTimeout(function () { chartElement.style.opacity = '1'; }, 2000);
                                 #end if
                                 new ApexCharts(chartElement, {
                                     ...graph_${cc_type}_config,
@@ -1024,7 +1020,7 @@
                                         ], $cc_color_count, "$x"),
                                     #end if
                                 }).render()
-                            }
+                            });
                         #end if
                     #end if
                 #end if

--- a/skins/neowx-material/month.html.tmpl
+++ b/skins/neowx-material/month.html.tmpl
@@ -19,11 +19,11 @@
 ## | Template for display card of values (left column)                       |
 ## +-------------------------------------------------------------------------+
 
-#def valuesCard($name)
+#def valuesCard($name, $section = "")
     ## ET requires a valid positive sum to be shown
     #if $getVar('month.' + name + '.has_data') and ($name != 'ET' or ($month.ET.sum.raw is not None and $month.ET.sum.raw > 0.0))
         <div class="col-12 col-md-6 col-xl-4 mb-4">
-            <div class="card card-value" id="${name}-value" data-name="$name">
+            <div class="card card-value" data-name="$name" data-section="$section">
                 <div class="card-body text-center">
                     <h3 class="h5-responsive $Extras.color-text">
                         $getVar('obs.label.' + name)
@@ -94,7 +94,7 @@
 ## | Template for display card of a single chart (right column)              |
 ## +-------------------------------------------------------------------------+
 
-#def chartCard($name, $id, $name2="XX")
+#def chartCard($name, $id, $name2="XX", $section = "")
     #if $name.startswith('customChart')
         #set $cc = $Extras.Appearance.get($name, {})
         #if $cc
@@ -109,10 +109,10 @@
             #set $cc_sensors_str = chr(44).join($cc_vals_list)
             #if len($cc_vals_list) > 0 and $cc_any_has_data
                 <div class="col-12 col-xl-6 mb-4">
-                    <div class="card card-chart" id="${name}-chart" data-name="$name" data-sensors="$cc_sensors_str">
+                    <div class="card card-chart" data-name="$name" data-section="$section" data-sensors="$cc_sensors_str">
                         <div class="card-body text-center">
                             <h5 class="h5-responsive $Extras.color-text">$cc_title</h5>
-                            <div id="$id"></div>
+                            <div data-chart-mount="$name"></div>
                         </div>
                     </div>
                 </div>
@@ -120,7 +120,7 @@
         #end if
     #else if ($getVar('month.' + name + '.has_data') or $name == "windvec") and $name != "appTemp" and ($name != 'ET' or ($month.ET.sum.raw is not None and $month.ET.sum.raw > 0.0))
         <div class="col-12 col-xl-6 mb-4">
-            <div class="card card-chart" id="${name}-chart" data-name="$name">
+            <div class="card card-chart" data-name="$name" data-section="$section">
                 <div class="card-body text-center">
                     <h5 class="h5-responsive $Extras.color-text">
                         #if $name2 != "XX"
@@ -130,7 +130,7 @@
                             $getVar('Extras.Charts.Titles.' + name, $getVar('obs.label.' + name))
                         #end if
                     </h5>
-                    <div id="$id"></div>
+                    <div data-chart-mount="$name"></div>
                 </div>
             </div>
         </div>
@@ -143,7 +143,7 @@
 ## | (handles ET guard, temperatureThresholdDays, and all normal cards)      |
 ## +-------------------------------------------------------------------------+
 
-#def renderValueItem($x)
+#def renderValueItem($x, $section = "")
     #if $x == "ET"
         #if $month.ET.has_data and $month.ET.sum.raw is not None and $month.ET.sum.raw > 0.0
             $valuesCard('ET')
@@ -198,7 +198,7 @@
             </div>
         </div>
     #else
-        $valuesCard($x)
+        $valuesCard($x, $section)
     #end if
 #end def
 
@@ -210,7 +210,7 @@
     #if $seg['type'] is None
         ## No panel – render cards directly into the surrounding row
         #for $x in $seg['items']
-            $renderValueItem($x)
+            $renderValueItem($x, $seg['slug'])
         #end for
     #else
         ## Expansion panel
@@ -233,7 +233,7 @@
             #set $p_show  = ' show' if $p_exp else ''
             #set $p_id    = 'nwm-val-panel-' + str($panel_idx)
             <div class="col-12 mb-3">
-                <div class="card nwm-expansion-panel">
+                <div class="card nwm-expansion-panel" data-section="$seg['slug']">
                     #set global $panel_title = $seg['title']
                     #set global $panel_id    = $p_id
                     #set global $panel_type  = $seg['type']
@@ -242,7 +242,7 @@
                         <div class="nwm-panel-body">
                             <div class="row">
                                 #for $x in $seg['items']
-                                    $renderValueItem($x)
+                                    $renderValueItem($x, $seg['slug'])
                                 #end for
                             </div>
                         </div>
@@ -260,7 +260,7 @@
 #def renderChartSegment($seg, $panel_idx)
     #if $seg['type'] is None
         #for $x in $seg['items']
-            $chartCard($x, $x + 'chart')
+            $chartCard($x, $x + 'chart', section=$seg['slug'])
         #end for
     #else
         #set $any_has_data = False
@@ -288,7 +288,7 @@
             #set $p_show  = ' show' if $p_exp else ''
             #set $p_id    = 'nwm-chart-panel-' + str($panel_idx)
             <div class="col-12 mb-3">
-                <div class="card nwm-expansion-panel">
+                <div class="card nwm-expansion-panel" data-section="$seg['slug']">
                     #set global $panel_title = $seg['title']
                     #set global $panel_id    = $p_id
                     #set global $panel_type  = $seg['type']
@@ -297,7 +297,7 @@
                         <div class="nwm-panel-body">
                             <div class="row">
                                 #for $x in $seg['items']
-                                    $chartCard($x, $x + 'chart')
+                                    $chartCard($x, $x + 'chart', section=$seg['slug'])
                                 #end for
                             </div>
                         </div>
@@ -450,8 +450,7 @@
 
                     ## Special diagram for outside temp
 
-                    var chartElement = document.querySelector('#$id');
-                    if (chartElement) {
+                    document.querySelectorAll('[data-chart-mount="$name"]').forEach(function (chartElement) {
                         new ApexCharts(chartElement, {
                             ...graph_${type}_config,
                             ## Per-series colors aligned to emitted series: outTemp renders min + max,
@@ -542,12 +541,11 @@
                                 #end if
                             ]
                         }).render()
-                    }
+                    });
 
                 #else
 
-                    var chartElement = document.querySelector('#$id');
-                    if (chartElement) {
+                    document.querySelectorAll('[data-chart-mount="$name"]').forEach(function (chartElement) {
                         new ApexCharts(chartElement, {
                             ...graph_${type}_config,
                             ## Per-series colors aligned to emitted series: series1 = slot 0; series2-8
@@ -664,7 +662,7 @@
                                 #end if
                             ]
                         }).render()
-                    }
+                    });
 
                 #end if
 
@@ -772,8 +770,7 @@
             #set $sc_color_list = []
             #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
             #silent $sc_color_list.append($cc_color_refs[1] if len($cc_color_refs) > 1 else 'default')
-            var windvecchart = document.querySelector('#windvecchart');
-            if (windvecchart) {
+            document.querySelectorAll('[data-chart-mount="windvec"]').forEach(function (windvecchart) {
                 new ApexCharts(windvecchart, {
                     ...graph_radar_config,
                     #if len($cc_color_refs) > 0
@@ -795,7 +792,7 @@
                         { name: "$obs.label.windGust",  data: max_values },
                     ]
                 }).render()
-            }
+            });
             #silent $processed_charts.add("windvec")
 
             // --- Default single-series charts: loop over the chart sections ---
@@ -952,11 +949,10 @@
                                     #end for
                                 #end if
                             #end for
-                            var chartElement = document.querySelector('#$cc_id');
-                            if (chartElement) {
+                            document.querySelectorAll('[data-chart-mount="$x"]').forEach(function (chartElement) {
                                 #if len($cc_hidden_names) > 0
                                 chartElement.style.opacity = '0';
-                                setTimeout(function () { var _e = document.querySelector('#$cc_id'); if (_e) { _e.style.opacity = '1'; } }, 2000);
+                                setTimeout(function () { chartElement.style.opacity = '1'; }, 2000);
                                 #end if
                                 new ApexCharts(chartElement, {
                                     ...graph_${cc_type}_config,
@@ -1141,7 +1137,7 @@
                                         ], $cc_color_count, "$x"),
                                     #end if
                                 }).render()
-                            }
+                            });
                         #end if
                     #end if
                 #end if

--- a/skins/neowx-material/month.html.tmpl
+++ b/skins/neowx-material/month.html.tmpl
@@ -146,7 +146,7 @@
 #def renderValueItem($x, $section = "")
     #if $x == "ET"
         #if $month.ET.has_data and $month.ET.sum.raw is not None and $month.ET.sum.raw > 0.0
-            $valuesCard('ET')
+            $valuesCard('ET', $section)
         #end if
     #else if $x == "temperatureThresholdDays"
         <div class="col-12 col-md-6 col-xl-4 mb-4">

--- a/skins/neowx-material/package-lock.json
+++ b/skins/neowx-material/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neowx-material",
-  "version": "1.71.9",
+  "version": "1.72.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neowx-material",
-      "version": "1.71.9",
+      "version": "1.72.0",
       "license": "MIT",
       "dependencies": {
         "sass": "1.102.0"

--- a/skins/neowx-material/package.json
+++ b/skins/neowx-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neowx-material",
-  "version": "1.71.9",
+  "version": "1.72.0",
   "description": "The most versatile and modern weewx skin",
   "main": "index.js",
   "repository": "https://github.com/neoground/neowx-material",

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -18,7 +18,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
 
-    version = 1.71.9
+    version = 1.72.0
 
     # Language
     # -------------------------------------------------------------------------
@@ -418,8 +418,35 @@
         # never displayed, but it must be unique.
         #
         # Sections appear in the order they are written, within each content
-        # value.  Items are de-duplicated, the first occurrence winning,
-        # separately for each content value.
+        # value.  Items are de-duplicated within a section, the first
+        # occurrence winning - so listing an item twice in one section shows it
+        # once, but the same item may appear in as many sections as you like
+        # and is drawn once in each.  For example:
+        #
+        #   [[[[overview]]]]
+        #       items = outTemp, outHumidity
+        #       title = Overview
+        #   [[[[temperature]]]]
+        #       items = outTemp, dewpoint
+        #       title = Temperature
+        #
+        # draws outTemp in both panels.
+        #
+        # "forecast" is the one exception.  Only one forecast is drawn per
+        # page, wherever it is listed; a second one is ignored, and a section
+        # holding nothing else disappears with it.
+        #
+        # A duplicated CARD repeats its database lookups, so a card listed in
+        # four panels costs four times the aggregate queries.  A duplicated
+        # CHART does not: its series data is generated once and every copy is
+        # drawn from it.
+        #
+        # Each card, chart and panel carries data-name and data-section
+        # attributes for styling.  Target every copy of an item with
+        # [data-name="outTemp"], or one specific copy with
+        # [data-section="temperature"] [data-name="outTemp"].  The per-item
+        # id attributes (outTemp-value, outTemp-chart) were removed in this
+        # release; nothing read them and they could not stay unique.
         #
         # Each section starts on a new line.  A full-width break is emitted
         # between sections, so an untitled section never continues the row of

--- a/skins/neowx-material/telemetry.html.tmpl
+++ b/skins/neowx-material/telemetry.html.tmpl
@@ -27,10 +27,10 @@
 ## | Template for display card of battery symbol values (top section)        |
 ## +-------------------------------------------------------------------------+
 
-#def batteryCard($name)
+#def batteryCard($name, $section = "")
     #if $getVar('day.' + name + '.has_data') and ($getVar('day.' + name + '.max.raw') > 0 or $Extras.Telemetry.allow_zero_values == "yes")
         <div class="col-12 col-md-6 col-xl-4 mb-4">
-            <div class="card card-value h-100" id="${name}-value" data-name="$name">
+            <div class="card card-value h-100" data-name="$name" data-section="$section">
                 <div class="card-body text-center">
                     <h3 class="h5-responsive $Extras.color-text">
                         $getVar('obs.label.' + name)
@@ -168,15 +168,15 @@
 ## | Template for display card of chart (bottom section)                     |
 ## +-------------------------------------------------------------------------+
 
-#def chartCard($name)
+#def chartCard($name, $section = "")
     #if $getVar('day.' + name + '.has_data') and ($getVar('day.' + name + '.max.raw') > 0 or $Extras.Telemetry.allow_zero_values == "yes")
         <div class="col-12 col-xl-6 mb-4">
-            <div class="card card-chart h-100" id="${name}-chart-card" data-name="$name">
+            <div class="card card-chart h-100" data-name="$name" data-section="$section">
                 <div class="card-body text-center">
                     <h5 class="h5-responsive $Extras.color-text">
                         $getVar('obs.label.' + name)
                     </h5>
-                    <div id="$name-chart"></div>
+                    <div data-chart-mount="$name"></div>
                 </div>
             </div>
         </div>
@@ -188,11 +188,11 @@
 ## +-------------------------------------------------------------------------+
 
 
-#def renderTeleItem($x, $kind)
+#def renderTeleItem($x, $kind, $section = "")
     #if $kind == 'chart'
-        $chartCard($x)
+        $chartCard($x, $section)
     #else
-        $batteryCard($x)
+        $batteryCard($x, $section)
     #end if
 #end def
 
@@ -208,14 +208,14 @@
 
     #if $seg['type'] is None
         #for $x in $seg['items']
-            $renderTeleItem($x, $kind)
+            $renderTeleItem($x, $kind, $seg['slug'])
         #end for
     #else if len($vis_items) > 0
         #set $p_exp   = ($seg['type'] != 'collapsed')
         #set $p_show  = ' show' if $p_exp else ''
         #set $p_id    = 'nwm-tele-' + $kind + '-panel-' + str($panel_idx)
         <div class="col-12 mb-3">
-            <div class="card nwm-expansion-panel">
+            <div class="card nwm-expansion-panel" data-section="$seg['slug']">
                 #set global $panel_title = $seg['title']
                 #set global $panel_id    = $p_id
                 #set global $panel_type  = $seg['type']
@@ -224,7 +224,7 @@
                     <div class="nwm-panel-body">
                         <div class="row">
                             #for $x in $seg['items']
-                                $renderTeleItem($x, $kind)
+                                $renderTeleItem($x, $kind, $seg['slug'])
                             #end for
                         </div>
                     </div>
@@ -768,7 +768,8 @@
 
                 // currentvalue: --> $chart_interval <--
 
-                new ApexCharts(document.querySelector('#$name-chart'), {
+                document.querySelectorAll('[data-chart-mount="$name"]').forEach(function (chartElement) {
+                new ApexCharts(chartElement, {
                     ...graph_area_config,
                     #if $pg_align_mid
                     xaxis: {
@@ -853,6 +854,7 @@
                         }
                     ]
                 }).render()
+                });
 
             #end if
 

--- a/skins/neowx-material/week.html.tmpl
+++ b/skins/neowx-material/week.html.tmpl
@@ -145,7 +145,7 @@
 #def renderValueItem($x, $section = "")
     #if $x == "ET"
         #if $week.ET.has_data and $week.ET.sum.raw is not None and $week.ET.sum.raw > 0.0
-            $valuesCard('ET')
+            $valuesCard('ET', $section)
         #end if
     #else if $x == "temperatureThresholdDays"
         <div class="col-12 col-md-6 col-xl-4 mb-4">

--- a/skins/neowx-material/week.html.tmpl
+++ b/skins/neowx-material/week.html.tmpl
@@ -10,11 +10,11 @@
 ## | Template for display card of values (left column)                       |
 ## +-------------------------------------------------------------------------+
 
-#def valuesCard($name)
+#def valuesCard($name, $section = "")
     ## ET requires a valid positive sum to be shown
     #if $getVar('week.' + name + '.has_data') and ($name != 'ET' or ($week.ET.sum.raw is not None and $week.ET.sum.raw > 0.0))
         <div class="col-12 col-md-6 col-xl-4 mb-4">
-            <div class="card card-value" id="${name}-value" data-name="$name">
+            <div class="card card-value" data-name="$name" data-section="$section">
                 <div class="card-body text-center">
                     <h3 class="h5-responsive $Extras.color-text">
                         $getVar('obs.label.' + name)
@@ -85,7 +85,7 @@
 ## | Template for display card of a single chart (right column)              |
 ## +-------------------------------------------------------------------------+
 
-#def chartCard($name, $id, $name2="XX")
+#def chartCard($name, $id, $name2="XX", $section = "")
     #if $name.startswith('customChart')
         #set $cc = $Extras.Appearance.get($name, {})
         #if $cc
@@ -100,10 +100,10 @@
             #set $cc_sensors_str = chr(44).join($cc_vals_list)
             #if len($cc_vals_list) > 0 and $cc_any_has_data
                 <div class="col-12 col-xl-6 mb-4">
-                    <div class="card card-chart" id="${name}-chart" data-name="$name" data-sensors="$cc_sensors_str">
+                    <div class="card card-chart" data-name="$name" data-section="$section" data-sensors="$cc_sensors_str">
                         <div class="card-body text-center">
                             <h5 class="h5-responsive $Extras.color-text">$cc_title</h5>
-                            <div id="$id"></div>
+                            <div data-chart-mount="$name"></div>
                         </div>
                     </div>
                 </div>
@@ -111,7 +111,7 @@
         #end if
     #else if ($getVar('week.' + name + '.has_data') or $name == "windvec") and $name != "appTemp" and ($name != 'ET' or ($week.ET.sum.raw is not None and $week.ET.sum.raw > 0.0))
         <div class="col-12 col-xl-6 mb-4">
-            <div class="card card-chart" id="${name}-chart" data-name="$name">
+            <div class="card card-chart" data-name="$name" data-section="$section">
                 <div class="card-body text-center">
                     <h5 class="h5-responsive $Extras.color-text">
                         #if $name2 != "XX"
@@ -121,7 +121,7 @@
                             $getVar('Extras.Charts.Titles.' + name, $getVar('obs.label.' + name))
                         #end if
                     </h5>
-                    <div id="$id"></div>
+                    <div data-chart-mount="$name"></div>
                 </div>
             </div>
         </div>
@@ -142,7 +142,7 @@
 ## | (handles ET guard, temperatureThresholdDays, and all normal cards)      |
 ## +-------------------------------------------------------------------------+
 
-#def renderValueItem($x)
+#def renderValueItem($x, $section = "")
     #if $x == "ET"
         #if $week.ET.has_data and $week.ET.sum.raw is not None and $week.ET.sum.raw > 0.0
             $valuesCard('ET')
@@ -197,7 +197,7 @@
             </div>
         </div>
     #else
-        $valuesCard($x)
+        $valuesCard($x, $section)
     #end if
 #end def
 
@@ -209,7 +209,7 @@
     #if $seg['type'] is None
         ## No panel – render cards directly into the surrounding row
         #for $x in $seg['items']
-            $renderValueItem($x)
+            $renderValueItem($x, $seg['slug'])
         #end for
     #else
         ## Expansion panel
@@ -232,7 +232,7 @@
             #set $p_show  = ' show' if $p_exp else ''
             #set $p_id    = 'nwm-val-panel-' + str($panel_idx)
             <div class="col-12 mb-3">
-                <div class="card nwm-expansion-panel">
+                <div class="card nwm-expansion-panel" data-section="$seg['slug']">
                     #set global $panel_title = $seg['title']
                     #set global $panel_id    = $p_id
                     #set global $panel_type  = $seg['type']
@@ -241,7 +241,7 @@
                         <div class="nwm-panel-body">
                             <div class="row">
                                 #for $x in $seg['items']
-                                    $renderValueItem($x)
+                                    $renderValueItem($x, $seg['slug'])
                                 #end for
                             </div>
                         </div>
@@ -259,7 +259,7 @@
 #def renderChartSegment($seg, $panel_idx)
     #if $seg['type'] is None
         #for $x in $seg['items']
-            $chartCard($x, $x + 'chart')
+            $chartCard($x, $x + 'chart', section=$seg['slug'])
         #end for
     #else
         #set $any_has_data = False
@@ -287,7 +287,7 @@
             #set $p_show  = ' show' if $p_exp else ''
             #set $p_id    = 'nwm-chart-panel-' + str($panel_idx)
             <div class="col-12 mb-3">
-                <div class="card nwm-expansion-panel">
+                <div class="card nwm-expansion-panel" data-section="$seg['slug']">
                     #set global $panel_title = $seg['title']
                     #set global $panel_id    = $p_id
                     #set global $panel_type  = $seg['type']
@@ -296,7 +296,7 @@
                         <div class="nwm-panel-body">
                             <div class="row">
                                 #for $x in $seg['items']
-                                    $chartCard($x, $x + 'chart')
+                                    $chartCard($x, $x + 'chart', section=$seg['slug'])
                                 #end for
                             </div>
                         </div>
@@ -444,8 +444,7 @@
                 #set global $cc_scope = ''
                 #include "chart_colors_setup.inc"
 
-                var chartElement = document.querySelector('#$id');
-                if (chartElement) {
+                document.querySelectorAll('[data-chart-mount="$name"]').forEach(function (chartElement) {
                     new ApexCharts(chartElement, {
                         ...graph_${type}_config,
                         ## Per-series colors aligned to emitted series: series1 = slot 0; series2-8
@@ -562,7 +561,7 @@
                             #end if
                         ]
                     }).render()
-                }
+                });
 
             #end if
 
@@ -691,8 +690,7 @@
             #set $sc_color_list = []
             #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
             #silent $sc_color_list.append($cc_color_refs[1] if len($cc_color_refs) > 1 else 'default')
-            var windvecchart = document.querySelector('#windvecchart');
-            if (windvecchart) {
+            document.querySelectorAll('[data-chart-mount="windvec"]').forEach(function (windvecchart) {
                 new ApexCharts(windvecchart, {
                     ...graph_radar_config,
                     #if len($cc_color_refs) > 0
@@ -720,7 +718,7 @@
                         },
                     ]
                 }).render()
-            }
+            });
             #silent $processed_charts.add("windvec")
 
             // --- Default single-series charts: loop over the chart sections ---
@@ -894,11 +892,10 @@
                                     #end for
                                 #end if
                             #end for
-                            var chartElement = document.querySelector('#$cc_id');
-                            if (chartElement) {
+                            document.querySelectorAll('[data-chart-mount="$x"]').forEach(function (chartElement) {
                                 #if len($cc_hidden_names) > 0
                                 chartElement.style.opacity = '0';
-                                setTimeout(function () { var _e = document.querySelector('#$cc_id'); if (_e) { _e.style.opacity = '1'; } }, 2000);
+                                setTimeout(function () { chartElement.style.opacity = '1'; }, 2000);
                                 #end if
                                 new ApexCharts(chartElement, {
                                     ...graph_${cc_type}_config,
@@ -1085,7 +1082,7 @@
                                         ], $cc_color_count, "$x"),
                                     #end if
                                 }).render()
-                            }
+                            });
                         #end if
                     #end if
                 #end if

--- a/skins/neowx-material/year-%Y.html.tmpl
+++ b/skins/neowx-material/year-%Y.html.tmpl
@@ -152,7 +152,7 @@
 #def renderValueItem($x, $section = "")
     #if $x == "ET"
         #if $year.ET.has_data and $year.ET.sum.raw is not None and $year.ET.sum.raw > 0.0
-            $valuesCard('ET')
+            $valuesCard('ET', $section)
         #end if
     #else if $x == "temperatureThresholdDays"
         <div class="col-12 col-lg-6 mb-4">

--- a/skins/neowx-material/year-%Y.html.tmpl
+++ b/skins/neowx-material/year-%Y.html.tmpl
@@ -15,11 +15,11 @@
 #set global $TropicNight = ($table_dict.get('tropical_nights_threshold', 20.0),  $threshold_unit)
 #set global $ArcticDay = ($table_dict.get('arctic_days_threshold', 0.0),  $threshold_unit)
 
-#def valuesCard($name)
+#def valuesCard($name, $section = "")
     ## ET requires a valid positive sum to be shown
     #if $getVar('year.' + name + '.has_data') and ($name != 'ET' or ($year.ET.sum.raw is not None and $year.ET.sum.raw > 0.0))
         <div class="col-12 col-lg-6 mb-4">
-            <div class="card card-value" id="${name}-value" data-name="$name">
+            <div class="card card-value" data-name="$name" data-section="$section">
                 <div class="card-body text-center">
                     <h3 class="h5-responsive $Extras.color-text">
                         $getVar('obs.label.' + name)
@@ -101,7 +101,7 @@
     #end if
 #end def
 
-#def chartCard($name, $id, $name2 = "XX")
+#def chartCard($name, $id, $name2 = "XX", $section = "")
     #if $name.startswith('customChart')
         #set $cc = $Extras.Appearance.get($name, {})
         #if $cc
@@ -116,10 +116,10 @@
             #set $cc_sensors_str = chr(44).join($cc_vals_list)
             #if len($cc_vals_list) > 0 and $cc_any_has_data
                 <div class="col-12 col-xl-6 mb-4">
-                    <div class="card card-chart" id="${name}-chart" data-name="$name" data-sensors="$cc_sensors_str">
+                    <div class="card card-chart" data-name="$name" data-section="$section" data-sensors="$cc_sensors_str">
                         <div class="card-body text-center">
                             <h5 class="h5-responsive $Extras.color-text">$cc_title</h5>
-                            <div id="$id"></div>
+                            <div data-chart-mount="$name"></div>
                         </div>
                     </div>
                 </div>
@@ -127,7 +127,7 @@
         #end if
     #else if ($getVar('year.' + name + '.has_data') or $name == "windvec") and $name != "appTemp" and ($name != 'ET' or ($year.ET.sum.raw is not None and $year.ET.sum.raw > 0.0))
         <div class="col-12 col-xl-6 mb-4">
-            <div class="card card-chart" id="${name}-chart" data-name="$name">
+            <div class="card card-chart" data-name="$name" data-section="$section">
                 <div class="card-body text-center">
                     <h5 class="h5-responsive $Extras.color-text">
                         #if $name2 != "XX"
@@ -137,7 +137,7 @@
                             $getVar('Extras.Charts.Titles.' + name, $getVar('obs.label.' + name))
                         #end if
                     </h5>
-                    <div id="$id"></div>
+                    <div data-chart-mount="$name"></div>
                 </div>
             </div>
         </div>
@@ -149,7 +149,7 @@
 ## | (handles ET guard, temperatureThresholdDays, and all normal cards)      |
 ## +-------------------------------------------------------------------------+
 
-#def renderValueItem($x)
+#def renderValueItem($x, $section = "")
     #if $x == "ET"
         #if $year.ET.has_data and $year.ET.sum.raw is not None and $year.ET.sum.raw > 0.0
             $valuesCard('ET')
@@ -204,7 +204,7 @@
             </div>
         </div>
     #else if $x != "forecast"
-        $valuesCard($x)
+        $valuesCard($x, $section)
     #end if
 #end def
 
@@ -216,7 +216,7 @@
     #if $seg['type'] is None
         ## No panel – render cards directly into the surrounding row
         #for $x in $seg['items']
-            $renderValueItem($x)
+            $renderValueItem($x, $seg['slug'])
         #end for
     #else
         ## Expansion panel
@@ -239,7 +239,7 @@
             #set $p_show  = ' show' if $p_exp else ''
             #set $p_id    = 'nwm-val-panel-' + str($panel_idx)
             <div class="col-12 mb-3">
-                <div class="card nwm-expansion-panel">
+                <div class="card nwm-expansion-panel" data-section="$seg['slug']">
                     #set global $panel_title = $seg['title']
                     #set global $panel_id    = $p_id
                     #set global $panel_type  = $seg['type']
@@ -248,7 +248,7 @@
                         <div class="nwm-panel-body">
                             <div class="row">
                                 #for $x in $seg['items']
-                                    $renderValueItem($x)
+                                    $renderValueItem($x, $seg['slug'])
                                 #end for
                             </div>
                         </div>
@@ -266,7 +266,7 @@
 #def renderChartSegment($seg, $panel_idx)
     #if $seg['type'] is None
         #for $x in $seg['items']
-            $chartCard($x, $x + 'chart')
+            $chartCard($x, $x + 'chart', section=$seg['slug'])
         #end for
     #else
         #set $any_has_data = False
@@ -294,7 +294,7 @@
             #set $p_show  = ' show' if $p_exp else ''
             #set $p_id    = 'nwm-chart-panel-' + str($panel_idx)
             <div class="col-12 mb-3">
-                <div class="card nwm-expansion-panel">
+                <div class="card nwm-expansion-panel" data-section="$seg['slug']">
                     #set global $panel_title = $seg['title']
                     #set global $panel_id    = $p_id
                     #set global $panel_type  = $seg['type']
@@ -303,7 +303,7 @@
                         <div class="nwm-panel-body">
                             <div class="row">
                                 #for $x in $seg['items']
-                                    $chartCard($x, $x + 'chart')
+                                    $chartCard($x, $x + 'chart', section=$seg['slug'])
                                 #end for
                             </div>
                         </div>
@@ -462,8 +462,7 @@
 
         #if $name == "outTemp"
 
-            var chartElement = document.querySelector('#$id');
-            if (chartElement) {
+            document.querySelectorAll('[data-chart-mount="$name"]').forEach(function (chartElement) {
                 new ApexCharts(chartElement, {
                     ...graph_${type}_config,
                     ## Per-series colors aligned to emitted series: outTemp renders min + max,
@@ -533,12 +532,11 @@
                         #end if
                     ]
                 }).render()
-            }
+            });
 
         #else
 
-            var chartElement = document.querySelector('#$id');
-            if (chartElement) {
+            document.querySelectorAll('[data-chart-mount="$name"]').forEach(function (chartElement) {
                 new ApexCharts(chartElement, {
                     ...graph_${type}_config,
                     ## Per-series colors aligned to emitted series: series1 = slot 0; series2-8
@@ -620,7 +618,7 @@
                         #end if
                     ]
                 }).render()
-            }
+            });
 
         #end if
 
@@ -710,8 +708,7 @@
     #set $sc_color_list = []
     #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
     #silent $sc_color_list.append($cc_color_refs[1] if len($cc_color_refs) > 1 else 'default')
-    var windvecchart = document.querySelector('#windvecchart');
-    if (windvecchart) {
+    document.querySelectorAll('[data-chart-mount="windvec"]').forEach(function (windvecchart) {
         new ApexCharts(windvecchart, {
             ...graph_radar_config,
             #if len($cc_color_refs) > 0
@@ -727,7 +724,7 @@
                 { name: "$obs.label.windGust",  data: max_values },
             ]
         }).render()
-    }
+    });
     #silent $processed_charts.add("windvec")
 
     // --- Default single-series charts: loop over the chart sections ---
@@ -879,11 +876,10 @@
                             #end for
                         #end if
                     #end for
-                    var chartElement = document.querySelector('#$cc_id');
-                    if (chartElement) {
+                    document.querySelectorAll('[data-chart-mount="$x"]').forEach(function (chartElement) {
                         #if len($cc_hidden_names) > 0
                         chartElement.style.opacity = '0';
-                        setTimeout(function () { var _e = document.querySelector('#$cc_id'); if (_e) { _e.style.opacity = '1'; } }, 2000);
+                        setTimeout(function () { chartElement.style.opacity = '1'; }, 2000);
                         #end if
                         new ApexCharts(chartElement, {
                             ...graph_${cc_type}_config,
@@ -1068,7 +1064,7 @@
                                 ], $cc_color_count, "$x"),
                             #end if
                         }).render()
-                    }
+                    });
                 #end if
             #end if
         #end if

--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -152,7 +152,7 @@
 #def renderValueItem($x, $section = "")
     #if $x == "ET"
         #if $year.ET.has_data and $year.ET.sum.raw is not None and $year.ET.sum.raw > 0.0
-            $valuesCard('ET')
+            $valuesCard('ET', $section)
         #end if
     #else if $x == "temperatureThresholdDays"
         <div class="col-12 col-md-6 col-xl-4 mb-4">

--- a/skins/neowx-material/year.html.tmpl
+++ b/skins/neowx-material/year.html.tmpl
@@ -15,11 +15,11 @@
 #set global $TropicNight = ($table_dict.get('tropical_nights_threshold', 20.0),  $threshold_unit)
 #set global $ArcticDay = ($table_dict.get('arctic_days_threshold', 0.0),  $threshold_unit)
 
-#def valuesCard($name)
+#def valuesCard($name, $section = "")
     ## ET requires a valid positive sum to be shown
     #if $getVar('year.' + name + '.has_data') and ($name != 'ET' or ($year.ET.sum.raw is not None and $year.ET.sum.raw > 0.0))
         <div class="col-12 col-md-6 col-xl-4 mb-4">
-            <div class="card card-value" id="${name}-value" data-name="$name">
+            <div class="card card-value" data-name="$name" data-section="$section">
                 <div class="card-body text-center">
                     <h3 class="h5-responsive $Extras.color-text">
                         $getVar('obs.label.' + name)
@@ -101,7 +101,7 @@
     #end if
 #end def
 
-#def chartCard($name, $id, $name2 = "XX")
+#def chartCard($name, $id, $name2 = "XX", $section = "")
     #if $name.startswith('customChart')
         #set $cc = $Extras.Appearance.get($name, {})
         #if $cc
@@ -116,10 +116,10 @@
             #set $cc_sensors_str = chr(44).join($cc_vals_list)
             #if len($cc_vals_list) > 0 and $cc_any_has_data
                 <div class="col-12 col-xl-6 mb-4">
-                    <div class="card card-chart" id="${name}-chart" data-name="$name" data-sensors="$cc_sensors_str">
+                    <div class="card card-chart" data-name="$name" data-section="$section" data-sensors="$cc_sensors_str">
                         <div class="card-body text-center">
                             <h5 class="h5-responsive $Extras.color-text">$cc_title</h5>
-                            <div id="$id"></div>
+                            <div data-chart-mount="$name"></div>
                         </div>
                     </div>
                 </div>
@@ -127,7 +127,7 @@
         #end if
     #else if ($getVar('year.' + name + '.has_data') or $name == "windvec") and $name != "appTemp" and ($name != 'ET' or ($year.ET.sum.raw is not None and $year.ET.sum.raw > 0.0))
         <div class="col-12 col-xl-6 mb-4">
-            <div class="card card-chart" id="${name}-chart" data-name="$name">
+            <div class="card card-chart" data-name="$name" data-section="$section">
                 <div class="card-body text-center">
                     <h5 class="h5-responsive $Extras.color-text">
                         #if $name2 != "XX"
@@ -137,7 +137,7 @@
                             $getVar('Extras.Charts.Titles.' + name, $getVar('obs.label.' + name))
                         #end if
                     </h5>
-                    <div id="$id"></div>
+                    <div data-chart-mount="$name"></div>
                 </div>
             </div>
         </div>
@@ -149,7 +149,7 @@
 ## | (handles ET guard, temperatureThresholdDays, and all normal cards)      |
 ## +-------------------------------------------------------------------------+
 
-#def renderValueItem($x)
+#def renderValueItem($x, $section = "")
     #if $x == "ET"
         #if $year.ET.has_data and $year.ET.sum.raw is not None and $year.ET.sum.raw > 0.0
             $valuesCard('ET')
@@ -204,7 +204,7 @@
             </div>
         </div>
     #else
-        $valuesCard($x)
+        $valuesCard($x, $section)
     #end if
 #end def
 
@@ -216,7 +216,7 @@
     #if $seg['type'] is None
         ## No panel – render cards directly into the surrounding row
         #for $x in $seg['items']
-            $renderValueItem($x)
+            $renderValueItem($x, $seg['slug'])
         #end for
     #else
         ## Expansion panel
@@ -239,7 +239,7 @@
             #set $p_show  = ' show' if $p_exp else ''
             #set $p_id    = 'nwm-val-panel-' + str($panel_idx)
             <div class="col-12 mb-3">
-                <div class="card nwm-expansion-panel">
+                <div class="card nwm-expansion-panel" data-section="$seg['slug']">
                     #set global $panel_title = $seg['title']
                     #set global $panel_id    = $p_id
                     #set global $panel_type  = $seg['type']
@@ -248,7 +248,7 @@
                         <div class="nwm-panel-body">
                             <div class="row">
                                 #for $x in $seg['items']
-                                    $renderValueItem($x)
+                                    $renderValueItem($x, $seg['slug'])
                                 #end for
                             </div>
                         </div>
@@ -266,7 +266,7 @@
 #def renderChartSegment($seg, $panel_idx)
     #if $seg['type'] is None
         #for $x in $seg['items']
-            $chartCard($x, $x + 'chart')
+            $chartCard($x, $x + 'chart', section=$seg['slug'])
         #end for
     #else
         #set $any_has_data = False
@@ -294,7 +294,7 @@
             #set $p_show  = ' show' if $p_exp else ''
             #set $p_id    = 'nwm-chart-panel-' + str($panel_idx)
             <div class="col-12 mb-3">
-                <div class="card nwm-expansion-panel">
+                <div class="card nwm-expansion-panel" data-section="$seg['slug']">
                     #set global $panel_title = $seg['title']
                     #set global $panel_id    = $p_id
                     #set global $panel_type  = $seg['type']
@@ -303,7 +303,7 @@
                         <div class="nwm-panel-body">
                             <div class="row">
                                 #for $x in $seg['items']
-                                    $chartCard($x, $x + 'chart')
+                                    $chartCard($x, $x + 'chart', section=$seg['slug'])
                                 #end for
                             </div>
                         </div>
@@ -420,8 +420,7 @@
 
                 #if $name == "outTemp"
 
-                    var chartElement = document.querySelector('#$id');
-                    if (chartElement) {
+                    document.querySelectorAll('[data-chart-mount="$name"]').forEach(function (chartElement) {
                         new ApexCharts(chartElement, {
                             ...graph_${type}_config,
                             ## Per-series colors aligned to emitted series: outTemp renders min + max,
@@ -491,12 +490,11 @@
                                 #end if
                             ]
                         }).render()
-                    }
+                    });
 
                 #else
 
-                    var chartElement = document.querySelector('#$id');
-                    if (chartElement) {
+                    document.querySelectorAll('[data-chart-mount="$name"]').forEach(function (chartElement) {
                         new ApexCharts(chartElement, {
                             ...graph_${type}_config,
                             ## Per-series colors aligned to emitted series: series1 = slot 0; series2-8
@@ -578,7 +576,7 @@
                                 #end if
                             ]
                         }).render()
-                    }
+                    });
 
                 #end if
 
@@ -661,8 +659,7 @@
             #set $sc_color_list = []
             #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
             #silent $sc_color_list.append($cc_color_refs[1] if len($cc_color_refs) > 1 else 'default')
-            var windvecchart = document.querySelector('#windvecchart');
-            if (windvecchart) {
+            document.querySelectorAll('[data-chart-mount="windvec"]').forEach(function (windvecchart) {
                 new ApexCharts(windvecchart, {
                     ...graph_radar_config,
                     #if len($cc_color_refs) > 0
@@ -678,7 +675,7 @@
                         { name: "$obs.label.windGust",  data: max_values },
                     ]
                 }).render()
-            }
+            });
             #silent $processed_charts.add("windvec")
 
             // --- Default single-series charts: loop over the chart sections ---
@@ -838,11 +835,10 @@
                                     #end for
                                 #end if
                             #end for
-                            var chartElement = document.querySelector('#$cc_id');
-                            if (chartElement) {
+                            document.querySelectorAll('[data-chart-mount="$x"]').forEach(function (chartElement) {
                                 #if len($cc_hidden_names) > 0
                                 chartElement.style.opacity = '0';
-                                setTimeout(function () { var _e = document.querySelector('#$cc_id'); if (_e) { _e.style.opacity = '1'; } }, 2000);
+                                setTimeout(function () { chartElement.style.opacity = '1'; }, 2000);
                                 #end if
                                 new ApexCharts(chartElement, {
                                     ...graph_${cc_type}_config,
@@ -1029,7 +1025,7 @@
                                         ], $cc_color_count, "$x"),
                                     #end if
                                 }).render()
-                            }
+                            });
                         #end if
                     #end if
                 #end if

--- a/skins/neowx-material/yesterday.html.tmpl
+++ b/skins/neowx-material/yesterday.html.tmpl
@@ -89,7 +89,7 @@
 #def renderValueItem($x, $section = "")
     #if $x == "ET"
         #if $yesterday.ET.has_data and $yesterday.ET.sum.raw is not None and $yesterday.ET.sum.raw > 0.0
-            $valuesCard('ET')
+            $valuesCard('ET', $section)
         #end if
     #else if $x == "temperatureThresholdDays"
         <div class="col-12 col-md-6 col-xl-4 mb-4">

--- a/skins/neowx-material/yesterday.html.tmpl
+++ b/skins/neowx-material/yesterday.html.tmpl
@@ -10,11 +10,11 @@
 ## | Template for display card of values (left column)                       |
 ## +-------------------------------------------------------------------------+
 
-#def valuesCard($name)
+#def valuesCard($name, $section = "")
     ## ET requires a valid positive sum to be shown
     #if $getVar('yesterday.' + name + '.has_data') and ($name != 'ET' or ($yesterday.ET.sum.raw is not None and $yesterday.ET.sum.raw > 0.0))
         <div class="col-12 col-md-6 col-xl-4 mb-4">
-            <div class="card card-value" id="${name}-value" data-name="$name">
+            <div class="card card-value" data-name="$name" data-section="$section">
                 <div class="card-body text-center">
                     <h3 class="h5-responsive $Extras.color-text">
                         $getVar('obs.label.' + name)
@@ -86,7 +86,7 @@
 ## | (handles ET guard, temperatureThresholdDays, and all normal cards)      |
 ## +-------------------------------------------------------------------------+
 
-#def renderValueItem($x)
+#def renderValueItem($x, $section = "")
     #if $x == "ET"
         #if $yesterday.ET.has_data and $yesterday.ET.sum.raw is not None and $yesterday.ET.sum.raw > 0.0
             $valuesCard('ET')
@@ -141,7 +141,7 @@
             </div>
         </div>
     #else
-        $valuesCard($x)
+        $valuesCard($x, $section)
     #end if
 #end def
 
@@ -153,7 +153,7 @@
     #if $seg['type'] is None
         ## No panel – render cards directly into the surrounding row
         #for $x in $seg['items']
-            $renderValueItem($x)
+            $renderValueItem($x, $seg['slug'])
         #end for
     #else
         ## Expansion panel
@@ -176,7 +176,7 @@
             #set $p_show  = ' show' if $p_exp else ''
             #set $p_id    = 'nwm-val-panel-' + str($panel_idx)
             <div class="col-12 mb-3">
-                <div class="card nwm-expansion-panel">
+                <div class="card nwm-expansion-panel" data-section="$seg['slug']">
                     #set global $panel_title = $seg['title']
                     #set global $panel_id    = $p_id
                     #set global $panel_type  = $seg['type']
@@ -185,7 +185,7 @@
                         <div class="nwm-panel-body">
                             <div class="row">
                                 #for $x in $seg['items']
-                                    $renderValueItem($x)
+                                    $renderValueItem($x, $seg['slug'])
                                 #end for
                             </div>
                         </div>
@@ -203,7 +203,7 @@
 #def renderChartSegment($seg, $panel_idx)
     #if $seg['type'] is None
         #for $x in $seg['items']
-            $chartCard($x, $x + 'chart')
+            $chartCard($x, $x + 'chart', section=$seg['slug'])
         #end for
     #else
         #set $any_has_data = False
@@ -231,7 +231,7 @@
             #set $p_show  = ' show' if $p_exp else ''
             #set $p_id    = 'nwm-chart-panel-' + str($panel_idx)
             <div class="col-12 mb-3">
-                <div class="card nwm-expansion-panel">
+                <div class="card nwm-expansion-panel" data-section="$seg['slug']">
                     #set global $panel_title = $seg['title']
                     #set global $panel_id    = $p_id
                     #set global $panel_type  = $seg['type']
@@ -240,7 +240,7 @@
                         <div class="nwm-panel-body">
                             <div class="row">
                                 #for $x in $seg['items']
-                                    $chartCard($x, $x + 'chart')
+                                    $chartCard($x, $x + 'chart', section=$seg['slug'])
                                 #end for
                             </div>
                         </div>
@@ -255,7 +255,7 @@
 ## | Template for display card of a single chart (right column)              |
 ## +-------------------------------------------------------------------------+
 
-#def chartCard($name, $id, $name2="XX")
+#def chartCard($name, $id, $name2="XX", $section = "")
     #if $name.startswith('customChart')
         #set $cc = $Extras.Appearance.get($name, {})
         #if $cc
@@ -270,10 +270,10 @@
             #set $cc_sensors_str = chr(44).join($cc_vals_list)
             #if len($cc_vals_list) > 0 and $cc_any_has_data
                 <div class="col-12 col-xl-6 mb-4">
-                    <div class="card card-chart" id="${name}-chart" data-name="$name" data-sensors="$cc_sensors_str">
+                    <div class="card card-chart" data-name="$name" data-section="$section" data-sensors="$cc_sensors_str">
                         <div class="card-body text-center">
                             <h5 class="h5-responsive $Extras.color-text">$cc_title</h5>
-                            <div id="$id"></div>
+                            <div data-chart-mount="$name"></div>
                         </div>
                     </div>
                 </div>
@@ -281,7 +281,7 @@
         #end if
     #else if ($getVar('yesterday.' + name + '.has_data') or $name == "windvec") and $name not in ["appTemp", "windrun"] and ($name != 'ET' or ($yesterday.ET.sum.raw is not None and $yesterday.ET.sum.raw > 0.0))
         <div class="col-12 col-xl-6 mb-4">
-            <div class="card card-chart" id="${name}-chart" data-name="$name">
+            <div class="card card-chart" data-name="$name" data-section="$section">
                 <div class="card-body text-center">
                     <h5 class="h5-responsive $Extras.color-text">
                         #if $name2 != "XX"
@@ -291,7 +291,7 @@
                             $getVar('Extras.Charts.Titles.' + name, $getVar('obs.label.' + name))
                         #end if
                     </h5>
-                    <div id="$id"></div>
+                    <div data-chart-mount="$name"></div>
                 </div>
             </div>
         </div>
@@ -481,8 +481,7 @@
                     end_of_yesterday8 = Math.min(series8data.length, $number_of_records);
                 #end if
 
-                var chartElement = document.querySelector('#$id');
-                if (chartElement) {
+                document.querySelectorAll('[data-chart-mount="$name"]').forEach(function (chartElement) {
                     new ApexCharts(chartElement, {
                         ...graph_${type}_config,
                         ## Per-series colors aligned to emitted series: series1 = slot 0; series2-8
@@ -599,7 +598,7 @@
                             #end if
                         ]
                     }).render()
-                }
+                });
 
             #end if
 
@@ -755,8 +754,7 @@
             #set $sc_color_list = []
             #silent $sc_color_list.append($cc_color_refs[0] if len($cc_color_refs) > 0 else 'default')
             #silent $sc_color_list.append($cc_color_refs[1] if len($cc_color_refs) > 1 else 'default')
-            var windvecchart = document.querySelector('#windvecchart');
-            if (windvecchart) {
+            document.querySelectorAll('[data-chart-mount="windvec"]').forEach(function (windvecchart) {
                 new ApexCharts(windvecchart, {
                     ...graph_radar_config,
                     #if len($cc_color_refs) > 0
@@ -784,7 +782,7 @@
                         },
                     ]
                 }).render()
-            }
+            });
             #silent $processed_charts.add("windvec")
 
             // --- Default single-series charts: loop over the chart sections ---
@@ -936,11 +934,10 @@
                                     #end for
                                 #end if
                             #end for
-                            var chartElement = document.querySelector('#$cc_id');
-                            if (chartElement) {
+                            document.querySelectorAll('[data-chart-mount="$x"]').forEach(function (chartElement) {
                                 #if len($cc_hidden_names) > 0
                                 chartElement.style.opacity = '0';
-                                setTimeout(function () { var _e = document.querySelector('#$cc_id'); if (_e) { _e.style.opacity = '1'; } }, 2000);
+                                setTimeout(function () { chartElement.style.opacity = '1'; }, 2000);
                                 #end if
                                 new ApexCharts(chartElement, {
                                     ...graph_${cc_type}_config,
@@ -1125,7 +1122,7 @@
                                         ], $cc_color_count, "$x"),
                                     #end if
                                 }).render()
-                            }
+                            });
                         #end if
                     #end if
                 #end if


### PR DESCRIPTION
Previously an item named in two `[[[sections]]]` sections rendered only once — the second occurrence was silently dropped. Now it renders once per section, so the same observation can appear in an Overview panel and again in a Temperature panel. A repeat *within* one section still collapses to one.

`forecast` is the exception and stays a singleton: one per page, wherever it is listed.

## Why the DOM changed

Once an item can appear more than once, no per-item `id` can be unique. It turned out nothing read them — `app.js`, `weewx-mqtt.js` and `head.inc` all select on class plus `data-name`, and the stylesheets contain no id selectors for cards. So the ids are gone, replaced by attributes that are more capable than what they replaced:

| | before | after |
|---|---|---|
| card wrapper | `id="outTemp-value"` | `data-name="outTemp" data-section="cards"` |
| chart wrapper | `id="outTemp-chart"` | `data-name="outTemp" data-section="charts"` |
| chart mount | `id="outTempchart"` | `data-chart-mount="outTemp"` |

Target every copy with `[data-name="outTemp"]`, or one specific copy with `[data-section="temperature"] [data-name="outTemp"]`.

The mount change is what makes duplicate charts work. The generated ApexCharts code now iterates `querySelectorAll('[data-chart-mount="…"]')` instead of resolving a single id, so every copy gets an instance built from **one** emitted config — the series data is still generated once per observation however many copies are drawn.

## Breaking change

Custom CSS keyed to `#outTemp-value`, `#outTemp-chart` or `#outTemp-chart-card` must move to `[data-name="outTemp"]`. Telemetry's private `-chart-card` / `-chart` id convention is gone with the rest.

## Bugs fixed along the way

- **A panel's `items_title_align` leaked into every other panel.** It was keyed on `data-name` alone. Now section-scoped, via `:where([data-section=…])` so the existing equal-specificity contract with the per-card rules is preserved.
- **The wind-direction icon has never worked, in any released version.** It looked up an element id no template emits, and the null fell through to a guard that swallowed the click. It now finds the windvec chart the way every other chart is found.
- **Jumping into a collapsed panel did nothing useful.** A `display:none` target has a zero bounding rect, so the page twitched ~100px upward and the highlight flashed on something invisible. The panel now expands first, then scrolls.
- **Card-to-chart jumps landed arbitrarily.** `querySelector` returned first-in-document-order regardless of which copy was clicked; now it picks the nearest visible match.
- **`hidevalues` charts stayed blank** until a 2s opacity fallback fired, because the reveal resolved the removed mount id. Uses `chartContext.el` now.
- **`id="wind-icon"` could duplicate**, leaving the second copy's arrow permanently stale under MQTT. Now a class, scoped per card.

## Testing

23 of 24 local checks pass. `sections-parity-check.py` fails — but it fails identically on `master` and its output is byte-identical before and after this branch. That check compares the shipped `[[[sections]]]` against a 1.68.x golden baseline, and the config has drifted from it independently of this work: it gained an "Additional Sensors" card panel, and has three chart sections where the golden expects five. The two missing ones are absent from `skin.conf` entirely, so no de-duplication change could affect them. **Worth a separate look — those defaults may have been lost in an edit.**

Two new checks were added locally (`dom-contract-check.py`, `sections-slug-check.py`); per project convention `tests/` is not committed.

Verified by hand on a live weewx render: duplicated cards and charts both draw, the jump handlers behave, and there are no duplicate ids in the generated HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)