### PR TITLE
Remember which panels you collapsed

### DIFF
--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class BasicInstaller(ExtensionInstaller):
     def __init__(self):
         super(BasicInstaller, self).__init__(
-            version="1.73.1",
+            version="1.73.2",
             name="neowx-material",
             description="The most versatile and modern weewx skin",
             author="Neoweewx",

--- a/skins/neowx-material/head.inc
+++ b/skins/neowx-material/head.inc
@@ -117,10 +117,16 @@
 #if $varExists('Extras.Appearance.rememberPanelState') and str($Extras.Appearance.rememberPanelState).strip().lower() not in ('false', 'no', '0')
 <script>
 (function () {
+    // Tells js/app.js the setting is on, so its own DOMContentLoaded handler
+    // knows whether to correct the DOM and bind the writers below - it has no
+    // template access of its own to check Extras.Appearance directly. Set
+    // before the try so it still lands even if storage is unreadable or the
+    // stored blob is malformed and one of the early returns below fires.
+    window.NWM_REMEMBER_PANELS = true;
     var stored;
     try { stored = JSON.parse(sessionStorage.getItem('nwm-panels') || '{}'); }
     catch (e) { return; }
-    if (!stored || typeof stored !== 'object' || stored.constructor !== Object) { return; }
+    if (!stored || typeof stored !== 'object' || Array.isArray(stored)) { return; }
     var css = '';
     for (var slug in stored) {
         if (!Object.prototype.hasOwnProperty.call(stored, slug)) { continue; }

--- a/skins/neowx-material/head.inc
+++ b/skins/neowx-material/head.inc
@@ -105,6 +105,52 @@
 ## ApexChart stylesheet
 <link rel="stylesheet" href="js/vendor/apexcharts/apexcharts.css">
 
+## Panel state restore.  Must be INLINE and must run before the body parses:
+## the panels are painted from the server-rendered default, so anything that
+## waits for DOMContentLoaded shows the wrong state first and corrects it
+## visibly.  On a page that auto-refreshes every few minutes that flash would
+## be relentless.
+##
+## The override needs no knowledge of what the default IS.  Each stored state
+## maps to a rule that is either corrective or a no-op, so we can emit both
+## directions blind.
+#if $varExists('Extras.Appearance.rememberPanelState') and str($Extras.Appearance.rememberPanelState).strip().lower() not in ('false', 'no', '0')
+<script>
+(function () {
+    var stored;
+    try { stored = JSON.parse(sessionStorage.getItem('nwm-panels') || '{}'); }
+    catch (e) { return; }
+    if (!stored || typeof stored !== 'object' || stored.constructor !== Object) { return; }
+    var css = '';
+    for (var slug in stored) {
+        if (!Object.prototype.hasOwnProperty.call(stored, slug)) { continue; }
+        if (!/^[A-Za-z0-9_-]+$/.test(slug)) { continue; }
+        var p = '.nwm-expansion-panel[data-section="' + slug + '"]';
+        // Static panels (collapsed = none) have no toggle, so a stale stored
+        // false would hide one with no way to reopen it.  The header is the
+        // body's immediate previous sibling, so + reaches exactly the right
+        // element without relying on the CSS :has selector.
+        var body = p + ' > .nwm-panel-header:not(.nwm-panel-static) + .collapse';
+        // The chevron rotates off [aria-expanded] on the header, which this
+        // override does not change - so without a matching transform the
+        // panel paints with its chevron pointing the wrong way.  This
+        // selector is (0,5,0) against the base rule's (0,3,0); a shorter one
+        // ties and is then decided by source order.
+        var icon = p + ' > .nwm-panel-header[aria-expanded] .nwm-panel-icon';
+        css += stored[slug]
+            ? body + '{display:block}' + icon + '{transform:rotate(180deg)}'
+            : body + '.show{display:none}' + icon + '{transform:none}';
+    }
+    if (css) {
+        var st = document.createElement('style');
+        st.id = 'nwm-panel-restore';
+        st.textContent = css;
+        document.head.appendChild(st);
+    }
+})();
+</script>
+#end if
+
 ## Appearance settings
 
 #if $Extras.Appearance.lo_value_color != ""

--- a/skins/neowx-material/js/app.js
+++ b/skins/neowx-material/js/app.js
@@ -43,6 +43,7 @@ document.addEventListener('DOMContentLoaded', function () {
     // content = card section and its chart in a content = chart section, so
     // their slugs never match.
     function findJumpTarget(selector, from) {
+        if (!from) return null;
         var all = Array.from(document.querySelectorAll(selector));
         var visible = all.filter(function (el) { return el.offsetParent !== null; });
         if (!visible.length) return all[0] || null;
@@ -58,14 +59,17 @@ document.addEventListener('DOMContentLoaded', function () {
     // a ~100px twitch upward, with the highlight flashing on something
     // invisible. Expand first, then scroll once layout has settled.
     //
-    // Bootstrap 4.4.1, so this is the jQuery plugin - there is no
-    // bootstrap.Collapse.getOrCreateInstance() here.
+    // Bootstrap 4.4.1, so this is the jQuery plugin, not a Bootstrap 5
+    // static instance getter.
     function jumpTo(target) {
         if (!target) return;
-        var body = target.closest('.collapse');
+        // A panel mid-animation carries .collapsing rather than .collapse, so
+        // matching only the latter silently scrolls on geometry that is about
+        // to change.
+        var body = target.closest('.collapse, .collapsing');
         if (body && !body.classList.contains('show')) {
-            var header = body.parentNode.querySelector(':scope > .nwm-panel-header');
-            if (header) header.setAttribute('aria-expanded', 'true');
+            // Bootstrap sets aria-expanded on the trigger itself during
+            // show(), and the trigger IS this header - so we do not touch it.
             $(body).one('shown.bs.collapse', function () {
                 scrollToElement(target, true);
             });
@@ -74,6 +78,78 @@ document.addEventListener('DOMContentLoaded', function () {
         }
         scrollToElement(target, true);
     }
+
+    // --- PANEL STATE ---------------------------------------------------
+    // head.inc has already painted the remembered state via an injected
+    // stylesheet. Our job is to make the real DOM agree, then drop that
+    // override, then keep storage in step with what the user does next.
+    var NWM_PANEL_KEY = 'nwm-panels';
+
+    function nwmReadPanels() {
+        // sessionStorage THROWS rather than returning null in private mode
+        // and wherever site data is blocked, so every access is guarded.
+        try {
+            var raw = sessionStorage.getItem(NWM_PANEL_KEY);
+            var parsed = raw ? JSON.parse(raw) : {};
+            if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+                return {};
+            }
+            return parsed;
+        } catch (e) {
+            return {};
+        }
+    }
+
+    function nwmWritePanel(slug, expanded) {
+        try {
+            var state = nwmReadPanels();
+            state[slug] = !!expanded;
+            sessionStorage.setItem(NWM_PANEL_KEY, JSON.stringify(state));
+        } catch (e) {
+            // Storage unavailable. The page still works; it just forgets.
+        }
+    }
+
+    (function nwmPanelState() {
+        var panels = document.querySelectorAll('.nwm-expansion-panel[data-section]');
+        if (!panels.length) return;
+        var stored = nwmReadPanels();
+
+        panels.forEach(function (panel) {
+            var header = panel.querySelector(':scope > .nwm-panel-header');
+            var body = panel.querySelector(':scope > .collapse');
+            if (!header || !body) return;
+            // A collapsed = none panel has no toggle. Restoring one to
+            // collapsed would hide it with no way to reopen it.
+            if (header.classList.contains('nwm-panel-static')) return;
+
+            var slug = panel.getAttribute('data-section');
+
+            // STEP 1 of 3: correct the DOM to match what the injected CSS is
+            // already showing. Set the class directly rather than going
+            // through Bootstrap's animated API - this must not animate.
+            if (Object.prototype.hasOwnProperty.call(stored, slug)) {
+                var wantOpen = !!stored[slug];
+                body.classList.toggle('show', wantOpen);
+                header.setAttribute('aria-expanded', wantOpen ? 'true' : 'false');
+            }
+
+            // STEP 3 of 3: keep storage in step from here on. Bootstrap fires
+            // these after the transition completes, and it maintains
+            // aria-expanded on the trigger itself, so we only record.
+            $(body).on('shown.bs.collapse', function () { nwmWritePanel(slug, true); });
+            $(body).on('hidden.bs.collapse', function () { nwmWritePanel(slug, false); });
+        });
+
+        // STEP 2 of 3: drop the override. This is visually inert ONLY because
+        // step 1 already made the DOM match it. Move this above the loop and
+        // every restored panel snaps - which is the exact flash this whole
+        // feature exists to avoid.
+        var override = document.getElementById('nwm-panel-restore');
+        if (override && override.parentNode) {
+            override.parentNode.removeChild(override);
+        }
+    })();
 
     // --- CLICK HANDLER 1: Value Cards -> Jump to Chart Cards ---
     valueCards.forEach(function(valueCard) {

--- a/skins/neowx-material/js/app.js
+++ b/skins/neowx-material/js/app.js
@@ -111,43 +111,60 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     (function nwmPanelState() {
+        // head.inc sets this only inside its own rememberPanelState #if, and
+        // only it emits the head-injected restore override - so when it's
+        // unset there is nothing to correct or remove, and no future toggle
+        // is worth persisting. Without this gate, rememberPanelState = false
+        // still bound these handlers and still corrected the DOM below,
+        // reproducing the exact flash the setting exists to turn off.
+        if (window.NWM_REMEMBER_PANELS !== true) return;
         var panels = document.querySelectorAll('.nwm-expansion-panel[data-section]');
-        if (!panels.length) return;
         var stored = nwmReadPanels();
 
-        panels.forEach(function (panel) {
-            var header = panel.querySelector(':scope > .nwm-panel-header');
-            var body = panel.querySelector(':scope > .collapse');
-            if (!header || !body) return;
-            // A collapsed = none panel has no toggle. Restoring one to
-            // collapsed would hide it with no way to reopen it.
-            if (header.classList.contains('nwm-panel-static')) return;
+        try {
+            panels.forEach(function (panel) {
+                var header = panel.querySelector(':scope > .nwm-panel-header');
+                // :scope > .collapse must keep selecting the same element as
+                // head.inc's "header + .collapse" - the two halves agree on
+                // which node is the panel body only because both selectors
+                // resolve to it.
+                var body = panel.querySelector(':scope > .collapse');
+                if (!header || !body) return;
+                // A collapsed = none panel has no toggle. Restoring one to
+                // collapsed would hide it with no way to reopen it.
+                if (header.classList.contains('nwm-panel-static')) return;
 
-            var slug = panel.getAttribute('data-section');
+                var slug = panel.getAttribute('data-section');
 
-            // STEP 1 of 3: correct the DOM to match what the injected CSS is
-            // already showing. Set the class directly rather than going
-            // through Bootstrap's animated API - this must not animate.
-            if (Object.prototype.hasOwnProperty.call(stored, slug)) {
-                var wantOpen = !!stored[slug];
-                body.classList.toggle('show', wantOpen);
-                header.setAttribute('aria-expanded', wantOpen ? 'true' : 'false');
+                // STEP 1 of 3: correct the DOM to match what the injected CSS is
+                // already showing. Set the class directly rather than going
+                // through Bootstrap's animated API - this must not animate.
+                if (Object.prototype.hasOwnProperty.call(stored, slug)) {
+                    var wantOpen = !!stored[slug];
+                    body.classList.toggle('show', wantOpen);
+                    header.setAttribute('aria-expanded', wantOpen ? 'true' : 'false');
+                }
+
+                // STEP 3 of 3: keep storage in step from here on. Bootstrap fires
+                // these after the transition completes, and it maintains
+                // aria-expanded on the trigger itself, so we only record.
+                $(body).on('shown.bs.collapse', function () { nwmWritePanel(slug, true); });
+                $(body).on('hidden.bs.collapse', function () { nwmWritePanel(slug, false); });
+            });
+        } finally {
+            // STEP 2 of 3: drop the override, whether or not the loop above
+            // completed. This is visually inert ONLY because step 1 already
+            // ran for every panel it reached before this fires - a finally
+            // runs after the try body, so that ordering holds even on a
+            // thrown error. Moving this above the loop (or back into the try,
+            // after the loop, guarded by an early return on no panels) would
+            // let a restored panel snap into place, or - worse, on a thrown
+            // error - leave the override's unconditional rules pinning a
+            // stored-collapsed panel hidden with no way to reopen it.
+            var override = document.getElementById('nwm-panel-restore');
+            if (override && override.parentNode) {
+                override.parentNode.removeChild(override);
             }
-
-            // STEP 3 of 3: keep storage in step from here on. Bootstrap fires
-            // these after the transition completes, and it maintains
-            // aria-expanded on the trigger itself, so we only record.
-            $(body).on('shown.bs.collapse', function () { nwmWritePanel(slug, true); });
-            $(body).on('hidden.bs.collapse', function () { nwmWritePanel(slug, false); });
-        });
-
-        // STEP 2 of 3: drop the override. This is visually inert ONLY because
-        // step 1 already made the DOM match it. Move this above the loop and
-        // every restored panel snaps - which is the exact flash this whole
-        // feature exists to avoid.
-        var override = document.getElementById('nwm-panel-restore');
-        if (override && override.parentNode) {
-            override.parentNode.removeChild(override);
         }
     })();
 

--- a/skins/neowx-material/package-lock.json
+++ b/skins/neowx-material/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neowx-material",
-  "version": "1.73.1",
+  "version": "1.73.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neowx-material",
-      "version": "1.73.1",
+      "version": "1.73.2",
       "license": "MIT",
       "dependencies": {
         "sass": "1.103.1"

--- a/skins/neowx-material/package.json
+++ b/skins/neowx-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neowx-material",
-  "version": "1.73.1",
+  "version": "1.73.2",
   "description": "The most versatile and modern weewx skin",
   "main": "index.js",
   "repository": "https://github.com/neoground/neowx-material",

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -483,6 +483,18 @@
         # above them, never below.
         enablePanels = true
 
+        # Remember which panels you collapsed, for as long as this browser tab
+        # stays open.  Without this, every panel springs back to its configured
+        # state on each page load - and the skin reloads itself every
+        # auto_refresh_seconds, so a panel you collapse reopens on its own
+        # within a few minutes.
+        #
+        # Scope is deliberately the tab, not forever: close the tab and you are
+        # back to the defaults below.  That also means editing "collapsed" here
+        # always takes effect, rather than being outranked indefinitely by what
+        # somebody's browser remembered.
+        rememberPanelState = true
+
         # Color of the panel header background and title text.
         # Leave empty to use the default inherited color.
         # Accepts any valid CSS color value, e.g.: #3f51b5, indigo, rgb(63,81,181)

--- a/skins/neowx-material/skin.conf
+++ b/skins/neowx-material/skin.conf
@@ -18,7 +18,7 @@
     # This is the current version of this skin.
     # You can check for updates on the project page.
 
-    version = 1.73.1
+    version = 1.73.2
 
     # Language
     # -------------------------------------------------------------------------


### PR DESCRIPTION
## The problem

The skin reloads itself every `auto_refresh_seconds`, which is 5 minutes out of the box. So any panel you collapse reopens on its own before long, usually while you are still looking at the page. Collapsing a panel you don't care about has been a gesture rather than a setting.

## What this does

Panels now stay how you left them for as long as the browser tab is open. Collapse the Rain panel, leave the dashboard up on a wall display, and it is still collapsed three refreshes later.

The restore happens before the browser draws the page, so you never see a panel open and then snap shut. That turned out to be the hard part. Anything that waits for the page to finish loading corrects the state visibly, and on a page that reloads twelve times an hour a flicker like that is worse than the problem it fixes. So a small inline script in the page head reads what you last did and adjusts the styling before the first paint, and the main script quietly takes over once the page is ready.

Nothing is remembered for a panel you have never touched. Your `skin.conf` defaults keep working exactly as they do today.

Panels set to `collapsed = none` are left alone completely. They have no toggle, so remembering one as collapsed would hide it with no way to get it back.

## New setting

```
[[Appearance]]
    rememberPanelState = true
```

It lives next to `enablePanels` and defaults to on. Set it to `false` and you get today's behaviour back exactly, nothing stored and nothing restored.

## It remembers for the tab, not forever

This is deliberate. Close the tab and you are back to whatever `skin.conf` says. That means editing `collapsed` in your config always takes effect, instead of being quietly outranked by something a browser remembered weeks ago.

One caveat worth knowing: if your browser reopens tabs for you, either through "continue where you left off" at startup or Ctrl+Shift+T, it restores this memory along with the tab. That is the browser deliberately pretending the tab never closed. A genuinely new tab always starts fresh.

## Also in here

Three small fixes to the click-a-card-to-jump-to-its-chart code, which this work sits on top of:

- Jumping to a chart inside a panel that was still mid-animation scrolled to the wrong spot, because a panel part way through opening isn't matched by the selector we were using.
- The jump was setting the chevron's expanded state by hand, which Bootstrap already does. Two things maintaining one attribute is one too many now that panel state is written there as well.
- A guard against being called with nothing to measure from.

## Testing

Verified on a live install: collapsing survives the auto refresh with no flicker, the chevron points the right way on load in both directions, toggling behaves normally afterwards, static panels are untouched, a new tab starts at the configured defaults, and `rememberPanelState = false` restores the old behaviour. Also checked in a private window, where storage is blocked and the page falls back to the defaults with a clean console.

Version bumped to 1.73.2 so browsers pick up the changed script instead of running the cached one.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
